### PR TITLE
⚡ task(council): implement Stage 2 peer review with structured JSON output

### DIFF
--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -2,6 +2,7 @@ package council
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"sync"
@@ -67,6 +68,68 @@ func (c *Council) runStage1(ctx context.Context, query string, models []string, 
 				results[i].Content = resp.Choices[0].Message.Content
 			}
 		}(i, model)
+	}
+	wg.Wait()
+	return results
+}
+
+// runStage2 sends peer-review requests to all stage1 models concurrently.
+// Each reviewer receives the full set of anonymised stage1 responses and returns
+// a ranked ordering as JSON. Parse failures are logged and treated as missing
+// rankings so midrank imputation in CalculateAggregateRankings handles them.
+// Unknown labels are logged and dropped from the ranking.
+// LLM call failures are stored in StageTwoResult.Error; parse failures are not.
+func (c *Council) runStage2(ctx context.Context, query string, stage1 []StageOneResult, temperature float64) []StageTwoResult {
+	// Build the prompt input once — same for every reviewer.
+	labeledResponses := make(map[string]string, len(stage1))
+	knownLabels := make(map[string]bool, len(stage1))
+	for _, r := range stage1 {
+		labeledResponses[r.Label] = r.Content
+		knownLabels[r.Label] = true
+	}
+
+	results := make([]StageTwoResult, len(stage1))
+	var wg sync.WaitGroup
+	for i, s1 := range stage1 {
+		wg.Add(1)
+		go func(i int, s1 StageOneResult) {
+			defer wg.Done()
+			resp, err := c.client.Complete(ctx, CompletionRequest{
+				Model:          s1.Model,
+				Messages:       BuildStage2Prompt(query, labeledResponses),
+				Temperature:    temperature,
+				ResponseFormat: &ResponseFormat{Type: "json_object"},
+			})
+			if err != nil {
+				results[i] = StageTwoResult{ReviewerLabel: s1.Label, Error: err}
+				return
+			}
+			if len(resp.Choices) == 0 {
+				results[i] = StageTwoResult{ReviewerLabel: s1.Label, Error: errNoChoices}
+				return
+			}
+
+			var parsed struct {
+				Rankings []string `json:"rankings"`
+			}
+			if err := json.Unmarshal([]byte(resp.Choices[0].Message.Content), &parsed); err != nil {
+				if c.logger != nil {
+					c.logger.Warn("stage2: parse failure", slog.String("reviewer", s1.Label), slog.Any("error", err))
+				}
+				results[i] = StageTwoResult{ReviewerLabel: s1.Label}
+				return
+			}
+
+			valid := make([]string, 0, len(parsed.Rankings))
+			for _, label := range parsed.Rankings {
+				if knownLabels[label] {
+					valid = append(valid, label)
+				} else if c.logger != nil {
+					c.logger.Warn("stage2: unknown label dropped", slog.String("reviewer", s1.Label), slog.String("label", label))
+				}
+			}
+			results[i] = StageTwoResult{ReviewerLabel: s1.Label, Rankings: valid}
+		}(i, s1)
 	}
 	wg.Wait()
 	return results

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -80,13 +80,14 @@ func (c *Council) runStage1(ctx context.Context, query string, models []string, 
 // Unknown labels are logged and dropped from the ranking.
 // LLM call failures are stored in StageTwoResult.Error; parse failures are not.
 func (c *Council) runStage2(ctx context.Context, query string, stage1 []StageOneResult, temperature float64) []StageTwoResult {
-	// Build the prompt input once — same for every reviewer.
+	// Build the prompt and label maps once — shared across all reviewer goroutines.
 	labeledResponses := make(map[string]string, len(stage1))
 	knownLabels := make(map[string]bool, len(stage1))
 	for _, r := range stage1 {
 		labeledResponses[r.Label] = r.Content
 		knownLabels[r.Label] = true
 	}
+	prompt := BuildStage2Prompt(query, labeledResponses)
 
 	results := make([]StageTwoResult, len(stage1))
 	var wg sync.WaitGroup
@@ -96,7 +97,7 @@ func (c *Council) runStage2(ctx context.Context, query string, stage1 []StageOne
 			defer wg.Done()
 			resp, err := c.client.Complete(ctx, CompletionRequest{
 				Model:          s1.Model,
-				Messages:       BuildStage2Prompt(query, labeledResponses),
+				Messages:       prompt,
 				Temperature:    temperature,
 				ResponseFormat: &ResponseFormat{Type: "json_object"},
 			})
@@ -115,6 +116,13 @@ func (c *Council) runStage2(ctx context.Context, query string, stage1 []StageOne
 			if err := json.Unmarshal([]byte(resp.Choices[0].Message.Content), &parsed); err != nil {
 				if c.logger != nil {
 					c.logger.Warn("stage2: parse failure", slog.String("reviewer", s1.Label), slog.Any("error", err))
+				}
+				results[i] = StageTwoResult{ReviewerLabel: s1.Label}
+				return
+			}
+			if len(parsed.Rankings) == 0 {
+				if c.logger != nil {
+					c.logger.Warn("stage2: empty rankings", slog.String("reviewer", s1.Label))
 				}
 				results[i] = StageTwoResult{ReviewerLabel: s1.Label}
 				return

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -125,3 +125,125 @@ func TestRunStage1_EmptyChoices_IsError(t *testing.T) {
 		t.Errorf("Content: want empty on error, got %q", results[0].Content)
 	}
 }
+
+// ── runStage2 ─────────────────────────────────────────────────────────────────
+
+// stage1Fixture returns labeled stage1 results for use in stage2 tests.
+func stage1Fixture() []StageOneResult {
+	return []StageOneResult{
+		{Label: "Response A", Model: "model-a", Content: "answer A"},
+		{Label: "Response B", Model: "model-b", Content: "answer B"},
+		{Label: "Response C", Model: "model-c", Content: "answer C"},
+	}
+}
+
+func TestRunStage2_AllSucceed(t *testing.T) {
+	stage1 := stage1Fixture()
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			// Each reviewer ranks A > B > C regardless of who they are.
+			return makeResponse(`{"rankings":["Response A","Response B","Response C"]}`), nil
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	results := c.runStage2(context.Background(), "q", stage1, 0.7)
+
+	if len(results) != 3 {
+		t.Fatalf("len: got %d, want 3", len(results))
+	}
+	for i, r := range results {
+		if r.Error != nil {
+			t.Errorf("results[%d].Error: unexpected %v", i, r.Error)
+		}
+		if len(r.Rankings) != 3 {
+			t.Errorf("results[%d].Rankings len: got %d, want 3", i, len(r.Rankings))
+		}
+		if r.ReviewerLabel != stage1[i].Label {
+			t.Errorf("results[%d].ReviewerLabel: got %q, want %q", i, r.ReviewerLabel, stage1[i].Label)
+		}
+	}
+}
+
+func TestRunStage2_ParseFailure_NilRankings_NoError(t *testing.T) {
+	client := &mockLLMClient{
+		complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+			return makeResponse("not valid json"), nil
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	results := c.runStage2(context.Background(), "q", stage1Fixture(), 0.7)
+
+	for i, r := range results {
+		if r.Error != nil {
+			t.Errorf("results[%d].Error: want nil on parse failure, got %v", i, r.Error)
+		}
+		if r.Rankings != nil {
+			t.Errorf("results[%d].Rankings: want nil on parse failure, got %v", i, r.Rankings)
+		}
+	}
+}
+
+func TestRunStage2_UnknownLabelsDropped(t *testing.T) {
+	client := &mockLLMClient{
+		complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+			return makeResponse(`{"rankings":["Response A","Response Z","Response B"]}`), nil
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	results := c.runStage2(context.Background(), "q", stage1Fixture(), 0.7)
+
+	for i, r := range results {
+		for _, label := range r.Rankings {
+			if label == "Response Z" {
+				t.Errorf("results[%d].Rankings: unknown label %q not dropped", i, label)
+			}
+		}
+		// "Response A" and "Response B" should remain
+		if len(r.Rankings) != 2 {
+			t.Errorf("results[%d].Rankings len: got %d, want 2", i, len(r.Rankings))
+		}
+	}
+}
+
+func TestRunStage2_LLMFailure_SetsError(t *testing.T) {
+	errBoom := errors.New("api error")
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			if req.Model == "model-b" {
+				return CompletionResponse{}, errBoom
+			}
+			return makeResponse(`{"rankings":["Response A","Response B","Response C"]}`), nil
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	results := c.runStage2(context.Background(), "q", stage1Fixture(), 0.7)
+
+	if results[0].Error != nil {
+		t.Errorf("results[0].Error: unexpected %v", results[0].Error)
+	}
+	if !errors.Is(results[1].Error, errBoom) {
+		t.Errorf("results[1].Error: got %v, want errBoom", results[1].Error)
+	}
+	if results[2].Error != nil {
+		t.Errorf("results[2].Error: unexpected %v", results[2].Error)
+	}
+}
+
+func TestRunStage2_JsonObjectFormatRequested(t *testing.T) {
+	var gotFormat *ResponseFormat
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			gotFormat = req.ResponseFormat
+			return makeResponse(`{"rankings":["Response A"]}`), nil
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	c.runStage2(context.Background(), "q", stage1Fixture()[:1], 0.7)
+
+	if gotFormat == nil {
+		t.Fatal("ResponseFormat: want non-nil, got nil")
+	}
+	if gotFormat.Type != "json_object" {
+		t.Errorf("ResponseFormat.Type: got %q, want %q", gotFormat.Type, "json_object")
+	}
+}

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -205,6 +205,37 @@ func TestRunStage2_UnknownLabelsDropped(t *testing.T) {
 	}
 }
 
+func TestRunStage2_EmptyOrMissingRankings_TreatedAsMissing(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"missing rankings field", `{}`},
+		{"null rankings", `{"rankings":null}`},
+		{"empty rankings array", `{"rankings":[]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &mockLLMClient{
+				complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+					return makeResponse(tc.payload), nil
+				},
+			}
+			c := NewCouncil(client, nil, nil)
+			results := c.runStage2(context.Background(), "q", stage1Fixture(), 0.7)
+
+			for i, r := range results {
+				if r.Error != nil {
+					t.Errorf("results[%d].Error: want nil, got %v", i, r.Error)
+				}
+				if r.Rankings != nil {
+					t.Errorf("results[%d].Rankings: want nil, got %v", i, r.Rankings)
+				}
+			}
+		})
+	}
+}
+
 func TestRunStage2_LLMFailure_SetsError(t *testing.T) {
 	errBoom := errors.New("api error")
 	client := &mockLLMClient{


### PR DESCRIPTION
## Summary
- Add `runStage2` to `Council` in `internal/council/runner.go`
- All stage1 models queried concurrently as reviewers via `sync.WaitGroup`
- Each request uses `ResponseFormat: &ResponseFormat{Type: "json_object"}`
- Parses `{"rankings": [...]}` — parse failures logged (`slog.Warn`) with nil Rankings (midrank imputation handles them)
- Unknown labels validated and dropped with a warning
- LLM call failures stored in `StageTwoResult.Error`; returns all results

Closes #83

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (5 new cases: all succeed, parse failure → nil rankings, unknown labels dropped, LLM failure, json_object format asserted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)