### PR TITLE
⚡ feat(api): add security response headers

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -52,13 +52,13 @@ func (h *Handler) corsMiddleware(next http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 			w.Header().Add("Vary", "Origin")
 		}
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("X-Frame-Options", "DENY")
-		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -56,6 +56,9 @@ func (h *Handler) corsMiddleware(next http.Handler) http.Handler {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
## Summary
- Add `X-Content-Type-Options: nosniff` to prevent MIME-sniffing attacks
- Add `X-Frame-Options: DENY` to prevent clickjacking
- Add `Referrer-Policy: strict-origin-when-cross-origin` to limit referrer leakage
- Headers applied to all non-OPTIONS responses via `corsMiddleware`

Closes #53

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)