### PR TITLE
docs: consolidate frontend knowledge into monorepo

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,142 @@
+---
+name: security-reviewer
+description: Use when new code has been written or modified and needs a security audit before a PR is created. Analyzes source code for OWASP Top 10 vulnerabilities, XSS risks, injection vectors, hardcoded secrets, and insecure patterns. Report-only — never modifies code. Invoke proactively after implementing features that handle user input, render LLM output, or make API calls.
+tools: Glob, Grep, Read, WebFetch, WebSearch
+model: sonnet
+color: blue
+---
+
+You are an application security engineer auditing the **LLM Council frontend** — a React 19 + Vite 8 single-page app in plain JavaScript (no TypeScript). You review recently written or modified code for security vulnerabilities. You **report only** — never modify code.
+
+## Stack Context
+
+- **React 19 + Vite 8, plain JavaScript** — no TypeScript, no Supabase
+- **`react-markdown`** renders LLM output — XSS risk is the primary concern
+- **`src/api.js`** is the sole HTTP client — all `fetch` calls live here
+- **`VITE_API_BASE`** env var controls the backend URL (default `http://localhost:8001`)
+- **No auth** — the frontend has no authentication layer; security focus is data integrity and XSS
+- **SSE streaming** via Fetch API `ReadableStream` — no EventSource API
+
+## Core Security Concerns for This Project
+
+### 1. XSS via LLM Output Rendering
+- `react-markdown` is the approved renderer — raw HTML insertion is forbidden
+- Flag any component that renders LLM/user content without going through `react-markdown`
+- Flag any new raw-HTML insertion patterns
+
+### 2. API URL Injection
+- `API_BASE` is constructed from `VITE_API_BASE` env var — verify no user-controlled data reaches URL construction
+- Flag any `fetch` call that builds URLs from unsanitised runtime values
+- Verify `API_BASE` trimming/sanitisation in `src/api.js` is preserved
+
+### 3. SSE Stream Parsing
+- `JSON.parse` on SSE `data:` lines — flag if error handling is removed or bypassed
+- Flag if raw SSE data leaks past the `onEvent(type, event)` boundary into components
+
+### 4. Hardcoded Secrets
+Scan for:
+- API keys, tokens, or credentials assigned as string literals
+- `VITE_*` variables with real values committed (not just in `.env.example`)
+- JWT secrets or OAuth tokens
+
+### 5. CORS and Origin Trust
+- Backend handles CORS — frontend should not assume or override origin headers
+- Flag any `mode: 'no-cors'` fetch calls that hide actual CORS errors
+
+### 6. Injection Risks
+- SQL injection is N/A (no direct DB access)
+- Path traversal: flag any user input used to construct URL paths
+- Prototype pollution: flag `Object.assign({}, userInput)` patterns without validation
+
+### 7. Sensitive Data Exposure
+- LLM responses, conversation history — should not be logged to console in production paths
+- Flag `console.log` with conversation content added to production code
+
+### 8. Dependency Vulnerabilities
+When `package.json` is in scope:
+- Flag packages with known CVEs relevant to the frontend
+- Note severely outdated packages in security-sensitive areas
+
+---
+
+## Analysis Methodology
+
+1. **Scope**: focus on recently changed files unless a full audit is requested
+2. **Data flow**: trace user input and LLM output from source to sink
+3. **Pattern scan**: check for known vulnerability patterns from the list above
+4. **Risk evaluation**: assess exploitability given the stack (no auth, no DB, SSE-only backend)
+5. **Report**: structured findings with severity, location, explanation, recommendation
+
+---
+
+## Output Format
+
+### Security Review Report
+
+**Summary**: `X issues — Y CRITICAL, Z HIGH, W MEDIUM, V LOW`
+
+For each issue:
+
+```
+🔴 CRITICAL | 🟠 HIGH | 🟡 MEDIUM | 🔵 LOW
+
+Type: <VULNERABILITY_TYPE>
+File: <filename>
+Line: <line number>
+
+Description:
+<why it's dangerous>
+
+Vulnerable Code:
+<snippet>
+
+Recommendation:
+<specific fix with corrected code>
+
+Reference: <OWASP category or CWE-ID>
+```
+
+End with:
+
+### Positive Security Observations
+Note good security practices found (reinforces good habits).
+
+### Priority Actions
+Ordered list of the most critical fixes needed.
+
+---
+
+## Severity Definitions
+
+| Severity | Criteria |
+|----------|----------|
+| **CRITICAL** | Direct XSS path, hardcoded production secret, data breach risk |
+| **HIGH** | Likely exploitable, indirect data exposure, broken input validation |
+| **MEDIUM** | Exploitable under specific conditions, minor information disclosure |
+| **LOW** | Defence-in-depth issue, best practice violation |
+
+---
+
+## Behavioural Guidelines
+
+- Focus on recently changed code unless asked to audit everything
+- Minimise false positives — only flag issues with clear evidence in the provided code
+- Always provide a concrete fix recommendation
+- Never modify code — report and advise only
+- Acknowledge that static analysis cannot catch all runtime vulnerabilities
+
+---
+
+# Persistent Agent Memory
+
+Memory path: `.claude/agent-memory/security-reviewer/`
+
+Build up knowledge across conversations — save when you discover recurring vulnerability patterns, false positives to avoid, or security conventions established by the team.
+
+**Memory types:** `user` (role/style) · `feedback` (rule + **Why:** + **How to apply:**) · `project` (fact + **Why:** + **How to apply:**) · `reference` (external pointers)
+
+**Don't save:** code patterns, architecture, file paths, git history, anything already in CLAUDE.md, or ephemeral task state.
+
+**How:** write `<topic>.md` to `.claude/agent-memory/security-reviewer/` with frontmatter (`name`, `description`, `type`), then add a one-line pointer to `.claude/agent-memory/security-reviewer/MEMORY.md`. Never write memory content directly into MEMORY.md. Create MEMORY.md when saving your first memory.
+
+**When to read:** check MEMORY.md when the user references prior work or explicitly asks you to recall.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Use when new code has been written or modified and needs a security audit before a PR is created. Analyzes source code for OWASP Top 10 vulnerabilities, XSS risks, injection vectors, hardcoded secrets, and insecure patterns. Report-only — never modifies code. Invoke proactively after implementing features that handle user input, render LLM output, or make API calls.
-tools: Glob, Grep, Read, WebFetch, WebSearch
+tools: Glob, Grep, Read
 model: sonnet
 color: blue
 ---
