### PR TITLE
Add unit tests for parseRankingFromText and CalculateAggregateRankings

### DIFF
--- a/internal/council/council_test.go
+++ b/internal/council/council_test.go
@@ -103,8 +103,14 @@ func TestCalculateAggregateRankings(t *testing.T) {
 		}
 		labelToModel := map[string]string{"Response A": "alpha", "Response B": "beta"}
 		got := CalculateAggregateRankings(stage2, labelToModel)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 aggregate rankings, got %d", len(got))
+		}
 		if got[0].Model != "alpha" || got[0].AverageRank != 1.0 || got[0].RankingsCount != 2 {
 			t.Errorf("unexpected first entry: %+v", got[0])
+		}
+		if got[1].Model != "beta" || got[1].AverageRank != 2.0 || got[1].RankingsCount != 2 {
+			t.Errorf("unexpected second entry: %+v", got[1])
 		}
 	})
 
@@ -126,6 +132,15 @@ func TestCalculateAggregateRankings(t *testing.T) {
 			if r.RankingsCount != 2 {
 				t.Errorf("expected 2 rankings for %s, got %d", r.Model, r.RankingsCount)
 			}
+		}
+		// Verify both expected models are present (order-independent — tied average ranks).
+		expectedModels := map[string]bool{"alpha": true, "beta": true}
+		actualModels := make(map[string]bool, len(got))
+		for _, r := range got {
+			actualModels[r.Model] = true
+		}
+		if !reflect.DeepEqual(expectedModels, actualModels) {
+			t.Errorf("expected models %v, got %v", expectedModels, actualModels)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Adds `internal/council/council_test.go` with table-driven tests for both pure functions:

**`parseRankingFromText`** — 9 cases covering:
- Standard numbered FINAL RANKING section
- Reversed order
- Unnumbered labels in FINAL RANKING section
- Body-only labels when no FINAL RANKING marker
- FINAL RANKING marker wins over body labels (numbered list)
- Garbled/empty output
- FINAL RANKING present but empty (documents non-fallback behaviour)

**`CalculateAggregateRankings`** — 6 cases covering:
- Single ranker, three models
- Multiple rankers, unanimous
- Multiple rankers, disagreement (averages positions)
- Unmapped label silently skipped
- Empty input
- No parsed rankings

Closes #10

## Test plan

- [ ] `go test ./internal/council/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)