### PR TITLE
⚖️ task(api): scaffold Handler, CRUD handlers, SSE stream, and handler tests

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -63,6 +63,7 @@ func (h *Handler) wrap(next http.HandlerFunc) http.Handler {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			w.Header().Add("Vary", "Origin")
 		}
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
@@ -195,6 +196,7 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 		stage3Result  council.StageThreeResult
 	)
 
+	// sendSSE emits a standard {type, data} SSE event and flushes.
 	sendSSE := func(eventType string, data any) {
 		dataJSON, err := json.Marshal(data)
 		if err != nil {
@@ -211,31 +213,73 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 		flusher.Flush()
 	}
 
+	// sendStage2SSE emits the spec-correct stage2_complete shape:
+	// { "type": "stage2_complete", "data": [...], "metadata": {...} }
+	// metadata is a top-level field, not nested under data.
+	sendStage2SSE := func(d council.Stage2CompleteData) {
+		type stage2Payload struct {
+			Type     string                 `json:"type"`
+			Data     []council.StageTwoResult `json:"data"`
+			Metadata council.Metadata       `json:"metadata"`
+		}
+		b, err := json.Marshal(stage2Payload{
+			Type:     "stage2_complete",
+			Data:     d.Results,
+			Metadata: d.Metadata,
+		})
+		if err != nil {
+			h.logger.Error("marshal stage2 SSE payload", "error", err)
+			return
+		}
+		fmt.Fprintf(w, "data: %s\n\n", b)
+		flusher.Flush()
+	}
+
+	// sendErrorSSE emits { "type": "error", "message": "..." } per the SSE spec.
+	sendErrorSSE := func(msg string) {
+		type errPayload struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		}
+		b, err := json.Marshal(errPayload{Type: "error", Message: msg})
+		if err != nil {
+			h.logger.Error("marshal error SSE payload", "error", err)
+			return
+		}
+		fmt.Fprintf(w, "data: %s\n\n", b)
+		flusher.Flush()
+	}
+
 	onEvent := func(eventType string, data any) {
 		switch eventType {
 		case "stage1_complete":
 			if results, ok := data.([]council.StageOneResult); ok {
 				stage1Results = results
 			}
+			sendSSE(eventType, data)
 		case "stage2_complete":
 			if d, ok := data.(council.Stage2CompleteData); ok {
 				stage2Data = d
+				sendStage2SSE(d)
 			}
 		case "stage3_complete":
 			if result, ok := data.(council.StageThreeResult); ok {
 				stage3Result = result
 			}
+			sendSSE(eventType, data)
+		default:
+			sendSSE(eventType, data)
 		}
-		sendSSE(eventType, data)
 	}
 
 	if err := h.runner.RunFull(r.Context(), body.Message, councilType, onEvent); err != nil {
 		var qe *council.QuorumError
 		if errors.As(err, &qe) {
-			sendSSE("error", map[string]string{"error": "council quorum not met"})
+			h.logger.Warn("council quorum not met", "id", id, "got", qe.Got, "need", qe.Need)
+			sendErrorSSE("council quorum not met")
 		} else {
 			h.logger.Error("council run", "id", id, "error", err)
-			sendSSE("error", map[string]string{"error": "internal server error"})
+			sendErrorSSE("internal server error")
 		}
 		return
 	}
@@ -250,7 +294,7 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.storage.SaveAssistantMessage(id, msg); err != nil {
 		h.logger.Error("save assistant message", "id", id, "error", err)
-		sendSSE("error", map[string]string{"error": "internal server error"})
+		sendErrorSSE("internal server error")
 		return
 	}
 
@@ -275,5 +319,7 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 		h.logger.Warn("title generation timed out", "id", id)
 	}
 
-	sendSSE("complete", msg)
+	// Spec: { "type": "complete" } with no payload.
+	fmt.Fprintf(w, "data: {\"type\":\"complete\"}\n\n")
+	flusher.Flush()
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1,1 +1,279 @@
 package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/valpere/llm-council/internal/council"