@@ -28,6 +28,7 @@ You are an application security engineer auditing the **LLM Council frontend** �
 - `API_BASE` is constructed from `VITE_API_BASE` env var — verify no user-controlled data reaches URL construction
 - Flag any `fetch` call that builds URLs from unsanitised runtime values
 - Verify `API_BASE` trimming/sanitisation in `src/api.js` is preserved
+- Path traversal: flag any user input used to construct URL paths
 
 ### 3. SSE Stream Parsing
 - `JSON.parse` on SSE `data:` lines — flag if error handling is removed or bypassed
@@ -43,10 +44,8 @@ Scan for:
 - Backend handles CORS — frontend should not assume or override origin headers
 - Flag any `mode: 'no-cors'` fetch calls that hide actual CORS errors
 
-### 6. Injection Risks
-- SQL injection is N/A (no direct DB access)
-- Path traversal: flag any user input used to construct URL paths
-- Prototype pollution: flag `Object.assign({}, userInput)` patterns without validation
+### 6. Prototype Pollution
+- Flag `Object.assign({}, userInput)` patterns without validation
 
 ### 7. Sensitive Data Exposure
 - LLM responses, conversation history — should not be logged to console in production paths
@@ -114,16 +113,6 @@ Ordered list of the most critical fixes needed.
 | **HIGH** | Likely exploitable, indirect data exposure, broken input validation |
 | **MEDIUM** | Exploitable under specific conditions, minor information disclosure |
 | **LOW** | Defence-in-depth issue, best practice violation |
-
----
-
-## Behavioural Guidelines
-
-- Focus on recently changed code unless asked to audit everything
-- Minimise false positives — only flag issues with clear evidence in the provided code
-- Always provide a concrete fix recommendation
-- Never modify code — report and advise only
-- Acknowledge that static analysis cannot catch all runtime vulnerabilities
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,20 @@ The following docs describe the **archived v1** implementation and are retained 
 ## Stack (planned for v2)
 
 - **Backend:** Go
+- **Frontend:** React 19 + Vite 8, plain JavaScript (no TypeScript) — lives in `frontend/`
 - **LLM Gateway:** OpenRouter API
 - **API key:** `.env` → `OPENROUTER_API_KEY=sk-or-v1-...`
