### PR TITLE
⚡ task(council): implement Stage 1 parallel generation

### DIFF
--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
+	"time"
 )
 
 var errNotImplemented = errors.New("council: RunFull not yet implemented")
@@ -33,4 +35,35 @@ var _ Runner = (*Council)(nil)
 // Stub — returns errNotImplemented until #86 is implemented.
 func (c *Council) RunFull(_ context.Context, _ string, _ string, _ EventFunc) error {
 	return errNotImplemented
+}
+
+// runStage1 sends query to all models concurrently and returns all results.
+// Each goroutine writes to its own pre-allocated results[i] slot — no mutex needed.
+// Context cancellation is propagated to every Complete call.
+// Quorum is NOT checked here — that is the caller's responsibility.
+func (c *Council) runStage1(ctx context.Context, query string, models []string, temperature float64) []StageOneResult {
+	results := make([]StageOneResult, len(models))
+	var wg sync.WaitGroup
+	for i, model := range models {
+		wg.Add(1)
+		go func(i int, model string) {
+			defer wg.Done()
+			start := time.Now()
+			resp, err := c.client.Complete(ctx, CompletionRequest{
+				Model:       model,
+				Messages:    BuildStage1Prompt(query),
+				Temperature: temperature,
+			})
+			results[i] = StageOneResult{
+				Model:      model,
+				DurationMs: time.Since(start).Milliseconds(),
+				Error:      err,
+			}
+			if err == nil && len(resp.Choices) > 0 {
+				results[i].Content = resp.Choices[0].Message.Content
+			}
+		}(i, model)
+	}
+	wg.Wait()
+	return results
 }

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -9,6 +9,7 @@ import (
 )
 
 var errNotImplemented = errors.New("council: RunFull not yet implemented")
+var errNoChoices = errors.New("council: completion response contained no choices")
 
 // Council orchestrates the full multi-stage deliberation pipeline.
 // Full implementation is provided in a later milestone.
@@ -54,12 +55,15 @@ func (c *Council) runStage1(ctx context.Context, query string, models []string, 
 				Messages:    BuildStage1Prompt(query),
 				Temperature: temperature,
 			})
+			if err == nil && len(resp.Choices) == 0 {
+				err = errNoChoices
+			}
 			results[i] = StageOneResult{
 				Model:      model,
 				DurationMs: time.Since(start).Milliseconds(),
 				Error:      err,
 			}
