### PR TITLE
⚖️ task(storage): implement JSON file backend and storage tests

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,9 +1,13 @@
 package storage
 
 import (
+	"crypto/rand"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/valpere/llm-council/internal/council"
@@ -48,18 +52,152 @@ type Storer interface {
 	SaveTitle(id, title string) error
 }
 
-// Store is the concrete JSON backend. It satisfies Storer.
-// Implementation lives in the L2.2 JSON storage backend issue.
-type Store struct{}
+// Store is the JSON file backend. One file per conversation under dataDir.
+type Store struct {
+	dataDir string
+	logger  *slog.Logger
+}
 
-var errNotImplemented = errors.New("not implemented")
-
-func (s *Store) CreateConversation() (*Conversation, error)                         { return nil, errNotImplemented }
-func (s *Store) GetConversation(id string) (*Conversation, error)                   { return nil, errNotImplemented }
-func (s *Store) ListConversations() ([]ConversationMeta, error)                     { return nil, errNotImplemented }
-func (s *Store) SaveUserMessage(id, content string) error                           { return errNotImplemented }
-func (s *Store) SaveAssistantMessage(id string, msg council.AssistantMessage) error { return errNotImplemented }
-func (s *Store) SaveTitle(id, title string) error                                   { return errNotImplemented }
+// NewStore creates the data directory if needed and returns a Store.
+func NewStore(dataDir string, logger *slog.Logger) (*Store, error) {
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return nil, fmt.Errorf("create data dir: %w", err)
+	}
+	return &Store{dataDir: dataDir, logger: logger}, nil
+}
 
 // Compile-time assertion: Store implements Storer.
 var _ Storer = (*Store)(nil)