+
+## Frontend architecture rules (immutable)
+
+These constraints are enforced by the `tech-lead` agent and must not be violated:
+
+1. **Components are pure UI.** No direct `fetch` or `api.js` calls from any component.
+2. **`src/api.js` is the adapter boundary.** `onEvent(type, event)` is the only interface `App.jsx` sees. Raw SSE lines and HTTP status codes never leak past this layer.
+3. **`App.jsx` owns all state.** Only `App.jsx` writes the assistant message shape via `setCurrentConversation`.
+4. **`react-markdown` is the only renderer for LLM output.** Inserting raw HTML is forbidden — it is an XSS risk with LLM-generated content.
+
+See `docs/frontend/` for the API contract, SSE streaming spec, component architecture, and user guide.
 
 ## Workflow
 

--- a/docs/council-research-gaps.md
+++ b/docs/council-research-gaps.md
@@ -17,220 +17,205 @@ This is intentional for the first stage.
 
 ---
 
-## 1. Things the synthesis does not address — design intentionally
+### Consensus metric — Kendall's W for rank-order strategies
 
-### 1.1 Consensus metric: Kendall's W vs. embedding cosine similarity
+Peer review (Stage 2 produces ordered rankings) maps directly to Kendall's W — no
+external embedding calls, measures exactly rank agreement. For free-text strategies
+(Debate, MoA), LLM-as-Judge is the v1 default (no embedding infrastructure required).
+Cosine similarity is deferred until free-text strategies are added.
 
-The synthesis covers cosine similarity at length but never mentions Kendall's coefficient
-of concordance (W). These solve different problems:
+The W-to-prose translation from archive/v1 is carried forward:
+- W ≥ 0.70 → "synthesize confidently"
+- 0.40 ≤ W < 0.70 → "acknowledge alternatives"
+- W < 0.40 → "present multiple perspectives"
 
-- **Kendall's W** — measures agreement across multiple *rank orderings*. Correct when Stage
-  2 produces ranked lists. Requires no external embedding calls. The archive/v1
-  implementation uses this.
-- **Cosine similarity** — measures *text content* similarity. Correct for strategies where
-  models produce free-text answers with no ranking (Debate, MoA). Requires an embedding
-  API or local model.
+---
 
-**Design decision required:** Which strategies will be supported in v1, and therefore which
-consensus metric(s) are needed?
+### Self-evaluation paradox — anonymization is sufficient mitigation for v1
 
