### PR TITLE
⚖️ task(council): implement pure council functions and unit tests

### DIFF
--- a/internal/council/council.go
+++ b/internal/council/council.go
@@ -1,1 +1,52 @@
 package council
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+// QuorumError is returned when not enough council members responded successfully.
+type QuorumError struct {
+	Got  int
+	Need int
+}
+
+func (e *QuorumError) Error() string {
+	return fmt.Sprintf("council quorum not met: got %d successful responses, need %d", e.Got, e.Need)
+}
+
+// checkQuorum filters results to successful entries and verifies the minimum quorum.
+// M_min = max(2, ⌈N/2⌉+1) where N = len(results), unless minQuorum > 0 overrides it.
+// Returns the successful subset or *QuorumError if the threshold is not met.
+func checkQuorum(results []StageOneResult, minQuorum int) ([]StageOneResult, error) {
+	var successful []StageOneResult
+	for _, r := range results {
+		if r.Error == nil {
+			successful = append(successful, r)
+		}
+	}
+	n := len(results)
+	need := minQuorum
+	if need <= 0 {
+		need = max(2, (n+1)/2+1) // ⌈N/2⌉ = (N+1)/2 in integer arithmetic
+	}
+	if len(successful) < need {
+		return nil, &QuorumError{Got: len(successful), Need: need}
+	}
+	return successful, nil
+}
+
+// assignLabels assigns anonymous labels to models using a per-request random shuffle.
+// Labels are "Response A", "Response B", … (up to 26 models).
+// Both forward (label→model) and reverse (model→label) maps are returned.
+func assignLabels(models []string) (labelToModel, modelToLabel map[string]string) {
+	perm := rand.Perm(len(models))
+	labelToModel = make(map[string]string, len(models))
+	modelToLabel = make(map[string]string, len(models))
+	for i, idx := range perm {
+		label := fmt.Sprintf("Response %c", rune('A'+i))
+		labelToModel[label] = models[idx]
+		modelToLabel[models[idx]] = label
+	}
+	return
+}