-			if err == nil && len(resp.Choices) > 0 {
+			if err == nil {
 				results[i].Content = resp.Choices[0].Message.Content
 			}
 		}(i, model)

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -1,0 +1,127 @@
+package council
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// mockLLMClient implements LLMClient for testing.
+type mockLLMClient struct {
+	complete func(ctx context.Context, req CompletionRequest) (CompletionResponse, error)
+}
+
+func (m *mockLLMClient) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	return m.complete(ctx, req)
+}
+
+func makeResponse(content string) CompletionResponse {
+	return CompletionResponse{
+		Choices: []struct {
+			Message ChatMessage `json:"message"`
+		}{
+			{Message: ChatMessage{Role: "assistant", Content: content}},
+		},
+	}
+}
+
+// ── runStage1 ─────────────────────────────────────────────────────────────────
+
+func TestRunStage1_AllSucceed(t *testing.T) {
+	models := []string{"model-a", "model-b", "model-c"}
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			return makeResponse("answer from " + req.Model), nil
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	results := c.runStage1(context.Background(), "test query", models, 0.7)
+
+	if len(results) != len(models) {
+		t.Fatalf("len: got %d, want %d", len(results), len(models))
+	}
+	for i, r := range results {
+		if r.Error != nil {
+			t.Errorf("results[%d].Error: unexpected %v", i, r.Error)
+		}
+		if r.Content == "" {
+			t.Errorf("results[%d].Content: empty", i)
+		}
+		if r.Model != models[i] {
+			t.Errorf("results[%d].Model: got %q, want %q", i, r.Model, models[i])
+		}
+		if r.DurationMs < 0 {
+			t.Errorf("results[%d].DurationMs: negative %d", i, r.DurationMs)
+		}
+	}
+}
+
+func TestRunStage1_PartialFailure_ReturnsAll(t *testing.T) {
+	errBoom := errors.New("model failed")
+	models := []string{"model-a", "model-b", "model-c"}
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			if req.Model == "model-b" {
+				return CompletionResponse{}, errBoom
+			}
+			return makeResponse("ok"), nil
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	results := c.runStage1(context.Background(), "test query", models, 0.7)
+
+	if len(results) != 3 {
+		t.Fatalf("len: got %d, want 3", len(results))
+	}
+	if results[0].Error != nil {
+		t.Errorf("results[0]: unexpected error %v", results[0].Error)
+	}
+	if !errors.Is(results[1].Error, errBoom) {
+		t.Errorf("results[1].Error: got %v, want errBoom", results[1].Error)
+	}
+	if results[1].Content != "" {
+		t.Errorf("results[1].Content: want empty on error, got %q", results[1].Content)
+	}
+	if results[2].Error != nil {
+		t.Errorf("results[2]: unexpected error %v", results[2].Error)
+	}
+}
+
+func TestRunStage1_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before any call
+
+	client := &mockLLMClient{
+		complete: func(ctx context.Context, _ CompletionRequest) (CompletionResponse, error) {
+			return CompletionResponse{}, ctx.Err()
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	results := c.runStage1(ctx, "test query", []string{"model-a", "model-b"}, 0.7)
+
+	if len(results) != 2 {
+		t.Fatalf("len: got %d, want 2", len(results))
+	}
+	for i, r := range results {
+		if !errors.Is(r.Error, context.Canceled) {
+			t.Errorf("results[%d].Error: got %v, want context.Canceled", i, r.Error)
+		}
+	}
+}
+
+func TestRunStage1_EmptyChoices_ContentEmpty(t *testing.T) {
+	client := &mockLLMClient{
+		complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+			return CompletionResponse{}, nil // no choices
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	results := c.runStage1(context.Background(), "q", []string{"model-a"}, 0.7)
+
+	if results[0].Error != nil {
+		t.Errorf("unexpected error: %v", results[0].Error)
+	}
+	if results[0].Content != "" {
+		t.Errorf("Content: want empty when no choices, got %q", results[0].Content)
+	}
+}

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -109,7 +109,7 @@ func TestRunStage1_ContextCancellation(t *testing.T) {
 	}
 }
 
-func TestRunStage1_EmptyChoices_ContentEmpty(t *testing.T) {
+func TestRunStage1_EmptyChoices_IsError(t *testing.T) {
 	client := &mockLLMClient{
 		complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
 			return CompletionResponse{}, nil // no choices
@@ -118,10 +118,10 @@ func TestRunStage1_EmptyChoices_ContentEmpty(t *testing.T) {
 	c := NewCouncil(client, nil, nil)
 	results := c.runStage1(context.Background(), "q", []string{"model-a"}, 0.7)
 
-	if results[0].Error != nil {
-		t.Errorf("unexpected error: %v", results[0].Error)
+	if results[0].Error == nil {
+		t.Error("expected error for empty choices, got nil")
 	}
 	if results[0].Content != "" {
-		t.Errorf("Content: want empty when no choices, got %q", results[0].Content)
+		t.Errorf("Content: want empty on error, got %q", results[0].Content)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `runStage1` to `Council` in `internal/council/runner.go`
- All models called concurrently via `sync.WaitGroup`; each goroutine writes to `results[i]` — no mutex
- Context cancellation propagated to every `Complete` call
- Returns all results (successes + failures); quorum check is the caller's responsibility

Closes #81

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (4 new cases: all succeed, partial failure, context cancellation, empty choices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)