### PR TITLE
⚡ task(scaffold): initialise Go module and empty package skeleton

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/valpere/llm-council
+
+go 1.26

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1,0 +1,1 @@
+package api

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,1 @@
+package config

--- a/internal/council/council.go
+++ b/internal/council/council.go
@@ -1,0 +1,1 @@
+package council

--- a/internal/council/interfaces.go
+++ b/internal/council/interfaces.go
@@ -1,0 +1,1 @@
+package council

--- a/internal/council/prompts.go
+++ b/internal/council/prompts.go
@@ -1,0 +1,1 @@
+package council

--- a/internal/council/rankings.go
+++ b/internal/council/rankings.go
@@ -1,0 +1,1 @@
+package council

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -1,0 +1,1 @@
+package council

--- a/internal/openrouter/client.go
+++ b/internal/openrouter/client.go
@@ -1,0 +1,1 @@
+package openrouter

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,1 @@
+package storage


### PR DESCRIPTION
## Summary

- Initialises `go.mod` with module `github.com/valpere/llm-council` at `go 1.26`
- Creates stub `.go` files for all seven packages: `cmd/server`, `internal/config`, `internal/openrouter`, `internal/council` (5 files: council, interfaces, types, prompts, rankings), `internal/storage`, `internal/api`
- All stubs are package declarations only — no logic

Closes #72

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)