### PR TITLE
⚡ task(types+storage): define council types and Storer interface

### DIFF
--- a/docs/frontend/api-contract.md
+++ b/docs/frontend/api-contract.md
@@ -145,7 +145,10 @@ Response: `text/event-stream` (Server-Sent Events). See [streaming.md](./streami
 
 ## Data Types
 
-> These are JSON object shapes. Property types use pseudocode notation (`string`, `number`, `bool`, `array[]`).
+> **v1 contract** — shapes below describe the archived v1 implementation on `archive/v1`.
+> **v2 changes:** stage result types are anonymisation-first — `StageOneResult` uses `label`/`content` instead of `model`/`response`; `StageTwoResult` uses `reviewer_label`/`rankings` instead of `model`/`ranking`/`parsed_ranking`; `StageThreeResult` adds `duration_ms`; `AssistantMessage` adds `metadata`. The v1 contract is retained here as the reference for the archived code.
+
+> Property types use pseudocode notation (`string`, `number`, `bool`, `array[]`).
 
 ### ConversationMeta
 

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -1,7 +1,5 @@
 package council
 
-import "time"
-
 // Strategy identifies the deliberation algorithm used by a CouncilType.
 type Strategy int
 
@@ -51,11 +49,11 @@ type EventFunc func(eventType string, data any)
 
 // StageOneResult holds a single council member's generated answer.
 type StageOneResult struct {
-	Label    string    `json:"label"`     // anonymised label, e.g. "Response A"
-	Content  string    `json:"content"`
-	Model    string    `json:"model"`
-	Duration time.Duration `json:"duration_ms"`
-	Error    error     `json:"-"`
+	Label      string `json:"label"`      // anonymised label, e.g. "Response A"
+	Content    string `json:"content"`
+	Model      string `json:"model"`
+	DurationMs int64  `json:"duration_ms"` // elapsed milliseconds
+	Error      error  `json:"-"`
 }
 
 // StageTwoResult holds a single council member's peer-review rankings.
@@ -67,10 +65,10 @@ type StageTwoResult struct {
 
 // StageThreeResult holds the chairman's synthesised final answer.
 type StageThreeResult struct {
-	Content  string        `json:"content"`
-	Model    string        `json:"model"`
-	Duration time.Duration `json:"duration_ms"`
-	Error    error         `json:"-"`
+	Content    string `json:"content"`
+	Model      string `json:"model"`
+	DurationMs int64  `json:"duration_ms"` // elapsed milliseconds
+	Error      error  `json:"-"`
 }
 
 // RankedModel pairs a model name with its aggregate rank score.

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -1,1 +1,97 @@
 package council
+
+import "time"
+
+// Strategy identifies the deliberation algorithm used by a CouncilType.
+type Strategy int
+
+const (
+	PeerReview Strategy = iota
+)
+
+// CouncilType describes a named council configuration.
+// QuorumMin of 0 means use the formula: max(2, ⌈N/2⌉+1).
+type CouncilType struct {
+	Name          string
+	Strategy      Strategy
+	Models        []string
+	ChairmanModel string
+	Temperature   float64
+	QuorumMin     int // 0 = use formula: max(2, ⌈N/2⌉+1)
+}
+
+// ChatMessage is a single turn in a conversation history.
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ResponseFormat instructs the LLM to return a specific format.
+type ResponseFormat struct {
+	Type string `json:"type"` // e.g. "json_object"
+}
+
+// CompletionRequest is sent to the LLM gateway.
+type CompletionRequest struct {
+	Model          string          `json:"model"`
+	Messages       []ChatMessage   `json:"messages"`
+	Temperature    float64         `json:"temperature"`
+	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
+}
+
+// CompletionResponse is received from the LLM gateway.
+type CompletionResponse struct {
+	Choices []struct {
+		Message ChatMessage `json:"message"`
+	} `json:"choices"`
+}
+
+// EventFunc is the callback used to stream stage-completion events to the caller.
+type EventFunc func(eventType string, data any)
+
+// StageOneResult holds a single council member's generated answer.
+type StageOneResult struct {
+	Label    string    `json:"label"`     // anonymised label, e.g. "Response A"
+	Content  string    `json:"content"`
+	Model    string    `json:"model"`
+	Duration time.Duration `json:"duration_ms"`
+	Error    error     `json:"-"`
+}
+
+// StageTwoResult holds a single council member's peer-review rankings.
+type StageTwoResult struct {
+	ReviewerLabel string   `json:"reviewer_label"`
+	Rankings      []string `json:"rankings"` // ordered labels, best first
+	Error         error    `json:"-"`
+}
+
+// StageThreeResult holds the chairman's synthesised final answer.
+type StageThreeResult struct {
+	Content  string        `json:"content"`
+	Model    string        `json:"model"`
+	Duration time.Duration `json:"duration_ms"`
+	Error    error         `json:"-"`
+}
+
+// RankedModel pairs a model name with its aggregate rank score.
+type RankedModel struct {
+	Model string  `json:"model"`
+	Score float64 `json:"score"`
+}
+
+// Metadata is persisted with every assistant message.
+type Metadata struct {
+	CouncilType       string        `json:"council_type"`
+	LabelToModel      map[string]string `json:"label_to_model"`
+	AggregateRankings []RankedModel `json:"aggregate_rankings"`
+	ConsensusW        float64       `json:"consensus_w"`
+}
+
+// AssistantMessage is the full deliberation record stored with each assistant turn.
+type AssistantMessage struct {
+	Role     string           `json:"role"`
+	Stage1   []StageOneResult `json:"stage1"`
+	Stage2   []StageTwoResult `json:"stage2"`
+	Stage3   StageThreeResult `json:"stage3"`
+	Metadata Metadata         `json:"metadata"`
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,1 +1,62 @@
 package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/valpere/llm-council/internal/council"
+)
+
+// NotFoundError is returned when a requested conversation does not exist.
+type NotFoundError struct {
+	ID string
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("conversation not found: %s", e.ID)
+}
+
+// ConversationMeta holds lightweight metadata for list responses.
+type ConversationMeta struct {
+	ID           string    `json:"id"`
+	CreatedAt    time.Time `json:"created_at"`
+	Title        string    `json:"title"`
+	MessageCount int       `json:"message_count"`
+}
+
+// Conversation is the full stored record including the message history.
+// Messages is []json.RawMessage so the heterogeneous user/assistant array
+// survives round-trips without losing type information; callers demux by
+// inspecting the "role" field of each element.
+type Conversation struct {
+	ID        string            `json:"id"`
+	CreatedAt time.Time         `json:"created_at"`
+	Title     string            `json:"title"`
+	Messages  []json.RawMessage `json:"messages"`
+}
+
+// Storer is the persistence interface. The handler depends only on this
+// interface — never on a concrete implementation.
+type Storer interface {
+	CreateConversation() (*Conversation, error)
+	GetConversation(id string) (*Conversation, error)
+	ListConversations() ([]ConversationMeta, error)
+	SaveUserMessage(id, content string) error
+	SaveAssistantMessage(id string, msg council.AssistantMessage) error
+	SaveTitle(id, title string) error
+}
+
+// Store is the concrete JSON backend. It satisfies Storer.
+// Implementation lives in the L2.2 JSON storage backend issue.
+type Store struct{}
+
+func (s *Store) CreateConversation() (*Conversation, error)                              { panic("not implemented") }
+func (s *Store) GetConversation(id string) (*Conversation, error)                        { panic("not implemented") }
+func (s *Store) ListConversations() ([]ConversationMeta, error)                          { panic("not implemented") }
+func (s *Store) SaveUserMessage(id, content string) error                                { panic("not implemented") }
+func (s *Store) SaveAssistantMessage(id string, msg council.AssistantMessage) error      { panic("not implemented") }
+func (s *Store) SaveTitle(id, title string) error                                        { panic("not implemented") }
+
+// Compile-time assertion: Store implements Storer.
+var _ Storer = (*Store)(nil)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,7 +14,7 @@ type NotFoundError struct {
 	ID string
 }
 
-func (e *NotFoundError) Error() string {
+func (e NotFoundError) Error() string {
 	return fmt.Sprintf("conversation not found: %s", e.ID)
 }
 
@@ -51,12 +52,14 @@ type Storer interface {
 // Implementation lives in the L2.2 JSON storage backend issue.
 type Store struct{}
 
-func (s *Store) CreateConversation() (*Conversation, error)                              { panic("not implemented") }
-func (s *Store) GetConversation(id string) (*Conversation, error)                        { panic("not implemented") }
-func (s *Store) ListConversations() ([]ConversationMeta, error)                          { panic("not implemented") }
-func (s *Store) SaveUserMessage(id, content string) error                                { panic("not implemented") }
-func (s *Store) SaveAssistantMessage(id string, msg council.AssistantMessage) error      { panic("not implemented") }
-func (s *Store) SaveTitle(id, title string) error                                        { panic("not implemented") }
+var errNotImplemented = errors.New("not implemented")
+
+func (s *Store) CreateConversation() (*Conversation, error)                         { return nil, errNotImplemented }
+func (s *Store) GetConversation(id string) (*Conversation, error)                   { return nil, errNotImplemented }
+func (s *Store) ListConversations() ([]ConversationMeta, error)                     { return nil, errNotImplemented }
+func (s *Store) SaveUserMessage(id, content string) error                           { return errNotImplemented }
+func (s *Store) SaveAssistantMessage(id string, msg council.AssistantMessage) error { return errNotImplemented }
+func (s *Store) SaveTitle(id, title string) error                                   { return errNotImplemented }
 
 // Compile-time assertion: Store implements Storer.
 var _ Storer = (*Store)(nil)


### PR DESCRIPTION
## Summary

- Defines all shared domain types in `internal/council/types.go` (`Strategy`, `CouncilType`, `CompletionRequest/Response`, `ChatMessage`, `ResponseFormat`, `EventFunc`, `StageOneResult`, `StageTwoResult`, `StageThreeResult`, `RankedModel`, `Metadata`, `AssistantMessage`)
- Defines `Storer` interface, `Conversation`, `ConversationMeta`, `NotFoundError` in `internal/storage/storage.go`
- `storage → council` one-way dependency; no import cycles
- `Store` stub satisfies the compile-time assertion `var _ Storer = (*Store)(nil)`; methods `panic("not implemented")` until the JSON backend lands in L2.2

Closes #74
Closes #76

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (no test files yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)