### PR TITLE
⚖️ task(cmd): implement main.go DI wiring and graceful shutdown

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,14 +23,16 @@ func main() {
 	// .env file work normally.
 	_ = godotenv.Load()
 
-	cfg, err := config.Load()
-	if err != nil {
-		slog.Error("configuration error", "error", err)
-		os.Exit(1)
-	}
-
+	// Initialise the JSON logger first so every subsequent slog call —
+	// including those inside config.Load() — uses a consistent format.
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	slog.SetDefault(logger)
+
+	cfg, err := config.Load()
+	if err != nil {
+		logger.Error("configuration error", "error", err)
+		os.Exit(1)
+	}
 
 	// Build the council type registry from config fields.
 	registry := map[string]council.CouncilType{
@@ -67,16 +69,23 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// errCh receives the first non-ErrServerClosed error from ListenAndServe,
+	// allowing the main goroutine to log and exit without skipping deferred cleanup.
+	errCh := make(chan error, 1)
 	go func() {
 		logger.Info("server starting", "addr", srv.Addr)
 		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			logger.Error("server error", "error", err)
-			os.Exit(1)
+			errCh <- err
 		}
 	}()
 
-	<-ctx.Done()
-	logger.Info("shutting down")
+	select {
+	case <-ctx.Done():
+		logger.Info("shutting down")
+	case err := <-errCh:
+		logger.Error("server error", "error", err)
+		os.Exit(1)
+	}
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,11 +1,21 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"log/slog"
+	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/joho/godotenv"
+	"github.com/valpere/llm-council/internal/api"
 	"github.com/valpere/llm-council/internal/config"
+	"github.com/valpere/llm-council/internal/council"
+	"github.com/valpere/llm-council/internal/openrouter"
+	"github.com/valpere/llm-council/internal/storage"
 )
 
 func main() {
@@ -19,5 +29,58 @@ func main() {
 		os.Exit(1)
 	}
 
-	_ = cfg // wiring in L3.8
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
+	// Build the council type registry from config fields.
+	registry := map[string]council.CouncilType{
+		cfg.DefaultCouncilType: {
+			Name:          cfg.DefaultCouncilType,
+			Strategy:      council.PeerReview,
+			Models:        cfg.DefaultCouncilModels,
+			ChairmanModel: cfg.DefaultCouncilChairmanModel,
+			Temperature:   cfg.DefaultCouncilTemperature,
+		},
+	}
+
+	client := openrouter.NewClient(cfg.OpenRouterAPIKey)
+	runner := council.NewCouncil(client, registry, logger)
+
+	store, err := storage.NewStore(cfg.DataDir, logger)
+	if err != nil {
+		logger.Error("storage init failed", "error", err)
+		os.Exit(1)
+	}
+
+	handler := api.NewHandler(runner, store, logger, cfg.DefaultCouncilType)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	srv := &http.Server{
+		Addr:              ":" + cfg.Port,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	// Graceful shutdown: cancel context on SIGINT or SIGTERM, then drain
+	// in-flight requests with a 10 s deadline.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		logger.Info("server starting", "addr", srv.Addr)
+		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("server error", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	logger.Info("shutting down")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		logger.Error("shutdown error", "error", err)
+	}
 }

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -2,8 +2,11 @@ package council
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 )
+
+var errNotImplemented = errors.New("council: RunFull not yet implemented")
 
 // Council orchestrates the full multi-stage deliberation pipeline.
 // Full implementation is provided in a later milestone.