--- a/internal/council/council_test.go
+++ b/internal/council/council_test.go
@@ -1,0 +1,185 @@
+package council
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// ── checkQuorum ──────────────────────────────────────────────────────────────
+
+func makeResults(total, successes int) []StageOneResult {
+	results := make([]StageOneResult, total)
+	for i := range results {
+		if i >= successes {
+			results[i].Error = errors.New("failed")
+		}
+	}
+	return results
+}
+
+func TestCheckQuorum_N4_ThreeSucceed(t *testing.T) {
+	// N=4: need = max(2, ⌈4/2⌉+1) = max(2,3) = 3. Three successes → passes.
+	got, err := checkQuorum(makeResults(4, 3), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("len: got %d, want 3", len(got))
+	}
+}
+
+func TestCheckQuorum_N4_TwoSucceed(t *testing.T) {
+	// N=4, need=3. Two successes → QuorumError.
+	_, err := checkQuorum(makeResults(4, 2), 0)
+	var qe *QuorumError
+	if !errors.As(err, &qe) {
+		t.Fatalf("expected *QuorumError, got %T: %v", err, err)
+	}
+	if qe.Got != 2 || qe.Need != 3 {
+		t.Errorf("QuorumError{Got:%d Need:%d}, want {2 3}", qe.Got, qe.Need)
+	}
+}
+
+func TestCheckQuorum_N4_OneSucceeds(t *testing.T) {
+	_, err := checkQuorum(makeResults(4, 1), 0)
+	var qe *QuorumError
+	if !errors.As(err, &qe) {
+		t.Fatalf("expected *QuorumError, got %T: %v", err, err)
+	}
+	if qe.Got != 1 {
+		t.Errorf("Got: %d, want 1", qe.Got)
+	}
+}
+
+func TestCheckQuorum_N2_TwoSucceed(t *testing.T) {
+	// N=2: need = max(2, ⌈2/2⌉+1) = max(2,2) = 2. Two successes → passes.
+	got, err := checkQuorum(makeResults(2, 2), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len: got %d, want 2", len(got))
+	}
+}
+
+func TestCheckQuorum_N2_OneSucceeds(t *testing.T) {
+	// N=2, need=2. One success → QuorumError.
+	_, err := checkQuorum(makeResults(2, 1), 0)
+	var qe *QuorumError
+	if !errors.As(err, &qe) {
+		t.Fatalf("expected *QuorumError, got %T: %v", err, err)
+	}
+}
+
+func TestCheckQuorum_MinQuorumOverride(t *testing.T) {
+	// minQuorum=2 overrides formula; N=4 normally needs 3.
+	got, err := checkQuorum(makeResults(4, 2), 2)
+	if err != nil {
+		t.Fatalf("unexpected error with override: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len: got %d, want 2", len(got))
+	}
+}
+
+// ── assignLabels ─────────────────────────────────────────────────────────────
+
+func TestAssignLabels_ConsistentMaps(t *testing.T) {
+	models := []string{"openai/gpt-4o", "anthropic/claude-haiku", "google/gemini-flash"}
+	ltm, mtl := assignLabels(models)
+
+	if len(ltm) != 3 {
+		t.Fatalf("labelToModel len: got %d, want 3", len(ltm))
+	}
+	if len(mtl) != 3 {
+		t.Fatalf("modelToLabel len: got %d, want 3", len(mtl))
+	}
+
+	// Every label must map to a model and back.
+	for label, model := range ltm {
+		if mtl[model] != label {
+			t.Errorf("round-trip failed: ltm[%q]=%q but mtl[%q]=%q",
+				label, model, model, mtl[model])
+		}
+	}
+
+	// Every model must appear exactly once.
+	seen := make(map[string]bool)
+	for _, model := range ltm {
+		if seen[model] {
+			t.Errorf("model %q appears more than once", model)
+		}
+		seen[model] = true
+	}
+	for _, m := range models {
+		if !seen[m] {
+			t.Errorf("model %q missing from labelToModel", m)
+		}
+	}
+}
+
+func TestAssignLabels_LabelsAreLetters(t *testing.T) {
+	models := []string{"m1", "m2", "m3"}
+	ltm, _ := assignLabels(models)
+
+	wantLabels := map[string]bool{"Response A": true, "Response B": true, "Response C": true}
+	for label := range ltm {
+		if !wantLabels[label] {
+			t.Errorf("unexpected label %q", label)
+		}
+	}
+}
+
+// ── BuildStage3Prompt (W-guidance injection) ─────────────────────────────────
+
+func TestBuildStage3Prompt_StrongConsensus(t *testing.T) {
+	msgs := BuildStage3Prompt("Why is the sky blue?", nil, nil, 0.75)
+	if len(msgs) == 0 {
+		t.Fatal("expected non-empty messages")
+	}
+	content := msgs[0].Content
+	if !strings.Contains(content, "strong consensus") {
+		t.Errorf("W=0.75: expected 'strong consensus' in prompt, got:\n%s", content)
+	}
+}
+
+func TestBuildStage3Prompt_ModerateConsensus(t *testing.T) {
+	msgs := BuildStage3Prompt("Why is the sky blue?", nil, nil, 0.55)
+	content := msgs[0].Content
+	if !strings.Contains(content, "moderate consensus") {
+		t.Errorf("W=0.55: expected 'moderate consensus' in prompt, got:\n%s", content)
+	}
+}
+
+func TestBuildStage3Prompt_NoConsensus(t *testing.T) {
+	msgs := BuildStage3Prompt("Why is the sky blue?", nil, nil, 0.30)
+	content := msgs[0].Content
+	if !strings.Contains(content, "did not reach consensus") {
+		t.Errorf("W=0.30: expected 'did not reach consensus' in prompt, got:\n%s", content)
+	}
+	if !strings.Contains(content, "minority") {
+		t.Errorf("W=0.30: expected minority-view guidance in prompt, got:\n%s", content)
+	}
+}
+
+func TestBuildStage3Prompt_StructuredAttribution(t *testing.T) {
+	rankings := []StageTwoResult{
+		{ReviewerLabel: "Response A", Rankings: []string{"Response B", "Response C"}},
+	}
+	labelToModel := map[string]string{
+		"Response B": "openai/gpt-4o",
+		"Response C": "google/gemini-flash",
+	}
+	msgs := BuildStage3Prompt("test query", rankings, labelToModel, 0.72)
+	content := msgs[0].Content
+
+	if !strings.Contains(content, "openai/gpt-4o") {
+		t.Errorf("expected model name in structured attribution, got:\n%s", content)
+	}
+	// Raw ranking text must NOT contain any LLM-generated prose from Stage 2.
+	// Only structured label + model pairs should appear.
+	if strings.Contains(content, "StageTwoResult") {
+		t.Errorf("raw struct leaked into prompt: %s", content)
+	}
+}