+
+func (s *Store) filePath(id string) string {
+	return filepath.Join(s.dataDir, id+".json")
+}
+
+func (s *Store) readConversation(id string) (*Conversation, error) {
+	data, err := os.ReadFile(s.filePath(id))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, &NotFoundError{ID: id}
+		}
+		return nil, fmt.Errorf("read %s: %w", id, err)
+	}
+	var c Conversation
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("unmarshal %s: %w", id, err)
+	}
+	return &c, nil
+}
+
+func (s *Store) writeConversation(c *Conversation) error {
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal conversation: %w", err)
+	}
+	if err := os.WriteFile(s.filePath(c.ID), data, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", c.ID, err)
+	}
+	return nil
+}
+
+func newUUID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+func (s *Store) CreateConversation() (*Conversation, error) {
+	id, err := newUUID()
+	if err != nil {
+		return nil, fmt.Errorf("generate id: %w", err)
+	}
+	c := &Conversation{
+		ID:        id,
+		CreatedAt: time.Now().UTC(),
+		Messages:  []json.RawMessage{},
+	}
+	if err := s.writeConversation(c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (s *Store) GetConversation(id string) (*Conversation, error) {
+	return s.readConversation(id)
+}
+
+func (s *Store) ListConversations() ([]ConversationMeta, error) {
+	entries, err := os.ReadDir(s.dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir: %w", err)
+	}
+	var metas []ConversationMeta
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		id := e.Name()[:len(e.Name())-5] // strip .json
+		data, err := os.ReadFile(filepath.Join(s.dataDir, e.Name()))
+		if err != nil {
+			s.logger.Warn("skipping unreadable conversation file", "file", e.Name(), "error", err)
+			continue
+		}
+		var c Conversation
+		if err := json.Unmarshal(data, &c); err != nil {
+			s.logger.Warn("skipping corrupt conversation file", "file", e.Name(), "error", err)
+			continue
+		}
+		metas = append(metas, ConversationMeta{
+			ID:           id,
+			CreatedAt:    c.CreatedAt,
+			Title:        c.Title,
+			MessageCount: len(c.Messages),
+		})
+	}
+	sort.Slice(metas, func(i, j int) bool {
+		return metas[i].CreatedAt.After(metas[j].CreatedAt)
+	})
+	return metas, nil
+}
+
+func (s *Store) SaveUserMessage(id, content string) error {
+	c, err := s.readConversation(id)
+	if err != nil {
+		return err
+	}
+	raw, err := json.Marshal(struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}{Role: "user", Content: content})
+	if err != nil {
+		return fmt.Errorf("marshal user message: %w", err)
+	}
+	c.Messages = append(c.Messages, raw)
+	return s.writeConversation(c)
+}
+
+func (s *Store) SaveAssistantMessage(id string, msg council.AssistantMessage) error {
+	c, err := s.readConversation(id)
+	if err != nil {
+		return err
+	}
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal assistant message: %w", err)
+	}
+	c.Messages = append(c.Messages, raw)
+	return s.writeConversation(c)
+}
+
+func (s *Store) SaveTitle(id, title string) error {
+	c, err := s.readConversation(id)
+	if err != nil {
+		return err
+	}
+	c.Title = title
+	return s.writeConversation(c)
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/valpere/llm-council/internal/council"
@@ -53,14 +55,26 @@ type Storer interface {
 }
 
 // Store is the JSON file backend. One file per conversation under dataDir.
+// A store-level RWMutex serialises write operations (create/save) while
+// allowing concurrent reads.
 type Store struct {
 	dataDir string
 	logger  *slog.Logger
+	mu      sync.RWMutex
 }
 
-// NewStore creates the data directory if needed and returns a Store.
+// uuidRE matches a canonical UUID v4.
+var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func isValidUUID(id string) bool { return uuidRE.MatchString(id) }
+
+// NewStore creates the data directory (mode 0700) if needed and returns a Store.
+// A nil logger falls back to slog.Default().
 func NewStore(dataDir string, logger *slog.Logger) (*Store, error) {
-	if err := os.MkdirAll(dataDir, 0755); err != nil {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
 		return nil, fmt.Errorf("create data dir: %w", err)
 	}
 	return &Store{dataDir: dataDir, logger: logger}, nil
@@ -73,7 +87,12 @@ func (s *Store) filePath(id string) string {
 	return filepath.Join(s.dataDir, id+".json")
 }
 
+// readConversation reads and unmarshals a conversation file.
+// Caller must hold at least s.mu.RLock().
 func (s *Store) readConversation(id string) (*Conversation, error) {
+	if !isValidUUID(id) {
+		return nil, &NotFoundError{ID: id}
+	}
 	data, err := os.ReadFile(s.filePath(id))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -88,13 +107,21 @@ func (s *Store) readConversation(id string) (*Conversation, error) {
 	return &c, nil
 }
 
+// writeConversation marshals c and atomically replaces the conversation file
+// using a tmp → rename pattern. Files are written with mode 0600.
+// Caller must hold s.mu.Lock().
 func (s *Store) writeConversation(c *Conversation) error {
 	data, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal conversation: %w", err)
 	}
-	if err := os.WriteFile(s.filePath(c.ID), data, 0644); err != nil {
-		return fmt.Errorf("write %s: %w", c.ID, err)
+	tmp := s.filePath(c.ID) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("write tmp %s: %w", c.ID, err)
+	}
+	if err := os.Rename(tmp, s.filePath(c.ID)); err != nil {
+		os.Remove(tmp) // best-effort cleanup
+		return fmt.Errorf("rename %s: %w", c.ID, err)
 	}
 	return nil
 }
@@ -118,8 +145,11 @@ func (s *Store) CreateConversation() (*Conversation, error) {
 	c := &Conversation{
 		ID:        id,
 		CreatedAt: time.Now().UTC(),
+		Title:     "New Conversation",
 		Messages:  []json.RawMessage{},
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if err := s.writeConversation(c); err != nil {
 		return nil, err
 	}
@@ -127,10 +157,15 @@ func (s *Store) CreateConversation() (*Conversation, error) {
 }
 
 func (s *Store) GetConversation(id string) (*Conversation, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.readConversation(id)
 }
 
 func (s *Store) ListConversations() ([]ConversationMeta, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	entries, err := os.ReadDir(s.dataDir)
 	if err != nil {
 		return nil, fmt.Errorf("read dir: %w", err)
@@ -141,6 +176,9 @@ func (s *Store) ListConversations() ([]ConversationMeta, error) {
 			continue
 		}
 		id := e.Name()[:len(e.Name())-5] // strip .json
+		if !isValidUUID(id) {
+			continue // skip non-conversation files (e.g. corrupt.json planted in tests)
+		}
 		data, err := os.ReadFile(filepath.Join(s.dataDir, e.Name()))
 		if err != nil {
 			s.logger.Warn("skipping unreadable conversation file", "file", e.Name(), "error", err)
@@ -165,10 +203,6 @@ func (s *Store) ListConversations() ([]ConversationMeta, error) {
 }
 
 func (s *Store) SaveUserMessage(id, content string) error {
-	c, err := s.readConversation(id)
-	if err != nil {
-		return err
-	}
 	raw, err := json.Marshal(struct {
 		Role    string `json:"role"`
 		Content string `json:"content"`
@@ -176,24 +210,34 @@ func (s *Store) SaveUserMessage(id, content string) error {
 	if err != nil {
 		return fmt.Errorf("marshal user message: %w", err)
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, err := s.readConversation(id)
+	if err != nil {
+		return err
+	}
 	c.Messages = append(c.Messages, raw)
 	return s.writeConversation(c)
 }
 
 func (s *Store) SaveAssistantMessage(id string, msg council.AssistantMessage) error {
-	c, err := s.readConversation(id)
-	if err != nil {
-		return err
-	}
 	raw, err := json.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("marshal assistant message: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, err := s.readConversation(id)
+	if err != nil {
+		return err
 	}
 	c.Messages = append(c.Messages, raw)
 	return s.writeConversation(c)
 }
 
 func (s *Store) SaveTitle(id, title string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	c, err := s.readConversation(id)
 	if err != nil {
 		return err

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,0 +1,233 @@
+package storage_test
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/valpere/llm-council/internal/council"
+	"github.com/valpere/llm-council/internal/storage"
+)
+
+func newTestStore(t *testing.T) *storage.Store {
+	t.Helper()
+	s, err := storage.NewStore(t.TempDir(), slog.Default())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+func TestCreateGetRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+
+	c, err := s.CreateConversation()
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if c.ID == "" {
+		t.Fatal("expected non-empty ID")
+	}
+
+	got, err := s.GetConversation(c.ID)
+	if err != nil {
+		t.Fatalf("GetConversation: %v", err)
+	}
+	if got.ID != c.ID {
+		t.Errorf("ID: got %q, want %q", got.ID, c.ID)
+	}
+	if !got.CreatedAt.Equal(c.CreatedAt) {
+		t.Errorf("CreatedAt: got %v, want %v", got.CreatedAt, c.CreatedAt)
+	}
+}
+
+func TestListNewestFirst(t *testing.T) {
+	s := newTestStore(t)
+
+	c1, err := s.CreateConversation()
+	if err != nil {
+		t.Fatalf("CreateConversation c1: %v", err)
+	}
+	time.Sleep(2 * time.Millisecond) // ensure distinct timestamps
+	c2, err := s.CreateConversation()
+	if err != nil {
+		t.Fatalf("CreateConversation c2: %v", err)
+	}
+
+	list, err := s.ListConversations()
+	if err != nil {
+		t.Fatalf("ListConversations: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 conversations, got %d", len(list))
+	}
+	if list[0].ID != c2.ID {
+		t.Errorf("expected newest first: got %q, want %q", list[0].ID, c2.ID)
+	}
+	if list[1].ID != c1.ID {
+		t.Errorf("expected oldest last: got %q, want %q", list[1].ID, c1.ID)
+	}
+}
+
+func TestSaveAssistantMessageRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+
+	c, err := s.CreateConversation()
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+
+	msg := council.AssistantMessage{
+		Role: "assistant",
+		Stage3: council.StageThreeResult{
+			Content:    "synthesised answer",
+			Model:      "openai/gpt-4o",
+			DurationMs: 1234,
+		},
+		Metadata: council.Metadata{
+			CouncilType: "default",
+			LabelToModel: map[string]string{
+				"Response A": "openai/gpt-4o",
+				"Response B": "anthropic/claude-haiku-4-5",
+			},
+			AggregateRankings: []council.RankedModel{
+				{Model: "openai/gpt-4o", Score: 1.5},
+				{Model: "anthropic/claude-haiku-4-5", Score: 2.5},
+			},
+			ConsensusW: 0.72,
+		},
+	}
+
+	if err := s.SaveAssistantMessage(c.ID, msg); err != nil {
+		t.Fatalf("SaveAssistantMessage: %v", err)
+	}
+
+	got, err := s.GetConversation(c.ID)
+	if err != nil {
+		t.Fatalf("GetConversation: %v", err)
+	}
+	if len(got.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(got.Messages))
+	}
+
+	var gotMsg council.AssistantMessage
+	if err := json.Unmarshal(got.Messages[0], &gotMsg); err != nil {
+		t.Fatalf("unmarshal assistant message: %v", err)
+	}
+
+	if gotMsg.Metadata.ConsensusW != 0.72 {
+		t.Errorf("ConsensusW: got %v, want 0.72", gotMsg.Metadata.ConsensusW)
+	}
+	if gotMsg.Metadata.CouncilType != "default" {
+		t.Errorf("CouncilType: got %q, want %q", gotMsg.Metadata.CouncilType, "default")
+	}
+	if len(gotMsg.Metadata.AggregateRankings) != 2 {
+		t.Errorf("AggregateRankings len: got %d, want 2", len(gotMsg.Metadata.AggregateRankings))
+	}
+	if gotMsg.Stage3.DurationMs != 1234 {
+		t.Errorf("Stage3.DurationMs: got %d, want 1234", gotMsg.Stage3.DurationMs)
+	}
+}
+
+func TestMissingMetadataUnmarshalsToZero(t *testing.T) {
+	dir := t.TempDir()
+	s, err := storage.NewStore(dir, slog.Default())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	c, err := s.CreateConversation()
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+
+	// Overwrite the file with a legacy message that has no metadata field.
+	type legacyConv struct {
+		ID        string            `json:"id"`
+		CreatedAt time.Time         `json:"created_at"`
+		Messages  []json.RawMessage `json:"messages"`
+	}
+	legacyMsg := json.RawMessage(`{"role":"assistant","stage1":[],"stage2":[],"stage3":{"content":"old","model":"gpt-3","duration_ms":0}}`)
+	lc := legacyConv{
+		ID:        c.ID,
+		CreatedAt: c.CreatedAt,
+		Messages:  []json.RawMessage{legacyMsg},
+	}
+	data, _ := json.Marshal(lc)
+	if err := os.WriteFile(filepath.Join(dir, c.ID+".json"), data, 0644); err != nil {
+		t.Fatalf("write legacy file: %v", err)
+	}
+
+	got, err := s.GetConversation(c.ID)
+	if err != nil {
+		t.Fatalf("GetConversation: %v", err)
+	}
+	if len(got.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(got.Messages))
+	}
+
+	var gotMsg council.AssistantMessage
+	if err := json.Unmarshal(got.Messages[0], &gotMsg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if gotMsg.Metadata.ConsensusW != 0 {
+		t.Errorf("ConsensusW: got %v, want 0", gotMsg.Metadata.ConsensusW)
+	}
+	if gotMsg.Metadata.CouncilType != "" {
+		t.Errorf("CouncilType: got %q, want empty", gotMsg.Metadata.CouncilType)
+	}
+	if gotMsg.Metadata.LabelToModel != nil {
+		t.Errorf("LabelToModel: got %v, want nil", gotMsg.Metadata.LabelToModel)
+	}
+}
+
+func TestNotFoundError(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.GetConversation("00000000-0000-0000-0000-000000000000")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var nfe *storage.NotFoundError
+	if !errors.As(err, &nfe) {
+		t.Errorf("expected *storage.NotFoundError, got %T: %v", err, err)
+	}
+	if nfe.ID != "00000000-0000-0000-0000-000000000000" {
+		t.Errorf("NotFoundError.ID: got %q", nfe.ID)
+	}
+}
+
+func TestCorruptFileSkippedInList(t *testing.T) {
+	dir := t.TempDir()
+	s, err := storage.NewStore(dir, slog.Default())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	c, err := s.CreateConversation()
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+
+	// Plant a corrupt JSON file alongside the valid one.
+	if err := os.WriteFile(filepath.Join(dir, "corrupt.json"), []byte("{not valid json{{"), 0644); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+
+	list, err := s.ListConversations()
+	if err != nil {
+		t.Fatalf("ListConversations: %v", err)
+	}
+	if len(list) != 1 {
+		t.Errorf("expected 1 conversation (corrupt skipped), got %d", len(list))
+	}
+	if len(list) > 0 && list[0].ID != c.ID {
+		t.Errorf("ID: got %q, want %q", list[0].ID, c.ID)
+	}
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -32,6 +32,9 @@ func TestCreateGetRoundTrip(t *testing.T) {
 	if c.ID == "" {
 		t.Fatal("expected non-empty ID")
 	}
+	if c.Title != "New Conversation" {
+		t.Errorf("Title: got %q, want %q", c.Title, "New Conversation")
+	}
 
 	got, err := s.GetConversation(c.ID)
 	if err != nil {
@@ -133,6 +136,62 @@ func TestSaveAssistantMessageRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSaveUserMessageRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+
+	c, err := s.CreateConversation()
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+
+	if err := s.SaveUserMessage(c.ID, "Why is the sky blue?"); err != nil {
+		t.Fatalf("SaveUserMessage: %v", err)
+	}
+
+	got, err := s.GetConversation(c.ID)
+	if err != nil {
+		t.Fatalf("GetConversation: %v", err)
+	}
+	if len(got.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(got.Messages))
+	}
+
+	var m struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(got.Messages[0], &m); err != nil {
+		t.Fatalf("unmarshal user message: %v", err)
+	}
+	if m.Role != "user" {
+		t.Errorf("role: got %q, want %q", m.Role, "user")
+	}
+	if m.Content != "Why is the sky blue?" {
+		t.Errorf("content: got %q, want %q", m.Content, "Why is the sky blue?")
+	}
+}
+
+func TestSaveTitleRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+
+	c, err := s.CreateConversation()
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+
+	if err := s.SaveTitle(c.ID, "Why is the sky blue?"); err != nil {
+		t.Fatalf("SaveTitle: %v", err)
+	}
+
+	got, err := s.GetConversation(c.ID)
+	if err != nil {
+		t.Fatalf("GetConversation: %v", err)
+	}
+	if got.Title != "Why is the sky blue?" {
+		t.Errorf("Title: got %q, want %q", got.Title, "Why is the sky blue?")
+	}
+}
+
 func TestMissingMetadataUnmarshalsToZero(t *testing.T) {
 	dir := t.TempDir()
 	s, err := storage.NewStore(dir, slog.Default())
@@ -158,7 +217,7 @@ func TestMissingMetadataUnmarshalsToZero(t *testing.T) {
 		Messages:  []json.RawMessage{legacyMsg},
 	}
 	data, _ := json.Marshal(lc)
-	if err := os.WriteFile(filepath.Join(dir, c.ID+".json"), data, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, c.ID+".json"), data, 0600); err != nil {
 		t.Fatalf("write legacy file: %v", err)
 	}
 
@@ -203,6 +262,18 @@ func TestNotFoundError(t *testing.T) {
 	}
 }
 
+func TestInvalidUUIDReturnNotFound(t *testing.T) {
+	s := newTestStore(t)
+
+	for _, id := range []string{"../etc/passwd", "not-a-uuid", "", "../../secret"} {
+		_, err := s.GetConversation(id)
+		var nfe *storage.NotFoundError
+		if !errors.As(err, &nfe) {
+			t.Errorf("id %q: expected *storage.NotFoundError, got %T: %v", id, err, err)
+		}
+	}
+}
+
 func TestCorruptFileSkippedInList(t *testing.T) {
 	dir := t.TempDir()
 	s, err := storage.NewStore(dir, slog.Default())
@@ -215,8 +286,10 @@ func TestCorruptFileSkippedInList(t *testing.T) {
 		t.Fatalf("CreateConversation: %v", err)
 	}
 
-	// Plant a corrupt JSON file alongside the valid one.
-	if err := os.WriteFile(filepath.Join(dir, "corrupt.json"), []byte("{not valid json{{"), 0644); err != nil {
+	// Plant a corrupt file with a valid UUID name so it passes the UUID filter
+	// and exercises the JSON-parse-error path in ListConversations.
+	corruptID := "ffffffff-ffff-4fff-bfff-ffffffffffff"
+	if err := os.WriteFile(filepath.Join(dir, corruptID+".json"), []byte("{not valid json{{"), 0600); err != nil {
 		t.Fatalf("write corrupt file: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

- Implements `NewStore(dataDir, logger)` and all 6 `Storer` methods in `internal/storage/storage.go` (#78)
- UUID v4 via `crypto/rand`; one JSON file per conversation under `dataDir`
- `ListConversations` sorted newest-first; corrupt files skipped with `slog.Warn`
- Legacy files without `metadata` field unmarshal to zero-value `Metadata{}` via Go defaults
- 6 tests in `internal/storage/storage_test.go` using `t.TempDir()` — no disk pollution (#94)

Closes #78
Closes #94

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/storage/... -race -count=1` passes (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)