### PR TITLE
⚖️ task(openrouter): implement HTTP client for OpenRouter API

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -45,7 +45,7 @@ func main() {
 		},
 	}
 
-	client := openrouter.NewClient(cfg.OpenRouterAPIKey)
+	client := openrouter.NewClient(cfg.OpenRouterAPIKey, 120*time.Second)
 	runner := council.NewCouncil(client, registry, logger)
 
 	store, err := storage.NewStore(cfg.DataDir, logger)

--- a/internal/openrouter/client.go
+++ b/internal/openrouter/client.go
@@ -1,30 +1,84 @@
 package openrouter
 
 import (
+	"bytes"
 	"context"
-	"errors"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
 
 	"github.com/valpere/llm-council/internal/council"
 )
 
-var errNotImplemented = errors.New("openrouter: HTTP client not yet implemented")
+const completionsURL = "https://openrouter.ai/api/v1/chat/completions"
 
-// Client sends completion requests to the OpenRouter API.
-// Full HTTP implementation is provided in a later milestone.
-type Client struct {
-	apiKey string
+// APIError is returned when OpenRouter responds with a non-200 status code.
+type APIError struct {
+	StatusCode int
+	Body       string
 }
 
-// NewClient creates a Client for the given OpenRouter API key.
-func NewClient(apiKey string) *Client {
-	return &Client{apiKey: apiKey}
+func (e *APIError) Error() string {
+	return fmt.Sprintf("openrouter: API error %d: %s", e.StatusCode, e.Body)
+}
+
+// Client sends completion requests to the OpenRouter API.
+type Client struct {
+	apiKey string
+	http   *http.Client
+}
+
+// NewClient creates a Client with the given API key and HTTP timeout.
+func NewClient(apiKey string, timeout time.Duration) *Client {
+	return &Client{
+		apiKey: apiKey,
+		http:   &http.Client{Timeout: timeout},
+	}
 }
 
 // Compile-time assertion: Client implements council.LLMClient.
 var _ council.LLMClient = (*Client)(nil)
 
-// Complete sends a chat completion request to OpenRouter.
-// Stub — returns errNotImplemented until the HTTP layer is implemented in #77.
-func (c *Client) Complete(_ context.Context, _ council.CompletionRequest) (council.CompletionResponse, error) {
-	return council.CompletionResponse{}, errNotImplemented
+// Complete POSTs a chat completion request to OpenRouter and returns the response.
+// Returns *APIError on non-200 responses.
+func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (council.CompletionResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return council.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, completionsURL, bytes.NewReader(body))
+	if err != nil {
+		return council.CompletionResponse{}, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	httpReq.Header.Set("HTTP-Referer", "https://github.com/valpere/llm-council")
+	httpReq.Header.Set("X-Title", "LLM Council")
+
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return council.CompletionResponse{}, fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return council.CompletionResponse{}, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return council.CompletionResponse{}, &APIError{
+			StatusCode: resp.StatusCode,
+			Body:       string(respBody),
+		}
+	}
+
+	var completionResp council.CompletionResponse
+	if err := json.Unmarshal(respBody, &completionResp); err != nil {
+		return council.CompletionResponse{}, fmt.Errorf("unmarshal response: %w", err)
+	}
+	return completionResp, nil
 }

--- a/internal/openrouter/client.go
+++ b/internal/openrouter/client.go
@@ -12,7 +12,10 @@ import (
 	"github.com/valpere/llm-council/internal/council"
 )
 
-const completionsURL = "https://openrouter.ai/api/v1/chat/completions"
+const (
+	defaultURL   = "https://openrouter.ai/api/v1/chat/completions"
+	maxBodyBytes = 4 * 1024 * 1024 // 4 MiB cap on response bodies
+)
 
 // APIError is returned when OpenRouter responds with a non-200 status code.
 type APIError struct {
@@ -26,15 +29,17 @@ func (e *APIError) Error() string {
 
 // Client sends completion requests to the OpenRouter API.
 type Client struct {
-	apiKey string
-	http   *http.Client
+	apiKey  string
+	baseURL string // overridable in tests; defaults to defaultURL
+	http    *http.Client
 }
 
 // NewClient creates a Client with the given API key and HTTP timeout.
 func NewClient(apiKey string, timeout time.Duration) *Client {
 	return &Client{
-		apiKey: apiKey,
-		http:   &http.Client{Timeout: timeout},
+		apiKey:  apiKey,
+		baseURL: defaultURL,
+		http:    &http.Client{Timeout: timeout},
 	}
 }
 
@@ -49,7 +54,7 @@ func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (c
 		return council.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, completionsURL, bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL, bytes.NewReader(body))
 	if err != nil {
 		return council.CompletionResponse{}, fmt.Errorf("create request: %w", err)
 	}
@@ -64,7 +69,8 @@ func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (c
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	// Limit reads to maxBodyBytes to guard against unexpectedly large responses.
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if err != nil {
 		return council.CompletionResponse{}, fmt.Errorf("read response: %w", err)
 	}

--- a/internal/openrouter/client_test.go
+++ b/internal/openrouter/client_test.go
@@ -1,0 +1,230 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/valpere/llm-council/internal/council"
+)
+
+// testClient returns a Client pointed at srv with the given API key.
+func testClient(apiKey string, srv *httptest.Server) *Client {
+	return &Client{
+		apiKey:  apiKey,
+		baseURL: srv.URL,
+		http:    srv.Client(),
+	}
+}
+
+// mockCompletion is the minimal OpenAI-compatible completion shape.
+type mockCompletion struct {
+	Choices []struct {
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// ── TestComplete_RequiredHeaders ──────────────────────────────────────────────
+
+func TestComplete_RequiredHeaders(t *testing.T) {
+	var gotAuth, gotReferer, gotTitle string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotReferer = r.Header.Get("HTTP-Referer")
+		gotTitle = r.Header.Get("X-Title")
+		writeJSON(w, mockCompletion{
+			Choices: []struct {
+				Message struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				} `json:"message"`
+			}{
+				{Message: struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				}{Role: "assistant", Content: "hi"}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient("sk-test-key", srv)
+	_, err := c.Complete(context.Background(), council.CompletionRequest{
+		Model:    "openai/gpt-4o-mini",
+		Messages: []council.ChatMessage{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAuth != "Bearer sk-test-key" {
+		t.Errorf("Authorization: got %q, want %q", gotAuth, "Bearer sk-test-key")
+	}
+	if gotReferer == "" {
+		t.Error("HTTP-Referer header missing")
+	}
+	if gotTitle == "" {
+		t.Error("X-Title header missing")
+	}
+}
+
+// ── TestComplete_SuccessfulResponse ──────────────────────────────────────────
+
+func TestComplete_SuccessfulResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, mockCompletion{
+			Choices: []struct {
+				Message struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				} `json:"message"`
+			}{
+				{Message: struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				}{Role: "assistant", Content: "Paris"}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient("key", srv)
+	resp, err := c.Complete(context.Background(), council.CompletionRequest{
+		Model:    "openai/gpt-4o-mini",
+		Messages: []council.ChatMessage{{Role: "user", Content: "capital of France?"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Choices) == 0 {
+		t.Fatal("no choices in response")
+	}
+	if got := resp.Choices[0].Message.Content; got != "Paris" {
+		t.Errorf("content: got %q, want %q", got, "Paris")
+	}
+}
+
+// ── TestComplete_APIError_OnNonOK ─────────────────────────────────────────────
+
+func TestComplete_APIError_OnNonOK(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"400 bad request", http.StatusBadRequest},
+		{"429 rate limited", http.StatusTooManyRequests},
+		{"500 internal error", http.StatusInternalServerError},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(`{"error":"test error"}`))
+			}))
+			defer srv.Close()
+
+			c := testClient("key", srv)
+			_, err := c.Complete(context.Background(), council.CompletionRequest{
+				Model:    "openai/gpt-4o-mini",
+				Messages: []council.ChatMessage{{Role: "user", Content: "hi"}},
+			})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			var apiErr *APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected *APIError, got %T: %v", err, err)
+			}
+			if apiErr.StatusCode != tc.statusCode {
+				t.Errorf("StatusCode: got %d, want %d", apiErr.StatusCode, tc.statusCode)
+			}
+			if apiErr.Body == "" {
+				t.Error("APIError.Body should not be empty")
+			}
+		})
+	}
+}
+
+// ── TestComplete_ResponseFormatForwarded ─────────────────────────────────────
+
+func TestComplete_ResponseFormatForwarded(t *testing.T) {
+	tests := []struct {
+		name           string
+		responseFormat *council.ResponseFormat
+		wantInBody     bool
+	}{
+		{
+			name:           "nil response_format omitted from request",
+			responseFormat: nil,
+			wantInBody:     false,
+		},
+		{
+			name:           "json_object format forwarded",
+			responseFormat: &council.ResponseFormat{Type: "json_object"},
+			wantInBody:     true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				writeJSON(w, mockCompletion{
+					Choices: []struct {
+						Message struct {
+							Role    string `json:"role"`
+							Content string `json:"content"`
+						} `json:"message"`
+					}{
+						{Message: struct {
+							Role    string `json:"role"`
+							Content string `json:"content"`
+						}{Role: "assistant", Content: "{}"}},
+					},
+				})
+			}))
+			defer srv.Close()
+
+			c := testClient("key", srv)
+			_, err := c.Complete(context.Background(), council.CompletionRequest{
+				Model:          "openai/gpt-4o-mini",
+				Messages:       []council.ChatMessage{{Role: "user", Content: "hi"}},
+				ResponseFormat: tc.responseFormat,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			_, present := gotBody["response_format"]
+			if present != tc.wantInBody {
+				t.Errorf("response_format present=%v, want %v", present, tc.wantInBody)
+			}
+		})
+	}
+}
+
+// ── TestNewClient ─────────────────────────────────────────────────────────────
+
+func TestNewClient(t *testing.T) {
+	c := NewClient("my-key", 30*time.Second)
+	if c.apiKey != "my-key" {
+		t.Errorf("apiKey: got %q, want %q", c.apiKey, "my-key")
+	}
+	if c.baseURL != defaultURL {
+		t.Errorf("baseURL: got %q, want %q", c.baseURL, defaultURL)
+	}
+	if c.http.Timeout != 30*time.Second {
+		t.Errorf("timeout: got %v, want 30s", c.http.Timeout)
+	}
+}


### PR DESCRIPTION
## Summary

- **`APIError{StatusCode, Body}`** returned on any non-200 response
- **`NewClient(apiKey string, timeout time.Duration) *Client`** — wraps a `http.Client` with the given timeout
- **`Complete()`** — POSTs to `https://openrouter.ai/api/v1/chat/completions` with `Authorization: Bearer`, `HTTP-Referer`, `X-Title` headers; forwards `response_format` when set (Stage 2 JSON mode)
- Compile-time `var _ council.LLMClient = (*Client)(nil)` assertion
- `cmd/server/main.go` updated to pass `120*time.Second` to `NewClient`

Closes #77

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)