--- a/internal/council/prompts.go
+++ b/internal/council/prompts.go
@@ -1,1 +1,101 @@
 package council
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// BuildStage1Prompt returns the messages for a Stage 1 generation request.
+func BuildStage1Prompt(query string) []ChatMessage {
+	return []ChatMessage{
+		{Role: "user", Content: query},
+	}
+}
+
+// BuildStage2Prompt returns the messages for a Stage 2 peer-review request.
+// labeledResponses maps anonymous label → response text (e.g. "Response A" → "...").
+// The prompt requests JSON output with schema {"rankings": ["Response X", ...]}.
+func BuildStage2Prompt(query string, labeledResponses map[string]string) []ChatMessage {
+	// Sort labels for a deterministic, readable prompt.
+	labels := make([]string, 0, len(labeledResponses))
+	for l := range labeledResponses {
+		labels = append(labels, l)
+	}
+	sort.Strings(labels)
+
+	var sb strings.Builder
+	sb.WriteString("You were asked the following question:\n\n")
+	sb.WriteString(query)
+	sb.WriteString("\n\nHere are the responses given by different assistants:\n\n")
+	for _, label := range labels {
+		sb.WriteString("## ")
+		sb.WriteString(label)
+		sb.WriteString("\n")
+		sb.WriteString(labeledResponses[label])
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("Rank these responses from best to worst based on accuracy, clarity, and completeness.\n")
+	sb.WriteString("Return ONLY a JSON object with this exact schema — no additional text:\n")
+	sb.WriteString(`{"rankings": ["Response X", "Response Y", ...]}`)
+	sb.WriteString("\n\nList all response labels in order from best (first) to worst (last).")
+
+	return []ChatMessage{
+		{Role: "user", Content: sb.String()},
+	}
+}
+
+// BuildStage3Prompt returns the messages for the Stage 3 Chairman synthesis request.
+// Rankings are built from Go structs — no raw LLM text is passed through,
+// preventing prompt injection from Stage 2 model output.
+// Kendall's W drives the synthesis guidance injected into the prompt.
+func BuildStage3Prompt(query string, rankings []StageTwoResult, labelToModel map[string]string, consensusW float64) []ChatMessage {
+	var guidance string
+	switch {
+	case consensusW >= 0.70:
+		guidance = fmt.Sprintf(
+			"The peer reviewers reached strong consensus (W=%.2f). "+
+				"Synthesize the responses confidently, drawing on the most highly-ranked insights.",
+			consensusW,
+		)
+	case consensusW >= 0.40:
+		guidance = fmt.Sprintf(
+			"The peer reviewers reached moderate consensus (W=%.2f). "+
+				"Synthesize the best insights while acknowledging where reviewers diverged.",
+			consensusW,
+		)
+	default:
+		guidance = fmt.Sprintf(
+			"The peer reviewers did not reach consensus (W=%.2f). "+
+				"Present the main perspectives fairly, surface well-reasoned minority views, "+
+				"and help the user understand the range of expert opinion.",
+			consensusW,
+		)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("You were asked to answer:\n\n")
+	sb.WriteString(query)
+	sb.WriteString("\n\n")
+	sb.WriteString(guidance)
+	sb.WriteString("\n\nPeer review rankings (structured attribution — best to worst):\n")
+
+	for _, r := range rankings {
+		if len(r.Rankings) == 0 {
+			continue
+		}
+		sb.WriteString("\nReviewer ")
+		sb.WriteString(r.ReviewerLabel)
+		sb.WriteString(":\n")
+		for i, label := range r.Rankings {
+			model := labelToModel[label]
+			sb.WriteString(fmt.Sprintf("  %d. %s (%s)\n", i+1, label, model))
+		}
+	}
+
+	sb.WriteString("\nProvide a comprehensive, well-reasoned answer that synthesizes the best insights from all responses.")
+
+	return []ChatMessage{
+		{Role: "user", Content: sb.String()},
+	}
+}

--- a/internal/council/rankings.go
+++ b/internal/council/rankings.go
@@ -27,12 +27,6 @@ func CalculateAggregateRankings(stage2 []StageTwoResult, allLabels []string) ([]
 	// rankSums[i] = sum of ranks assigned to allLabels[i] across all judges.
 	rankSums := make([]float64, n)
 
-	// Index allLabels for O(1) position lookup.
-	labelIdx := make(map[string]int, n)
-	for i, l := range allLabels {
-		labelIdx[l] = i
-	}
-
 	validJudges := 0
 	for _, result := range stage2 {
 		if len(result.Rankings) == 0 {

--- a/internal/council/rankings.go
+++ b/internal/council/rankings.go
@@ -1,1 +1,96 @@
 package council
+
+import "sort"
+
+// CalculateAggregateRankings computes aggregate rankings and Kendall's W coefficient
+// from Stage 2 peer-review results.
+//
+// allLabels lists every anonymous label being ranked (e.g. "Response A").
+// Judges with nil/empty Rankings receive midrank imputation: each item is assigned
+// rank (n+1)/2 so they contribute without distorting the aggregate.
+//
+// Returns (nil, 0.0) when stage2 is empty, allLabels is empty, or all judges have
+// nil Rankings.
+//
+// Kendall's W formula: W = 12·S / (k²·(n³−n))
+// where S = Σ(Rj − R̄)², Rj = sum of ranks for item j, R̄ = k·(n+1)/2.
+// W is clamped to [0.0, 1.0]; 1.0 = perfect agreement, 0.0 = no agreement.
+func CalculateAggregateRankings(stage2 []StageTwoResult, allLabels []string) ([]RankedModel, float64) {
+	n := len(allLabels)
+	k := len(stage2)
+	if n == 0 || k == 0 {
+		return nil, 0.0
+	}
+
+	midrank := float64(n+1) / 2.0
+
+	// rankSums[i] = sum of ranks assigned to allLabels[i] across all judges.
+	rankSums := make([]float64, n)
+
+	// Index allLabels for O(1) position lookup.
+	labelIdx := make(map[string]int, n)
+	for i, l := range allLabels {
+		labelIdx[l] = i
+	}
+
+	validJudges := 0
+	for _, result := range stage2 {
+		if len(result.Rankings) == 0 {
+			// Midrank imputation: all items get (n+1)/2.
+			for i := range rankSums {
+				rankSums[i] += midrank
+			}
+			continue
+		}
+		validJudges++
+		// Build rank-by-label map for this judge; unmentioned items get midrank.
+		rankOf := make(map[string]float64, len(result.Rankings))
+		for pos, label := range result.Rankings {
+			rankOf[label] = float64(pos + 1)
+		}
+		for i, label := range allLabels {
+			if r, ok := rankOf[label]; ok {
+				rankSums[i] += r
+			} else {
+				rankSums[i] += midrank
+			}
+		}
+	}
+
+	if validJudges == 0 {
+		return nil, 0.0
+	}
+
+	// Kendall's W.
+	kf := float64(k)
+	meanRankSum := kf * float64(n+1) / 2.0
+	var S float64
+	for _, rj := range rankSums {
+		d := rj - meanRankSum
+		S += d * d
+	}
+	denom := kf * kf * (float64(n)*float64(n)*float64(n) - float64(n))
+	if denom == 0 {
+		return nil, 0.0
+	}
+	W := 12.0 * S / denom
+	if W < 0 {
+		W = 0
+	}
+	if W > 1 {
+		W = 1
+	}
+
+	// Build result sorted by average rank ascending (1.0 = always ranked first).
+	ranked := make([]RankedModel, n)
+	for i, label := range allLabels {
+		ranked[i] = RankedModel{
+			Model: label,
+			Score: rankSums[i] / kf,
+		}
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		return ranked[i].Score < ranked[j].Score
+	})
+	return ranked, W
+}

--- a/internal/council/rankings_test.go
+++ b/internal/council/rankings_test.go
@@ -1,0 +1,118 @@
+package council
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCalculateAggregateRankings_FullAgreement(t *testing.T) {
+	labels := []string{"Response A", "Response B", "Response C"}
+	stage2 := []StageTwoResult{
+		{Rankings: []string{"Response A", "Response B", "Response C"}},
+		{Rankings: []string{"Response A", "Response B", "Response C"}},
+	}
+	ranked, W := CalculateAggregateRankings(stage2, labels)
+	if math.Abs(W-1.0) > 1e-9 {
+		t.Errorf("W: got %.6f, want 1.0 (full agreement)", W)
+	}
+	if len(ranked) != 3 {
+		t.Fatalf("len(ranked): got %d, want 3", len(ranked))
+	}
+	if ranked[0].Model != "Response A" {
+		t.Errorf("top-ranked: got %q, want %q", ranked[0].Model, "Response A")
+	}
+}
+
+func TestCalculateAggregateRankings_NoAgreement(t *testing.T) {
+	// Two judges with reversed rankings: rank sums are equal → W = 0.
+	labels := []string{"Response A", "Response B", "Response C"}
+	stage2 := []StageTwoResult{
+		{Rankings: []string{"Response A", "Response B", "Response C"}},
+		{Rankings: []string{"Response C", "Response B", "Response A"}},
+	}
+	_, W := CalculateAggregateRankings(stage2, labels)
+	if math.Abs(W) > 1e-9 {
+		t.Errorf("W: got %.6f, want 0.0 (no agreement)", W)
+	}
+}
+
+func TestCalculateAggregateRankings_OneMissingMidrank(t *testing.T) {
+	// Judge 2 has nil Rankings → midrank imputation (rank 2.0 for all 3 items).
+	// Judge 1: A=1, B=2, C=3
+	// Judge 2: A=2, B=2, C=2 (midrank)
+	// Rank sums: A=3, B=4, C=5  mean=4  S=1+0+1=2  W=12*2/(4*24)=0.25
+	labels := []string{"Response A", "Response B", "Response C"}
+	stage2 := []StageTwoResult{
+		{Rankings: []string{"Response A", "Response B", "Response C"}},
+		{Rankings: nil},
+	}
+	ranked, W := CalculateAggregateRankings(stage2, labels)
+	wantW := 0.25
+	if math.Abs(W-wantW) > 1e-9 {
+		t.Errorf("W: got %.6f, want %.6f (one missing → midrank)", W, wantW)
+	}
+	if len(ranked) == 0 || ranked[0].Model != "Response A" {
+		t.Errorf("top-ranked: got %v, want Response A", ranked)
+	}
+}
+
+func TestCalculateAggregateRankings_AllMissing(t *testing.T) {
+	labels := []string{"Response A", "Response B"}
+	stage2 := []StageTwoResult{
+		{Rankings: nil},
+		{Rankings: nil},
+	}
+	ranked, W := CalculateAggregateRankings(stage2, labels)
+	if ranked != nil {
+		t.Errorf("ranked: got %v, want nil", ranked)
+	}
+	if W != 0.0 {
+		t.Errorf("W: got %v, want 0.0", W)
+	}
+}
+
+func TestCalculateAggregateRankings_Empty(t *testing.T) {
+	ranked, W := CalculateAggregateRankings(nil, []string{"Response A"})
+	if ranked != nil || W != 0.0 {
+		t.Errorf("empty stage2: got ranked=%v W=%v, want nil 0.0", ranked, W)
+	}
+	ranked, W = CalculateAggregateRankings([]StageTwoResult{{Rankings: []string{"Response A"}}}, nil)
+	if ranked != nil || W != 0.0 {
+		t.Errorf("empty labels: got ranked=%v W=%v, want nil 0.0", ranked, W)
+	}
+}
+
+func TestCalculateAggregateRankings_SingleJudge(t *testing.T) {
+	// A single complete ranking always produces W = 1.0.
+	labels := []string{"Response A", "Response B", "Response C"}
+	stage2 := []StageTwoResult{
+		{Rankings: []string{"Response B", "Response A", "Response C"}},
+	}
+	ranked, W := CalculateAggregateRankings(stage2, labels)
+	if math.Abs(W-1.0) > 1e-9 {
+		t.Errorf("W: got %.6f, want 1.0 (single judge)", W)
+	}
+	if len(ranked) == 0 || ranked[0].Model != "Response B" {
+		t.Errorf("top-ranked: got %v, want Response B", ranked)
+	}
+}
+
+func TestCalculateAggregateRankings_TwoJudgeManual(t *testing.T) {
+	// Judge 1: A(1) B(2) C(3)   Judge 2: A(2) B(1) C(3)
+	// Rank sums: A=3, B=3, C=6   mean=4   S=1+1+4=6
+	// W = 12*6 / (4*24) = 72/96 = 0.75
+	labels := []string{"Response A", "Response B", "Response C"}
+	stage2 := []StageTwoResult{
+		{Rankings: []string{"Response A", "Response B", "Response C"}},
+		{Rankings: []string{"Response B", "Response A", "Response C"}},
+	}
+	ranked, W := CalculateAggregateRankings(stage2, labels)
+	wantW := 0.75
+	if math.Abs(W-wantW) > 1e-9 {
+		t.Errorf("W: got %.6f, want %.6f", W, wantW)
+	}
+	// C should be bottom-ranked (score 3.0).
+	if len(ranked) < 3 || ranked[2].Model != "Response C" {
+		t.Errorf("bottom-ranked: got %v, want Response C", ranked)
+	}
+}


### PR DESCRIPTION
## Summary

- `assignLabels()` with `rand.Perm` shuffle — no model is systematically "Response A" (#79)
- `BuildStage1/2/3Prompt` in `prompts.go`; Stage 3 injects Kendall's W guidance; rankings built from Go structs, not raw LLM text (#80)
- `checkQuorum()` + `QuorumError` — `M_min = max(2, ⌈N/2⌉+1)` with `minQuorum` override (#82)
- `CalculateAggregateRankings` with Kendall's W (midrank imputation for missing/failed judges, W clamped to [0,1]) (#84)
- 19 unit tests in `council_test.go` and `rankings_test.go` — no real API calls (#93)

Closes #79
Closes #80
Closes #82
Closes #84
Closes #93

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/council/... -race -count=1` passes (19/19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)