+	"github.com/valpere/llm-council/internal/storage"
+)
+
+var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+var allowedOrigins = map[string]bool{
+	"http://localhost:5173": true,
+	"http://localhost:3000": true,
+}
+
+// Handler holds the dependencies for all API handlers.
+type Handler struct {
+	runner             council.Runner
+	storage            storage.Storer
+	logger             *slog.Logger
+	defaultCouncilType string
+}
+
+// NewHandler constructs a Handler. A nil logger defaults to slog.Default().
+func NewHandler(runner council.Runner, store storage.Storer, logger *slog.Logger, defaultCouncilType string) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{
+		runner:             runner,
+		storage:            store,
+		logger:             logger,
+		defaultCouncilType: defaultCouncilType,
+	}
+}
+
+// RegisterRoutes attaches all API routes to mux wrapped with CORS and security middleware.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.Handle("GET /health/live", h.wrap(h.healthLive))
+	mux.Handle("GET /health/ready", h.wrap(h.healthReady))
+	mux.Handle("GET /api/conversations", h.wrap(h.listConversations))
+	mux.Handle("POST /api/conversations", h.wrap(h.createConversation))
+	mux.Handle("GET /api/conversations/{id}", h.wrap(h.getConversation))
+	mux.Handle("POST /api/conversations/{id}/message", h.wrap(h.sendMessage))
+	mux.Handle("POST /api/conversations/{id}/message/stream", h.wrap(h.sendMessageStream))
+}
+
+// wrap applies CORS and security headers to every route.
+func (h *Handler) wrap(next http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Content-Security-Policy", "default-src 'none'")
+
+		if origin := r.Header.Get("Origin"); allowedOrigins[origin] {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		}
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next(w, r)
+	})
+}
+
+func (h *Handler) writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		h.logger.Error("write JSON response", "error", err)
+	}
+}
+
+func (h *Handler) writeError(w http.ResponseWriter, status int, msg string) {
+	h.writeJSON(w, status, map[string]string{"error": msg})
+}
+
+func (h *Handler) healthLive(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) healthReady(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listConversations(w http.ResponseWriter, r *http.Request) {
+	convs, err := h.storage.ListConversations()
+	if err != nil {
+		h.logger.Error("list conversations", "error", err)
+		h.writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	if convs == nil {
+		convs = []storage.ConversationMeta{}
+	}
+	h.writeJSON(w, http.StatusOK, convs)
+}
+
+func (h *Handler) createConversation(w http.ResponseWriter, r *http.Request) {
+	conv, err := h.storage.CreateConversation()
+	if err != nil {
+		h.logger.Error("create conversation", "error", err)
+		h.writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	h.writeJSON(w, http.StatusCreated, conv)
+}
+
+func (h *Handler) getConversation(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !uuidRE.MatchString(id) {
+		h.writeError(w, http.StatusBadRequest, "invalid conversation id")
+		return
+	}
+	conv, err := h.storage.GetConversation(id)
+	if err != nil {
+		var nfe *storage.NotFoundError
+		if errors.As(err, &nfe) {
+			h.writeError(w, http.StatusNotFound, "not found")
+			return
+		}
+		h.logger.Error("get conversation", "id", id, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	h.writeJSON(w, http.StatusOK, conv)
+}
+
+// sendMessage is a stub; implemented in a later milestone.
+func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// sseEnvelope is the JSON shape of every SSE data line.
+type sseEnvelope struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		h.writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	id := r.PathValue("id")
+	if !uuidRE.MatchString(id) {
+		h.writeError(w, http.StatusBadRequest, "invalid conversation id")
+		return
+	}
+
+	var body struct {
+		Message     string `json:"message"`
+		CouncilType string `json:"council_type"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Message == "" {
+		h.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if err := h.storage.SaveUserMessage(id, body.Message); err != nil {
+		var nfe *storage.NotFoundError
+		if errors.As(err, &nfe) {
+			h.writeError(w, http.StatusNotFound, "not found")
+			return
+		}
+		h.logger.Error("save user message", "id", id, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	// SSE headers must be set before any write.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	councilType := body.CouncilType
+	if councilType == "" {
+		councilType = h.defaultCouncilType
+	}
+
+	var (
+		stage1Results []council.StageOneResult
+		stage2Data    council.Stage2CompleteData
+		stage3Result  council.StageThreeResult
+	)
+
+	sendSSE := func(eventType string, data any) {
+		dataJSON, err := json.Marshal(data)
+		if err != nil {
+			h.logger.Error("marshal SSE event data", "type", eventType, "error", err)
+			return
+		}
+		env := sseEnvelope{Type: eventType, Data: json.RawMessage(dataJSON)}
+		envJSON, err := json.Marshal(env)
+		if err != nil {
+			h.logger.Error("marshal SSE envelope", "type", eventType, "error", err)
+			return
+		}
+		fmt.Fprintf(w, "data: %s\n\n", envJSON)
+		flusher.Flush()
+	}
+
+	onEvent := func(eventType string, data any) {
+		switch eventType {
+		case "stage1_complete":
+			if results, ok := data.([]council.StageOneResult); ok {
+				stage1Results = results
+			}
+		case "stage2_complete":
+			if d, ok := data.(council.Stage2CompleteData); ok {
+				stage2Data = d
+			}
+		case "stage3_complete":
+			if result, ok := data.(council.StageThreeResult); ok {
+				stage3Result = result
+			}
+		}
+		sendSSE(eventType, data)
+	}
+
+	if err := h.runner.RunFull(r.Context(), body.Message, councilType, onEvent); err != nil {
+		var qe *council.QuorumError
+		if errors.As(err, &qe) {
+			sendSSE("error", map[string]string{"error": "council quorum not met"})
+		} else {
+			h.logger.Error("council run", "id", id, "error", err)
+			sendSSE("error", map[string]string{"error": "internal server error"})
+		}
+		return
+	}
+
+	msg := council.AssistantMessage{
+		Role:     "assistant",
+		Stage1:   stage1Results,
+		Stage2:   stage2Data.Results,
+		Stage3:   stage3Result,
+		Metadata: stage2Data.Metadata,
+	}
+
+	if err := h.storage.SaveAssistantMessage(id, msg); err != nil {
+		h.logger.Error("save assistant message", "id", id, "error", err)
+		sendSSE("error", map[string]string{"error": "internal server error"})
+		return
+	}
+
+	// Title generation: run in a goroutine to avoid blocking the ResponseWriter.
+	// A buffered channel of size 1 prevents goroutine leak if the select times out.
+	titleCh := make(chan string, 1)
+	go func() {
+		content := msg.Stage3.Content
+		if len(content) > 50 {
+			content = content[:50]
+		}
+		titleCh <- content
+	}()
+
+	select {
+	case title := <-titleCh:
+		if err := h.storage.SaveTitle(id, title); err != nil {
+			h.logger.Warn("save title", "id", id, "error", err)
+		}
+		sendSSE("title_complete", map[string]string{"title": title})
+	case <-time.After(30 * time.Second):
+		h.logger.Warn("title generation timed out", "id", id)
+	}
+
+	sendSSE("complete", msg)
+}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -100,26 +100,7 @@ func parseSSEEventTypes(body string) []string {
 	return types
 }
 
-// parseSSEEventData finds the first SSE event with the given type and unmarshals
-// its "data" field into v. Returns false if no matching event is found.
-func parseSSEEventData(body, eventType string, v any) bool {
-	for _, line := range strings.Split(body, "\n") {
-		if !strings.HasPrefix(line, "data: ") {
-			continue
-		}
-		var env struct {
-			Type string          `json:"type"`
-			Data json.RawMessage `json:"data"`
-		}
-		if err := json.Unmarshal([]byte(line[6:]), &env); err != nil || env.Type != eventType {
-			continue
-		}
-		return json.Unmarshal(env.Data, v) == nil
-	}
-	return false
-}
-
-// ── ListConversations ────────────────────────────────────────────────────────
+//── ListConversations ────────────────────────────────────────────────────────
 
 func TestListConversations(t *testing.T) {
 	tests := []struct {
@@ -344,16 +325,27 @@ func TestSendMessageStream(t *testing.T) {
 					t.Errorf("last event: got %v, want 'complete'", types)
 				}
 
-				// metadata must be present and populated in stage2_complete.
-				var s2 council.Stage2CompleteData
-				if !parseSSEEventData(body, "stage2_complete", &s2) {
-					t.Fatal("could not parse stage2_complete data")
-				}
-				if s2.Metadata.ConsensusW != 0.9 {
-					t.Errorf("consensus_w: got %f, want 0.9", s2.Metadata.ConsensusW)
-				}
-				if s2.Metadata.LabelToModel["Response A"] != "openai/gpt-4o" {
-					t.Errorf("label_to_model: got %v", s2.Metadata.LabelToModel)
+				// stage2_complete must have metadata as a TOP-LEVEL field per the
+				// streaming spec: { "type": "stage2_complete", "data": [...], "metadata": {...} }
+				for _, line := range strings.Split(body, "\n") {
+					if !strings.HasPrefix(line, "data: ") {
+						continue
+					}
+					var env struct {
+						Type     string               `json:"type"`
+						Data     []council.StageTwoResult `json:"data"`
+						Metadata council.Metadata     `json:"metadata"`
+					}
+					if err := json.Unmarshal([]byte(line[6:]), &env); err != nil || env.Type != "stage2_complete" {
+						continue
+					}
+					if env.Metadata.ConsensusW != 0.9 {
+						t.Errorf("consensus_w: got %f, want 0.9", env.Metadata.ConsensusW)
+					}
+					if env.Metadata.LabelToModel["Response A"] != "openai/gpt-4o" {
+						t.Errorf("label_to_model: got %v", env.Metadata.LabelToModel)
+					}
+					break
 				}
 			},
 		},
@@ -368,13 +360,25 @@ func TestSendMessageStream(t *testing.T) {
 			},
 			wantCode: http.StatusOK,
 			checkSSE: func(t *testing.T, body string) {
-				types := parseSSEEventTypes(body)
-				for _, typ := range types {
-					if typ == "error" {
-						return
+				// Error event must be present with a non-empty "message" field
+				// per the SSE spec: { "type": "error", "message": "..." }
+				for _, line := range strings.Split(body, "\n") {
+					if !strings.HasPrefix(line, "data: ") {
+						continue
 					}
+					var env struct {
+						Type    string `json:"type"`
+						Message string `json:"message"`
+					}
+					if err := json.Unmarshal([]byte(line[6:]), &env); err != nil || env.Type != "error" {
+						continue
+					}
+					if env.Message == "" {
+						t.Errorf("error event missing 'message' field, got: %s", line[6:])
+					}
+					return
 				}
-				t.Errorf("expected 'error' event for QuorumError, got events: %v", types)
+				t.Errorf("expected 'error' event for QuorumError, got:\n%s", body)
 			},
 		},
 		{

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1,0 +1,418 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/valpere/llm-council/internal/council"
+	"github.com/valpere/llm-council/internal/storage"
+)
+
+// ── mocks ────────────────────────────────────────────────────────────────────
+
+type mockStorer struct {
+	listConversations    func() ([]storage.ConversationMeta, error)
+	createConversation   func() (*storage.Conversation, error)
+	getConversation      func(string) (*storage.Conversation, error)
+	saveUserMessage      func(string, string) error
+	saveAssistantMessage func(string, council.AssistantMessage) error
+	saveTitle            func(string, string) error
+}
+
+func (m *mockStorer) ListConversations() ([]storage.ConversationMeta, error) {
+	if m.listConversations != nil {
+		return m.listConversations()
+	}
+	return nil, nil
+}
+func (m *mockStorer) CreateConversation() (*storage.Conversation, error) {
+	if m.createConversation != nil {
+		return m.createConversation()
+	}
+	return &storage.Conversation{ID: testConvID}, nil
+}
+func (m *mockStorer) GetConversation(id string) (*storage.Conversation, error) {
+	if m.getConversation != nil {
+		return m.getConversation(id)
+	}
+	return &storage.Conversation{ID: id}, nil
+}
+func (m *mockStorer) SaveUserMessage(id, content string) error {
+	if m.saveUserMessage != nil {
+		return m.saveUserMessage(id, content)
+	}
+	return nil
+}
+func (m *mockStorer) SaveAssistantMessage(id string, msg council.AssistantMessage) error {
+	if m.saveAssistantMessage != nil {
+		return m.saveAssistantMessage(id, msg)
+	}
+	return nil
+}
+func (m *mockStorer) SaveTitle(id, title string) error {
+	if m.saveTitle != nil {
+		return m.saveTitle(id, title)
+	}
+	return nil
+}
+
+type mockRunner struct {
+	runFull func(context.Context, string, string, council.EventFunc) error
+}
+
+func (m *mockRunner) RunFull(ctx context.Context, query, councilType string, onEvent council.EventFunc) error {
+	if m.runFull != nil {
+		return m.runFull(ctx, query, councilType, onEvent)
+	}
+	return nil
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// testConvID is a canonical UUID v4 used across tests.
+const testConvID = "00000000-0000-4000-8000-000000000001"
+
+// newTestHandler builds a Handler with no-op defaults and a silent logger.
+func newTestHandler(storer *mockStorer, runner *mockRunner) *Handler {
+	return NewHandler(runner, storer, nil, "standard")
+}
+
+// parseSSEEventTypes returns the "type" field from every SSE data line in body.
+func parseSSEEventTypes(body string) []string {
+	var types []string
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var env struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal([]byte(line[6:]), &env); err == nil && env.Type != "" {
+			types = append(types, env.Type)
+		}
+	}
+	return types
+}
+
+// parseSSEEventData finds the first SSE event with the given type and unmarshals
+// its "data" field into v. Returns false if no matching event is found.
+func parseSSEEventData(body, eventType string, v any) bool {
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var env struct {
+			Type string          `json:"type"`
+			Data json.RawMessage `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(line[6:]), &env); err != nil || env.Type != eventType {
+			continue
+		}
+		return json.Unmarshal(env.Data, v) == nil
+	}
+	return false
+}
+
+// ── ListConversations ────────────────────────────────────────────────────────
+
+func TestListConversations(t *testing.T) {
+	tests := []struct {
+		name     string
+		storer   *mockStorer
+		wantCode int
+		check    func(t *testing.T, body string)
+	}{
+		{
+			name: "happy path",
+			storer: &mockStorer{
+				listConversations: func() ([]storage.ConversationMeta, error) {
+					return []storage.ConversationMeta{{ID: testConvID, Title: "Test"}}, nil
+				},
+			},
+			wantCode: http.StatusOK,
+			check: func(t *testing.T, body string) {
+				var convs []storage.ConversationMeta
+				if err := json.Unmarshal([]byte(strings.TrimSpace(body)), &convs); err != nil {
+					t.Fatalf("parse body: %v", err)
+				}
+				if len(convs) != 1 || convs[0].ID != testConvID {
+					t.Errorf("body: got %v, want 1 item with ID %q", convs, testConvID)
+				}
+			},
+		},
+		{
+			name: "empty list returns [] not null",
+			storer: &mockStorer{
+				listConversations: func() ([]storage.ConversationMeta, error) {
+					return nil, nil // storage returns nil slice → handler converts to []
+				},
+			},
+			wantCode: http.StatusOK,
+			check: func(t *testing.T, body string) {
+				trimmed := strings.TrimSpace(body)
+				if !strings.HasPrefix(trimmed, "[") {
+					t.Errorf("body: got %q, want JSON array (not null)", trimmed)
+				}
+			},
+		},
+		{
+			name: "storage error returns 500",
+			storer: &mockStorer{
+				listConversations: func() ([]storage.ConversationMeta, error) {
+					return nil, errors.New("disk failure")
+				},
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(tc.storer, &mockRunner{})
+			req := httptest.NewRequest(http.MethodGet, "/api/conversations", nil)
+			w := httptest.NewRecorder()
+			h.listConversations(w, req)
+			if w.Code != tc.wantCode {
+				t.Errorf("status: got %d, want %d", w.Code, tc.wantCode)
+			}
+			if tc.check != nil {
+				tc.check(t, w.Body.String())
+			}
+		})
+	}
+}
+
+// ── CreateConversation ───────────────────────────────────────────────────────
+
+func TestCreateConversation(t *testing.T) {
+	tests := []struct {
+		name     string
+		storer   *mockStorer
+		wantCode int
+	}{
+		{
+			name: "happy path returns 201",
+			storer: &mockStorer{
+				createConversation: func() (*storage.Conversation, error) {
+					return &storage.Conversation{ID: testConvID, Title: "New Conversation"}, nil
+				},
+			},
+			wantCode: http.StatusCreated,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(tc.storer, &mockRunner{})
+			req := httptest.NewRequest(http.MethodPost, "/api/conversations", nil)
+			w := httptest.NewRecorder()
+			h.createConversation(w, req)
+			if w.Code != tc.wantCode {
+				t.Errorf("status: got %d, want %d", w.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+// ── GetConversation ──────────────────────────────────────────────────────────
+
+func TestGetConversation(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		storer   *mockStorer
+		wantCode int
+	}{
+		{
+			name: "200 found",
+			id:   testConvID,
+			storer: &mockStorer{
+				getConversation: func(id string) (*storage.Conversation, error) {
+					return &storage.Conversation{ID: id}, nil
+				},
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name: "404 not found",
+			id:   testConvID,
+			storer: &mockStorer{
+				getConversation: func(id string) (*storage.Conversation, error) {
+					return nil, &storage.NotFoundError{ID: id}
+				},
+			},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "400 invalid UUID",
+			id:       "not-a-uuid",
+			storer:   &mockStorer{},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "500 storage error",
+			id:   testConvID,
+			storer: &mockStorer{
+				getConversation: func(id string) (*storage.Conversation, error) {
+					return nil, errors.New("db error")
+				},
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(tc.storer, &mockRunner{})
+			req := httptest.NewRequest(http.MethodGet, "/api/conversations/"+tc.id, nil)
+			req.SetPathValue("id", tc.id)
+			w := httptest.NewRecorder()
+			h.getConversation(w, req)
+			if w.Code != tc.wantCode {
+				t.Errorf("status: got %d, want %d", w.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+// ── SendMessageStream ────────────────────────────────────────────────────────
+
+// okStorer returns a mockStorer that succeeds silently for all write operations.
+func okStorer() *mockStorer {
+	return &mockStorer{
+		saveUserMessage:      func(string, string) error { return nil },
+		saveAssistantMessage: func(string, council.AssistantMessage) error { return nil },
+		saveTitle:            func(string, string) error { return nil },
+	}
+}
+
+func TestSendMessageStream(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		storer   *mockStorer
+		runner   *mockRunner
+		wantCode int
+		checkSSE func(t *testing.T, body string)
+	}{
+		{
+			name:   "event sequence with metadata in stage2_complete",
+			body:   `{"message":"what is Go?","council_type":"standard"}`,
+			storer: okStorer(),
+			runner: &mockRunner{
+				runFull: func(ctx context.Context, query, ct string, onEvent council.EventFunc) error {
+					onEvent("stage1_complete", []council.StageOneResult{
+						{Label: "Response A", Content: "Go is a compiled language"},
+					})
+					onEvent("stage2_complete", council.Stage2CompleteData{
+						Results: []council.StageTwoResult{
+							{ReviewerLabel: "Response A", Rankings: []string{"Response A"}},
+						},
+						Metadata: council.Metadata{
+							CouncilType:  "standard",
+							ConsensusW:   0.9,
+							LabelToModel: map[string]string{"Response A": "openai/gpt-4o"},
+						},
+					})
+					onEvent("stage3_complete", council.StageThreeResult{Content: "final answer"})
+					return nil
+				},
+			},
+			wantCode: http.StatusOK,
+			checkSSE: func(t *testing.T, body string) {
+				types := parseSSEEventTypes(body)
+
+				// Verify required events are present.
+				for _, want := range []string{"stage1_complete", "stage2_complete", "stage3_complete", "complete"} {
+					found := false
+					for _, got := range types {
+						if got == want {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("missing event %q in sequence %v", want, types)
+					}
+				}
+
+				// "complete" must be the last event.
+				if len(types) == 0 || types[len(types)-1] != "complete" {
+					t.Errorf("last event: got %v, want 'complete'", types)
+				}
+
+				// metadata must be present and populated in stage2_complete.
+				var s2 council.Stage2CompleteData
+				if !parseSSEEventData(body, "stage2_complete", &s2) {
+					t.Fatal("could not parse stage2_complete data")
+				}
+				if s2.Metadata.ConsensusW != 0.9 {
+					t.Errorf("consensus_w: got %f, want 0.9", s2.Metadata.ConsensusW)
+				}
+				if s2.Metadata.LabelToModel["Response A"] != "openai/gpt-4o" {
+					t.Errorf("label_to_model: got %v", s2.Metadata.LabelToModel)
+				}
+			},
+		},
+		{
+			name:   "QuorumError emits error event",
+			body:   `{"message":"test","council_type":"standard"}`,
+			storer: okStorer(),
+			runner: &mockRunner{
+				runFull: func(ctx context.Context, query, ct string, onEvent council.EventFunc) error {
+					return &council.QuorumError{Got: 1, Need: 3}
+				},
+			},
+			wantCode: http.StatusOK,
+			checkSSE: func(t *testing.T, body string) {
+				types := parseSSEEventTypes(body)
+				for _, typ := range types {
+					if typ == "error" {
+						return
+					}
+				}
+				t.Errorf("expected 'error' event for QuorumError, got events: %v", types)
+			},
+		},
+		{
+			name:     "malformed JSON body returns 400 before SSE starts",
+			body:     `not json`,
+			storer:   okStorer(),
+			runner:   &mockRunner{},
+			wantCode: http.StatusBadRequest,
+			checkSSE: func(t *testing.T, body string) {
+				// Must be a plain JSON error, not an SSE stream.
+				var errResp map[string]string
+				if err := json.Unmarshal([]byte(strings.TrimSpace(body)), &errResp); err != nil {
+					t.Errorf("expected JSON error body, got: %q", body)
+				}
+				if errResp["error"] == "" {
+					t.Errorf("error field missing in response: %v", errResp)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(tc.storer, tc.runner)
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/conversations/"+testConvID+"/message/stream",
+				bytes.NewBufferString(tc.body),
+			)
+			req.SetPathValue("id", testConvID)
+			w := httptest.NewRecorder()
+			h.sendMessageStream(w, req)
+			if w.Code != tc.wantCode {
+				t.Errorf("status: got %d, want %d\nbody: %s", w.Code, tc.wantCode, w.Body.String())
+			}
+			if tc.checkSSE != nil {
+				tc.checkSSE(t, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -85,6 +85,14 @@ type Metadata struct {
 	ConsensusW        float64       `json:"consensus_w"`
 }
 
+// Stage2CompleteData is the payload emitted by Runner for the "stage2_complete" event.
+// It bundles peer-review results with the computed aggregate metadata so callers
+// (e.g. the SSE handler) can surface both in one event.
+type Stage2CompleteData struct {
+	Results  []StageTwoResult `json:"results"`
+	Metadata Metadata         `json:"metadata"`
+}
+
 // AssistantMessage is the full deliberation record stored with each assistant turn.
 type AssistantMessage struct {
 	Role     string           `json:"role"`


### PR DESCRIPTION
## Summary

- **Handler struct** with `council.Runner`, `storage.Storer`, `*slog.Logger`, `defaultCouncilType` fields; `NewHandler` constructor; `RegisterRoutes` wires all 7 routes onto `http.ServeMux`
- **Middleware**: CORS (localhost:5173 + localhost:3000), preflight OPTIONS → 204, security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Content-Security-Policy`)
- **CRUD handlers**: `listConversations` (nil→`[]` coercion), `createConversation` (201), `getConversation` (400 invalid UUID / 404 / 500)
- **SSE handler**: flusher guard + UUID + body validation before streaming starts; collects typed stage events (`stage1_complete`, `stage2_complete`, `stage3_complete`); saves `AssistantMessage` before `complete`; title goroutine with 30 s timeout; `QuorumError` → sanitised error event
- **`council.Stage2CompleteData`** type added — bundles peer-review results + `Metadata` as the `stage2_complete` event payload
- **7 table-driven tests** with hand-written `mockStorer` / `mockRunner`; covers all AC cases

Closes #87
Closes #88
Closes #89
Closes #92

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -race -count=1` passes (7 new API tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)