-The archive/v1 implementation also translated W into prose for the Chairman prompt via a
-threshold table (W ≥ 0.70 → "synthesize confidently", 0.40–0.70 → "acknowledge
-alternatives", < 0.40 → "present multiple perspectives"). This W-to-prose pattern avoids
-passing raw floats to the LLM and is worth carrying forward.
+Separate ranker models add cost and operational complexity with uncertain benefit.
+Mitigation: shuffled label assignment (`rand.Perm`) per request so no model is
+systematically "Response A". Self-identification is probabilistic, not deterministic.
+Separate ranker pools are a named council type variant, not a v1 requirement.
 
-### 1.2 The self-evaluation paradox in Stage 2
+---
 
-The Karpathy peer-review design uses the **same models** as both generators (Stage 1) and
-rankers (Stage 2). Anonymisation via shuffled labels (A, B, C…) reduces but does not
-eliminate self-identification bias — models may recognise their own writing style.
+### Council type scope — model sets only for v1; strategy abstraction deferred
 
-The synthesis covers positional bias and authority bias but not this specific risk.
+A "council type" is a named configuration: a fixed strategy (Karpathy peer-review)
+combined with a configurable model set and parameters. Multiple council types with
+different model sets require zero interface changes. Strategy variants require a dispatch
+layer and are out of scope until the peer-review design is proven.
 
-**Design decision required:** Use separate ranker models, or accept self-evaluation with
-anonymisation as sufficient mitigation?
+---
 
-### 1.3 Council type: model set, strategy, or both?
+### LCCP first-stage scope — Core conformance, single round, no REFINE loop
 
-The synthesis describes multiple strategies (Voting, Generate→Rank→Refine, Debate, MoA,
-Peer Review) as equally available. In practice, adding a new strategy requires either
-redesigning the core interface or adding a dispatch layer. The two dimensions:
-
-1. **Model set** — same algorithm, different models ("expert council" vs. "fast council").
-   Cheapest; no interface change needed.
-2. **Strategy** — different deliberation algorithm per type. Requires a strategy abstraction
-   or dispatcher.
-3. **Both** — a full registry combining model set and strategy per named council type.
-
-**Design decision required:** Which scope for "first stage" — model sets only, or strategy
-variants too?
-
-### 1.4 LCCP first-stage scope
-
-The synthesis presents a 12-state LCCP state machine with 4 configuration profiles and 4
-conformance levels. For a first build, the implementation scope must be scoped explicitly.
-
-If the first stage is "Karpathy peer review only, single round, no refinement," the state
-machine reduces to:
+Effective state machine for v1:
 ```
 INIT → GENERATE → VALIDATE_GENERATION → EVALUATE → VALIDATE_EVALUATION
-     → AGGREGATE → DECIDE → FINALIZE → TERMINATE  (no REFINE loop)
+     → AGGREGATE → DECIDE → FINALIZE → TERMINATE  (+ FAIL branch at any node)
 ```
 
-Key scoping questions:
-- Is a REFINE loop in scope for the first build, or deferred?
-- Which conformance level is the target: Core, Safe, Robust, or Auditable?
-- Are BestSoFar tracking and fallback finalization modes required from the start?
-
-**Design decision required:** Explicitly state which LCCP states, invariants, and
-conformance level are in scope for v1. This decision drives the entire architecture.
-
-### 1.5 Quorum enforcement
-
-If some council models fail to respond, the deliberation degrades silently. For the
-peer-review design, if only one model responds, Stage 2 ranking is meaningless (a model
-ranking its own answer). Kendall's W returns 0 for fewer than 2 rankers, but without a
-quorum gate, Stage 3 proceeds anyway.
-
-The synthesis defines `M_min` (minimum quorum) as a hard requirement. The new
-implementation should enforce it explicitly with a clear error response rather than
-producing a degenerate result.
-
-**Design decision required:** What is `M_min` per council type? What is the response when
-quorum is not met — error, or fallback to single-model answer?
-
-### 1.6 Metadata persistence per message
-
-The `labelToModel` mapping, aggregate rankings, and consensus score are produced per
-council run. If not stored with the conversation message, audit and replay are impossible.
-The synthesis recommends full traceability (Invariant I4).
-
-**Design decision required:** Store full metadata with every assistant message, or treat
-it as ephemeral? If stored, what schema?
-
-### 1.7 Structured output vs. free-text parsing for rankings
-
-In archive/v1, Stage 2 rankings were extracted from free-text model output via regex.
-The failure mode (model deviates from expected format) silently produces an empty ranking,
-which receives a mid-rank imputation in Kendall's W — degrading the consensus score with
-no warning.
-
-The synthesis recommends structured JSON output as best practice.
-
-**Design decision required:** Require JSON output (via `response_format: json_object` on
-OpenRouter) for ranking responses, with explicit failure handling when parsing fails?
+Explicitly deferred: REFINE loop, BestSoFar tracking, fallback finalization modes
+(synthesize_top_k → select_best → fallback_best_so_far). Target: Core conformance level.
+Robust and Auditable conformance are post-v1. This is the scope-limiting decision that
+drives the entire architecture.
 
 ---
 
-## 2. Under-specified recommendations in the synthesis
+### Quorum enforcement — M_min = ⌈N/2⌉ + 1, minimum 2; failure → error
 
-### 2.1 Convergence criteria: which metric for which strategy?
-
-§5.3 presents cosine embedding similarity as the primary convergence mechanism. But the
-synthesis already covers Kendall's W (for rank-order strategies) and mentions LLM-as-Judge
-as an option. The synthesis does not map metric to strategy:
-
-- **Rank-order strategies** (peer review): Kendall's W is sufficient, no embedding calls.
-- **Free-text strategies** (Debate, MoA): cosine similarity requires embedding
-  infrastructure; LLM-as-Judge requires no extra dependencies.
-
-The remaining unresolved question is not which metric to use in general — the synthesis
-already addresses that — but which metric to use per strategy variant, and whether
-LLM-as-Judge should be the v1 default for strategies without a natural rank ordering.
-
-### 2.2 "Preserve unique insights" is not operationalised
-
-The synthesis repeatedly recommends "explicitly prompt synthesis to preserve unique
-insights." But neither the synthesis nor the Chairman prompt in archive/v1 defines what
-makes an insight "unique" or how to distinguish a fringe claim from a minority-but-correct
-insight. This is stated as a mitigation but not specified.
-
-### 2.3 Trust weighting has no acquisition path
-
-§5.1 and §9.4 reference trust-weighted scoring. The synthesis does not describe how trust
-values are initialised, calibrated, or updated. Without a ground-truth oracle, trust
-weights cannot be meaningfully set. For a first-stage implementation with no evaluation
-framework, this feature should be deferred or treated as uniform weights.
-
-### 2.4 "Council type" and "strategy" are conflated
-
-§2 describes strategies. §11.5 describes a council type registry with model IDs and
-strategy per type. The synthesis uses the terms interchangeably. In the new implementation
-these should be distinct concepts: a **strategy** is a deliberation algorithm; a **council
-type** is a named configuration combining a strategy with a model set and parameters.
-
-### 2.5 The Chairman prompt receives untrusted Stage 2 input — internal contradiction
-
-The synthesis contradicts itself on this point:
-
-- §2.5 (Karpathy design): "Chairman receives all responses + all reviews" — raw Stage 2.
-- §7 (Prompt Injection Propagation hazard): "pass only arbiter's summary, not raw output."
-- §9.9 (Security): "Never pass raw responses; pass arbiter's validated summary."
-
-The Karpathy design passes raw Stage 2 output; the safety recommendations say not to. A
-decision is needed: sanitise/structure Stage 2 input to Stage 3, or accept the risk with
-prompt-level mitigations?
+If Stage 1 returns fewer than M_min successful responses, return an explicit error to the
+caller. A single-model Stage 2 ranking is meaningless (a model ranking its own answer).
+Within-quorum partial failures (some models fail but M_min succeed) are tolerated.
+The quorum threshold is a council type configuration parameter, not hardcoded.
 
 ---
 
-## 3. Unclear design questions
+### Metadata persistence — store full metadata with every assistant message
 
-### 3.1 Council type selection scope in the API
+Schema addition to the assistant message:
+```json
+{
+  "role": "assistant",
+  "stage1": [...],
+  "stage2": [...],
+  "stage3": {...},
+  "metadata": {
+    "council_type": "default",
+    "label_to_model": {"Response A": "model-x", ...},
+    "aggregate_rankings": [...],
+    "consensus_w": 0.72
+  }
+}
+```
 
-Given that context is stateless per query, council type selection is per-request. The
-remaining question is the API shape:
-- Field in the POST request body (most explicit)
-- Query parameter (simpler, less RESTful)
-- Server-wide config only (archive/v1 approach; no selection at runtime)
-
-### 3.2 Should Stage 3 support graceful non-synthesis?
-
-When council answers are strongly contradictory (consensus near 0), the Chairman should be
-able to surface "the council could not reach a synthesis" as a first-class outcome rather
-than being forced to synthesise anyway. The LCCP fallback chain — synthesize_top_k →
-select_best → fallback_best_so_far — is not in the archive/v1 implementation and needs an
-explicit decision.
-
-### 3.3 Streaming architecture: stage events vs. token streaming
-
-Archive/v1 streams stage-completion events over SSE (stage1_start, stage1_complete,
-stage2_start, …). Token-by-token streaming within a stage would require passing a
-streaming callback through the council pipeline. The design choice affects the core LLM
-client interface.
+Old conversation files (no `metadata` field) fail gracefully via zero-value defaults
+in Go struct unmarshalling.
 
 ---
 
-## 4. Production constraints to design for from the start
+### Structured JSON output for Stage 2 rankings
 
-### 4.1 JSON file storage has known limits
+Use `response_format: json_object` on OpenRouter for Stage 2 ranking responses.
+Schema: `{"rankings": ["Response C", "Response A", "Response B", "Response D"]}`.
+If JSON parsing fails: log `slog.Warn`, treat as missing ranking (existing midrank
+imputation in Kendall's W handles it). Replaces the silent regex failure mode from v1.
 
-A `List()` that reads every conversation file is O(n) on disk. With many long conversations
-storing full Stage 1/2/3 responses per message, this will get slow. The storage abstraction
-(a `Storer` interface over a pluggable backend) should be designed from the start to allow
-replacing the JSON backend later without rewriting handlers.
+---
 
-### 4.2 OpenRouter model lifecycle
+### Trust weighting — deferred; uniform weights in v1
 
-Models on OpenRouter are deprecated, renamed, and temporarily unavailable. A council type
-registry that stores specific model IDs by string will break when those IDs change. The
-new implementation needs a model configuration layer that can be updated without redeploying,
-separate from the council logic.
+Trust weighting requires a calibration mechanism (ground-truth oracle or historical
+performance data) that doesn't exist. Uniform weights are the correct default. Defer
+until an evaluation framework exists.
 
-### 4.3 The `CalculateAggregateRankings` placement
+---
 
-In archive/v1, `CalculateAggregateRankings` lived on the `Runner` interface — a pure
-computation function on a behaviour interface. Any new strategy implementation would also
-need to satisfy it regardless of whether it produces rankings. In the new design this
-should be a package-level function (or belong to a separate ranking/metrics layer), not
-part of the deliberation interface.
+### Strategy vs. council type — distinct concepts in code and API
 
-### 4.4 Load-bearing infrastructure tasks before extending the API surface
+- **Strategy:** A deliberation algorithm (`PeerReview`, `MajorityVoting`, `MoA`). Pure
+  behavior, no model specifics. Typed constant/enum in Go.
+- **Council type:** A named, user-selectable configuration combining strategy + model
+  set + parameters (`"default"`, `"expert"`, `"fast"`). User-facing.
 
-The following were pending in archive/v1 and remain relevant for any new build:
+In the API, the field is `council_type` (string name). Strategy is resolved server-side
+from the council type registry. Users never specify a strategy directly.
+
+---
+
+### Chairman input — parsed/structured rankings, not raw Stage 2 prose
+
+The Chairman receives parsed rankings formatted as structured attribution:
+"Model X ranked these responses: 1st: Response C, 2nd: Response A, ...". The Chairman
+prompt is constructed from Go structs, not by concatenating raw LLM output. With
+structured JSON output in Stage 2 (see above), the ranking content contains no
+user-controlled text — only server-assigned labels.
+
+This resolves the internal synthesis contradiction: §2.5 (pass raw output) vs. §7/§9.9
+(pass only validated summary). Middle ground: parsed structure, no full sanitization pass.
+
+---
+
+### Council type selection API shape — field in POST request body
+
+```json
+POST /api/conversations/{id}/message
+{"content": "What is the best sorting algorithm?", "council_type": "default"}
+```
+
+`council_type` is optional; defaults to server-configured default. Server-wide config
+only (archive/v1 approach) is inadequate once multiple council types exist. Query
+parameters are less discoverable and harder to validate.
+
+---
+
+### Stage 3 graceful non-synthesis — deferred to post-v1
+
+The W-to-prose translation already guides the Chairman toward presenting perspectives
+rather than synthesizing when W < 0.40. A first-class "council could not reach a
+synthesis" outcome requires the REFINE loop and LCCP fallback chain — both explicitly
+out of scope (see LCCP scope decision). Document as a known v1 limitation.
+
+---
+
+### Streaming architecture — stage-completion events only; no intra-stage token streaming
+
+Token-by-token streaming within a stage requires threading a streaming callback through
+the entire council pipeline interface. The SSE event-per-stage model provides meaningful
+progress feedback without this interface complexity. Intra-stage token streaming is a
+valid post-v1 enhancement.
+
+---
+
+### Storage interface — pluggable Storer from day one; JSON backend is v1 only
+
+The `Storer` interface must be designed to allow replacing the JSON backend without
+rewriting handlers. The JSON file backend is v1 only — `List()` is O(n) on disk and
+does not scale. Interface design must not leak JSON-specific assumptions.
+
+---
+
+### OpenRouter model lifecycle — model IDs in configuration, not code
+
+Council type registry stores model IDs as configuration strings updatable without
+redeployment. The implementation must not hardcode model IDs in source code.
+
+---
+
+### CalculateAggregateRankings — package-level function, not on Runner interface
+
+In archive/v1 this lived on the `Runner` interface, forcing every strategy to satisfy
+it regardless of whether it produces rankings. In v2 it is a package-level function
+(or belongs to a separate ranking/metrics layer).
+
+---
+
+### Infrastructure prerequisites — confirmed requirements for any v2 build
+
+The following are prerequisites, not optional niceties:
 - Config validation at startup (fail fast on missing API key)
 - HTTP client timeout on the OpenRouter client
 - Graceful shutdown for the HTTP server
 - Structured logging (`slog`)
 - Handler tests using mock interfaces
 
-These are not optional niceties — they are prerequisites for a production REST API.
+---
+
+## Remaining open questions
+
+### "Preserve unique insights" is not operationalised
+
+The synthesis repeatedly recommends "explicitly prompt synthesis to preserve unique
+insights." Neither the synthesis nor any source material defines what makes an insight
+"unique" or how to distinguish a fringe claim from a minority-but-correct insight.
+
+**Current position:** The Chairman prompt includes an explicit instruction to surface
+minority perspectives that appear well-reasoned even if not consensus — particularly when
+W < 0.40. Formal operationalization (defining "unique" algorithmically, tracking insight
+provenance) is deferred until an evaluation framework exists to validate any criterion.
+
+**What needs answering before this can be closed:** A concrete rubric or test for
+distinguishing "unique minority insight" from "fringe claim," or an explicit decision
+that this is permanently a prompt-level heuristic.

--- a/docs/frontend/api-contract.md
+++ b/docs/frontend/api-contract.md
@@ -5,7 +5,7 @@ The frontend communicates with the Go backend (port 8001 by default) via REST + 
 ## Design Constraints
 
 - **One question per conversation.** Each conversation stores exactly one user message and one assistant message. Sending a second message to an existing conversation is not supported by the UI — the frontend creates a new conversation for each question.
-- **`metadata` is ephemeral.** The `label_to_model` and `aggregate_rankings` fields are only returned during the streaming response and are not persisted. `GET /api/conversations/{id}` does not include them.
+- **`metadata` is ephemeral (v1).** The `label_to_model` and `aggregate_rankings` fields are only returned during the streaming response and are not persisted. `GET /api/conversations/{id}` does not include them. **v2 note:** the resolved design decision for v2 is to persist full metadata with every assistant message — see `docs/council-research-gaps.md`.
 
 ---
 

--- a/docs/frontend/api-contract.md
+++ b/docs/frontend/api-contract.md
@@ -5,7 +5,7 @@ The frontend communicates with the Go backend (port 8001 by default) via REST + 
 ## Design Constraints
 
 - **One question per conversation.** Each conversation stores exactly one user message and one assistant message. Sending a second message to an existing conversation is not supported by the UI — the frontend creates a new conversation for each question.
-- **`metadata` is ephemeral (v1).** The `label_to_model` and `aggregate_rankings` fields are only returned during the streaming response and are not persisted. `GET /api/conversations/{id}` does not include them. **v2 note:** the resolved design decision for v2 is to persist full metadata with every assistant message — see `docs/council-research-gaps.md`.
+- **`metadata` is ephemeral (v1).** The `label_to_model` and `aggregate_rankings` fields are only returned during the streaming response and are not persisted. `GET /api/conversations/{id}` does not include them. **v2 note:** metadata will be persisted with every assistant message; the v2 schema extends v1 with two new fields: `council_type` (string) and `consensus_w` (float, Kendall's W score). See `docs/council-research-gaps.md`.
 
 ---
 
@@ -232,3 +232,8 @@ The backend allows:
 - Origins: `http://localhost:5173`, `http://localhost:3000`
 - Methods: `GET`, `POST`, `OPTIONS`
 - Headers: `Content-Type`
+
+> **Deployment scope:** This API is designed for localhost use only. All endpoints are
+> unauthenticated. CORS origin restrictions do not protect server-side callers (curl,
+> server-side fetch). Before any non-localhost deployment, an authentication layer must
+> be added.


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: adds frontend stack entry and four immutable architecture rules (component purity, `src/api.js` adapter boundary, `App.jsx` state ownership, `react-markdown`-only LLM output rendering)
- **`docs/council-research-gaps.md`**: replaces all open design questions with their resolved v2 decisions; single remaining open question is "preserve unique insights" (not yet operationalised)
- **`docs/frontend/api-contract.md`**: annotates the `metadata` ephemeral constraint with a v1/v2 note (v2 will persist metadata per resolved design decision)
- **`.claude/agents/security-reviewer.md`**: imports the React/JS/XSS-focused security reviewer agent from the now-deleted `llm-council-frontend` sibling repo; complements the existing `go-security-reviewer` agent

The `../llm-council-frontend` directory can be safely deleted after this merges.

## Test plan
- [ ] `CLAUDE.md` frontend section present and architecture rules accurate
- [ ] `docs/council-research-gaps.md` contains only resolved decisions + one open question
- [ ] `.claude/agents/security-reviewer.md` exists and is React/JS-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)