@@ -27,7 +30,7 @@ func NewCouncil(client LLMClient, registry map[string]CouncilType, logger *slog.
 var _ Runner = (*Council)(nil)
 
 // RunFull orchestrates a full council deliberation.
-// Stub — full implementation is provided in a later milestone.
+// Stub — returns errNotImplemented until #86 is implemented.
 func (c *Council) RunFull(_ context.Context, _ string, _ string, _ EventFunc) error {
-	return nil
+	return errNotImplemented
 }

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -1,0 +1,33 @@
+package council
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Council orchestrates the full multi-stage deliberation pipeline.
+// Full implementation is provided in a later milestone.
+type Council struct {
+	client   LLMClient
+	registry map[string]CouncilType
+	logger   *slog.Logger
+}
+
+// NewCouncil creates a Council that uses client for LLM calls and resolves
+// named council types from registry.
+func NewCouncil(client LLMClient, registry map[string]CouncilType, logger *slog.Logger) *Council {
+	return &Council{
+		client:   client,
+		registry: registry,
+		logger:   logger,
+	}
+}
+
+// Compile-time assertion: Council implements Runner.
+var _ Runner = (*Council)(nil)
+
+// RunFull orchestrates a full council deliberation.
+// Stub — full implementation is provided in a later milestone.
+func (c *Council) RunFull(_ context.Context, _ string, _ string, _ EventFunc) error {
+	return nil
+}

--- a/internal/openrouter/client.go
+++ b/internal/openrouter/client.go
@@ -2,9 +2,12 @@ package openrouter
 
 import (
 	"context"
+	"errors"
 
 	"github.com/valpere/llm-council/internal/council"
 )
+
+var errNotImplemented = errors.New("openrouter: HTTP client not yet implemented")
 
 // Client sends completion requests to the OpenRouter API.
 // Full HTTP implementation is provided in a later milestone.
@@ -21,7 +24,7 @@ func NewClient(apiKey string) *Client {
 var _ council.LLMClient = (*Client)(nil)
 
 // Complete sends a chat completion request to OpenRouter.
-// Stub — returns empty response until the HTTP layer is implemented.
+// Stub — returns errNotImplemented until the HTTP layer is implemented in #77.
 func (c *Client) Complete(_ context.Context, _ council.CompletionRequest) (council.CompletionResponse, error) {
-	return council.CompletionResponse{}, nil
+	return council.CompletionResponse{}, errNotImplemented
 }

--- a/internal/openrouter/client.go
+++ b/internal/openrouter/client.go
@@ -1,1 +1,27 @@
 package openrouter
+
+import (
+	"context"
+
+	"github.com/valpere/llm-council/internal/council"
+)
+
+// Client sends completion requests to the OpenRouter API.
+// Full HTTP implementation is provided in a later milestone.
+type Client struct {
+	apiKey string
+}
+
+// NewClient creates a Client for the given OpenRouter API key.
+func NewClient(apiKey string) *Client {
+	return &Client{apiKey: apiKey}
+}
+
+// Compile-time assertion: Client implements council.LLMClient.
+var _ council.LLMClient = (*Client)(nil)
+
+// Complete sends a chat completion request to OpenRouter.
+// Stub — returns empty response until the HTTP layer is implemented.
+func (c *Client) Complete(_ context.Context, _ council.CompletionRequest) (council.CompletionResponse, error) {
+	return council.CompletionResponse{}, nil
+}


### PR DESCRIPTION
## Summary

- **`cmd/server/main.go`**: JSON structured logger; council type registry assembled from `cfg.Default*` fields; `openrouter.NewClient` → `council.NewCouncil` → `storage.NewStore` → `api.NewHandler` wired in dependency order; `http.Server` with `ReadHeaderTimeout: 10s`; `signal.NotifyContext(SIGINT/SIGTERM)` + `srv.Shutdown` with 10 s drain timeout
- **`internal/council/runner.go`**: `Council` struct + `NewCouncil` constructor + `RunFull` stub implementing `Runner` interface (compile-time assertion); full implementation deferred to #86
- **`internal/openrouter/client.go`**: `Client` struct + `NewClient` constructor + `Complete` stub implementing `council.LLMClient` (compile-time assertion); full HTTP implementation deferred to #77

Closes #91

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -race -count=1` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)