### PR TITLE
⚡ task(council): implement Stage 3 Chairman synthesis

### DIFF
--- a/internal/council/council_test.go
+++ b/internal/council/council_test.go
@@ -134,7 +134,7 @@ func TestAssignLabels_LabelsAreLetters(t *testing.T) {
 // ── BuildStage3Prompt (W-guidance injection) ─────────────────────────────────
 
 func TestBuildStage3Prompt_StrongConsensus(t *testing.T) {
-	msgs := BuildStage3Prompt("Why is the sky blue?", nil, nil, 0.75)
+	msgs := BuildStage3Prompt("Why is the sky blue?", nil, nil, 0.75, nil)
 	if len(msgs) == 0 {
 		t.Fatal("expected non-empty messages")
 	}
@@ -145,7 +145,7 @@ func TestBuildStage3Prompt_StrongConsensus(t *testing.T) {
 }
 
 func TestBuildStage3Prompt_ModerateConsensus(t *testing.T) {
-	msgs := BuildStage3Prompt("Why is the sky blue?", nil, nil, 0.55)
+	msgs := BuildStage3Prompt("Why is the sky blue?", nil, nil, 0.55, nil)
 	content := msgs[0].Content
 	if !strings.Contains(content, "moderate consensus") {
 		t.Errorf("W=0.55: expected 'moderate consensus' in prompt, got:\n%s", content)
@@ -153,7 +153,7 @@ func TestBuildStage3Prompt_ModerateConsensus(t *testing.T) {
 }
 
 func TestBuildStage3Prompt_NoConsensus(t *testing.T) {
-	msgs := BuildStage3Prompt("Why is the sky blue?", nil, nil, 0.30)
+	msgs := BuildStage3Prompt("Why is the sky blue?", nil, nil, 0.30, nil)
 	content := msgs[0].Content
 	if !strings.Contains(content, "did not reach consensus") {
 		t.Errorf("W=0.30: expected 'did not reach consensus' in prompt, got:\n%s", content)
@@ -171,7 +171,7 @@ func TestBuildStage3Prompt_StructuredAttribution(t *testing.T) {
 		"Response B": "openai/gpt-4o",
 		"Response C": "google/gemini-flash",
 	}
-	msgs := BuildStage3Prompt("test query", rankings, labelToModel, 0.72)
+	msgs := BuildStage3Prompt("test query", rankings, labelToModel, 0.72, nil)
 	content := msgs[0].Content
 
 	if !strings.Contains(content, "openai/gpt-4o") {

--- a/internal/council/prompts.go
+++ b/internal/council/prompts.go
@@ -46,10 +46,11 @@ func BuildStage2Prompt(query string, labeledResponses map[string]string) []ChatM
 }
 
 // BuildStage3Prompt returns the messages for the Stage 3 Chairman synthesis request.
-// Rankings are built from Go structs — no raw LLM text is passed through,
+// labeledResponses contains the Stage 1 candidate answers (label → content).
+// Rankings are built from Go structs — Stage 2 reviewer prose is never passed through,
 // preventing prompt injection from Stage 2 model output.
 // Kendall's W drives the synthesis guidance injected into the prompt.
-func BuildStage3Prompt(query string, rankings []StageTwoResult, labelToModel map[string]string, consensusW float64) []ChatMessage {
+func BuildStage3Prompt(query string, rankings []StageTwoResult, labelToModel map[string]string, consensusW float64, labeledResponses map[string]string) []ChatMessage {
 	var guidance string
 	switch {
 	case consensusW >= 0.70:
@@ -76,6 +77,23 @@ func BuildStage3Prompt(query string, rankings []StageTwoResult, labelToModel map
 	var sb strings.Builder
 	sb.WriteString("You were asked to answer:\n\n")
 	sb.WriteString(query)
+
+	// Include Stage 1 candidate responses so the Chairman can synthesize their content.
+	if len(labeledResponses) > 0 {
+		labels := make([]string, 0, len(labeledResponses))
+		for l := range labeledResponses {
+			labels = append(labels, l)
+		}
+		sort.Strings(labels)
+		sb.WriteString("\n\nCandidate responses:\n")
+		for _, label := range labels {
+			sb.WriteString("\n## ")
+			sb.WriteString(label)
+			sb.WriteString("\n")
+			sb.WriteString(labeledResponses[label])
+		}
+	}
+
 	sb.WriteString("\n\n")
 	sb.WriteString(guidance)
 	sb.WriteString("\n\nPeer review rankings (structured attribution — best to worst):\n")

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -141,4 +142,26 @@ func (c *Council) runStage2(ctx context.Context, query string, stage1 []StageOne
 	}
 	wg.Wait()
 	return results
+}
+
+// runStage3 calls the Chairman model to synthesize a final answer from the
+// Stage 2 peer-review rankings. Sequential — single LLM call, no concurrency.
+func (c *Council) runStage3(ctx context.Context, query string, stage2 []StageTwoResult, labelToModel map[string]string, consensusW float64, chairmanModel string) (StageThreeResult, error) {
+	start := time.Now()
+	resp, err := c.client.Complete(ctx, CompletionRequest{
+		Model:    chairmanModel,
+		Messages: BuildStage3Prompt(query, stage2, labelToModel, consensusW),
+	})
+	elapsed := time.Since(start).Milliseconds()
+	if err != nil {
+		return StageThreeResult{Model: chairmanModel, DurationMs: elapsed}, fmt.Errorf("stage3: %w", err)
+	}
+	if len(resp.Choices) == 0 {
+		return StageThreeResult{Model: chairmanModel, DurationMs: elapsed}, fmt.Errorf("stage3: %w", errNoChoices)
+	}
+	return StageThreeResult{
+		Content:    resp.Choices[0].Message.Content,
+		Model:      chairmanModel,
+		DurationMs: elapsed,
+	}, nil
 }

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -145,12 +145,13 @@ func (c *Council) runStage2(ctx context.Context, query string, stage1 []StageOne
 }
 
 // runStage3 calls the Chairman model to synthesize a final answer from the
-// Stage 2 peer-review rankings. Sequential — single LLM call, no concurrency.
-func (c *Council) runStage3(ctx context.Context, query string, stage2 []StageTwoResult, labelToModel map[string]string, consensusW float64, chairmanModel string) (StageThreeResult, error) {
+// Stage 1 responses and Stage 2 peer-review rankings. Sequential — single LLM call.
+func (c *Council) runStage3(ctx context.Context, query string, stage2 []StageTwoResult, labelToModel map[string]string, consensusW float64, chairmanModel string, temperature float64, labeledResponses map[string]string) (StageThreeResult, error) {
 	start := time.Now()
 	resp, err := c.client.Complete(ctx, CompletionRequest{
-		Model:    chairmanModel,
-		Messages: BuildStage3Prompt(query, stage2, labelToModel, consensusW),
+		Model:       chairmanModel,
+		Messages:    BuildStage3Prompt(query, stage2, labelToModel, consensusW, labeledResponses),
+		Temperature: temperature,
 	})
 	elapsed := time.Since(start).Milliseconds()
 	if err != nil {

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -3,6 +3,7 @@ package council
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -272,7 +273,8 @@ func TestRunStage3_Success(t *testing.T) {
 	result, err := c.runStage3(context.Background(), "q",
 		[]StageTwoResult{{ReviewerLabel: "Response A", Rankings: []string{"Response A", "Response B"}}},
 		map[string]string{"Response A": "model-a", "Response B": "model-b"},
-		0.75, "chairman-model",
+		0.75, "chairman-model", 0.3,
+		map[string]string{"Response A": "answer A", "Response B": "answer B"},
 	)
 
 	if err != nil {
@@ -297,7 +299,7 @@ func TestRunStage3_ClientError_WrappedAndModelPreserved(t *testing.T) {
 		},
 	}
 	c := NewCouncil(client, nil, nil)
-	result, err := c.runStage3(context.Background(), "q", nil, nil, 0.5, "chairman-model")
+	result, err := c.runStage3(context.Background(), "q", nil, nil, 0.5, "chairman-model", 0.3, nil)
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -317,7 +319,7 @@ func TestRunStage3_EmptyChoices_WrappedError(t *testing.T) {
 		},
 	}
 	c := NewCouncil(client, nil, nil)
-	_, err := c.runStage3(context.Background(), "q", nil, nil, 0.5, "chairman-model")
+	_, err := c.runStage3(context.Background(), "q", nil, nil, 0.5, "chairman-model", 0.3, nil)
 
 	if err == nil {
 		t.Fatal("expected error for empty choices, got nil")
@@ -336,10 +338,34 @@ func TestRunStage3_UsesChairmanModel(t *testing.T) {
 		},
 	}
 	c := NewCouncil(client, nil, nil)
-	c.runStage3(context.Background(), "q", nil, nil, 0.5, "my-chairman") //nolint:errcheck
+	c.runStage3(context.Background(), "q", nil, nil, 0.5, "my-chairman", 0.3, nil) //nolint:errcheck
 
 	if gotModel != "my-chairman" {
 		t.Errorf("Model: got %q, want %q", gotModel, "my-chairman")
+	}
+}
+
+func TestRunStage3_Stage1ContentAndTemperatureForwarded(t *testing.T) {
+	var gotReq CompletionRequest
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			gotReq = req
+			return makeResponse("ok"), nil
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	c.runStage3(context.Background(), "q", nil, nil, 0.5, "chairman", 0.3, //nolint:errcheck
+		map[string]string{"Response A": "the actual answer"},
+	)
+
+	if gotReq.Temperature != 0.3 {
+		t.Errorf("Temperature: got %v, want 0.3", gotReq.Temperature)
+	}
+	if len(gotReq.Messages) == 0 {
+		t.Fatal("Messages: empty")
+	}
+	if !strings.Contains(gotReq.Messages[0].Content, "the actual answer") {
+		t.Error("stage1 content missing from chairman prompt")
 	}
 }
 

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -260,6 +260,89 @@ func TestRunStage2_LLMFailure_SetsError(t *testing.T) {
 	}
 }
 
+// ── runStage3 ─────────────────────────────────────────────────────────────────
+
+func TestRunStage3_Success(t *testing.T) {
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			return makeResponse("synthesized answer"), nil
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	result, err := c.runStage3(context.Background(), "q",
+		[]StageTwoResult{{ReviewerLabel: "Response A", Rankings: []string{"Response A", "Response B"}}},
+		map[string]string{"Response A": "model-a", "Response B": "model-b"},
+		0.75, "chairman-model",
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Content != "synthesized answer" {
+		t.Errorf("Content: got %q, want %q", result.Content, "synthesized answer")
+	}
+	if result.Model != "chairman-model" {
+		t.Errorf("Model: got %q, want %q", result.Model, "chairman-model")
+	}
+	if result.DurationMs < 0 {
+		t.Errorf("DurationMs: negative %d", result.DurationMs)
+	}
+}
+
+func TestRunStage3_ClientError_WrappedAndModelPreserved(t *testing.T) {
+	errBoom := errors.New("network failure")
+	client := &mockLLMClient{
+		complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+			return CompletionResponse{}, errBoom
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	result, err := c.runStage3(context.Background(), "q", nil, nil, 0.5, "chairman-model")
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, errBoom) {
+		t.Errorf("error chain: want errBoom, got %v", err)
+	}
+	if result.Model != "chairman-model" {
+		t.Errorf("Model: got %q, want %q on error", result.Model, "chairman-model")
+	}
+}
+
+func TestRunStage3_EmptyChoices_WrappedError(t *testing.T) {
+	client := &mockLLMClient{
+		complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+			return CompletionResponse{}, nil
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	_, err := c.runStage3(context.Background(), "q", nil, nil, 0.5, "chairman-model")
+
+	if err == nil {
+		t.Fatal("expected error for empty choices, got nil")
+	}
+	if !errors.Is(err, errNoChoices) {
+		t.Errorf("error chain: want errNoChoices, got %v", err)
+	}
+}
+
+func TestRunStage3_UsesChairmanModel(t *testing.T) {
+	var gotModel string
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			gotModel = req.Model
+			return makeResponse("ok"), nil
+		},
+	}
+	c := NewCouncil(client, nil, nil)
+	c.runStage3(context.Background(), "q", nil, nil, 0.5, "my-chairman") //nolint:errcheck
+
+	if gotModel != "my-chairman" {
+		t.Errorf("Model: got %q, want %q", gotModel, "my-chairman")
+	}
+}
+
 func TestRunStage2_JsonObjectFormatRequested(t *testing.T) {
 	var gotFormat *ResponseFormat
 	client := &mockLLMClient{


### PR DESCRIPTION
## Summary
- Add `runStage3` to `Council` in `internal/council/runner.go`
- Single sequential `Complete` call using the Chairman model
- Uses `BuildStage3Prompt` with structured rankings + Kendall's W guidance (no raw Stage 2 prose)
- Returns `StageThreeResult{Content, Model, DurationMs}` on success
- Wraps errors with `"stage3:"` prefix; treats empty choices as `errNoChoices`

Closes #85

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (4 new cases: success, client error wrapped, empty choices error, chairman model forwarded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)