### PR TITLE
⚖️ test(api): handler tests using fakeStore and fakeCouncil

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -102,7 +102,7 @@ internal/openrouter/   ← LLM calls; no council, no storage
 
 ---
 
-## Step 5: Pre-flight
+## Step 4: Pre-flight
 
 ```bash
 go build ./...
@@ -116,7 +116,7 @@ Fix any failures from your changes before proceeding. Note pre-existing failures
 
 ---
 
-## Step 6: Create PR
+## Step 5: Create PR
 
 Push the branch and open a PR:
 
@@ -144,7 +144,7 @@ Debt emoji: `⚡` quick-fix · `⚖️` balanced · `🏗️` proper-refactor
 
 ---
 
-## Step 7: Wait for Copilot review (poll yourself)
+## Step 6: Wait for Copilot review (poll yourself)
 
 Check review status yourself — do not ask the user:
 
@@ -162,7 +162,7 @@ Once Copilot has posted its review (or 5 minutes have elapsed with no review), p
 
 ---
 
-## Step 8: Address Copilot comments (if any)
+## Step 7: Address Copilot comments (if any)
 
 Fetch the review comments:
 
@@ -187,7 +187,7 @@ git push
 
 ---
 
-## Step 9: Merge
+## Step 8: Merge
 
 ```bash
 gh pr merge <number> --squash --delete-branch
@@ -196,7 +196,7 @@ git checkout main && git pull
 
 ---
 
-## Step 10: Resolve and report
+## Step 9: Resolve and report
 
 The `Closes #N` in the PR body auto-closes the issue on merge. Verify:
 
@@ -213,7 +213,7 @@ Report: issue closed, PR merged, what Copilot flagged (if anything).
 
 ---
 
-## Step 11: Present next issue
+## Step 10: Present next issue
 
 Show the next unblocked issue from the queue (same query as Step 0, skip already-resolved).
 **Do not start implementing it** — wait for the user's command.

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -51,9 +52,12 @@ func (f *fakeStore) AddMessage(id string, msg any) error {
 	defer f.mu.Unlock()
 	conv, ok := f.convs[id]
 	if !ok {
-		return nil
+		return fmt.Errorf("conversation %s not found", id)
 	}
-	raw, _ := json.Marshal(msg)
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
 	conv.Messages = append(conv.Messages, raw)
 	return nil
 }
@@ -61,9 +65,11 @@ func (f *fakeStore) AddMessage(id string, msg any) error {
 func (f *fakeStore) UpdateTitle(id, title string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if conv, ok := f.convs[id]; ok {
-		conv.Title = title
+	conv, ok := f.convs[id]
+	if !ok {
+		return fmt.Errorf("conversation %s not found", id)
 	}
+	conv.Title = title
 	return nil
 }
 
@@ -164,8 +170,29 @@ func TestCreateConversation(t *testing.T) {
 		t.Errorf("status: got %d, want %d", w.Code, http.StatusOK)
 	}
 	body := decodeBody(t, w)
-	if body["id"] == "" {
-		t.Error("response missing id field")
+	id, ok := body["id"].(string)
+	if !ok || id == "" {
+		t.Errorf("response id field missing or not a non-empty string: got %T (%v)", body["id"], body["id"])
+	}
+}
+
+func TestListConversations(t *testing.T) {
+	store := newFakeStore()
+	store.Create("aaaaaaaa-0000-0000-0000-000000000001")
+	store.Create("aaaaaaaa-0000-0000-0000-000000000002")
+	h := newTestHandler(store, &fakeCouncil{})
+
+	w := do(t, h, http.MethodGet, "/api/conversations", nil)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", w.Code, http.StatusOK)
+	}
+	var list []map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("list length: got %d, want 2", len(list))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `internal/api/handler_test.go` with 7 tests covering all public handler paths
- `fakeStore` — in-memory `storage.Storer` (no filesystem I/O)
- `fakeCouncil` — configurable `council.Runner` with controllable `RunFull` result/error (no network calls)
- Compile-time interface satisfaction checks on both fakes
- Tests: `GET /` (healthCheck), `POST /api/conversations`, `GET /api/conversations/{id}` (found + not found), `POST /api/conversations/{id}/message` (success, RunFull error, conversation not found)

Closes #29

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./internal/api/...` passes (7/7)
- [x] `go test -race ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)