### PR TITLE
⚡ task(council): define LLMClient and Runner interfaces

### DIFF
--- a/internal/council/interfaces.go
+++ b/internal/council/interfaces.go
@@ -1,1 +1,17 @@
 package council
+
+import "context"
+
+// LLMClient is the interface for sending completion requests to an LLM gateway.
+// openrouter.Client implements this; council logic depends only on this interface.
+type LLMClient interface {
+	Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error)
+}
+
+// Runner orchestrates a full council deliberation.
+// All stage results are delivered via onEvent — the caller never receives
+// stage structs directly, keeping the handler free of council-internal types.
+// councilType is a string name resolved to a CouncilType by the Runner implementation.
+type Runner interface {
+	RunFull(ctx context.Context, query string, councilType string, onEvent EventFunc) error
+}

--- a/internal/council/interfaces.go
+++ b/internal/council/interfaces.go
@@ -3,7 +3,7 @@ package council
 import "context"
 
 // LLMClient is the interface for sending completion requests to an LLM gateway.
-// openrouter.Client implements this; council logic depends only on this interface.
+// Council logic depends only on this interface, not on a specific gateway implementation.
 type LLMClient interface {
 	Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error)
 }


### PR DESCRIPTION
## Summary

- Defines `LLMClient` interface in `internal/council/interfaces.go`: `Complete(ctx, CompletionRequest) (CompletionResponse, error)`
- Defines `Runner` interface: `RunFull(ctx, query, councilType string, onEvent EventFunc) error`
- Both interfaces use only types from `council/types.go` and stdlib `context` — no external imports
- `openrouter` and `api` will implement/consume these interfaces without importing each other

Closes #75

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)