### PR TITLE
⚖️ task(council): implement RunFull LCCP Core orchestration

### DIFF
--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 )
@@ -71,16 +72,27 @@ func (c *Council) RunFull(ctx context.Context, query string, councilTypeName str
 	stage2Results := c.runStage2(ctx, query, successful, ct.Temperature)
 
 	// Compute aggregate rankings and Kendall's W consensus coefficient.
+	// Sort labels for deterministic ranking output across runs.
 	allLabels := make([]string, 0, len(labelToModel))
 	for label := range labelToModel {
 		allLabels = append(allLabels, label)
 	}
+	sort.Strings(allLabels)
 	aggregateRankings, consensusW := CalculateAggregateRankings(stage2Results, allLabels)
+
+	// Translate label-keyed RankedModel entries to real model names for persistence/API.
+	rankedByModel := make([]RankedModel, len(aggregateRankings))
+	for i, r := range aggregateRankings {
+		if model, ok := labelToModel[r.Model]; ok {
+			r.Model = model
+		}
+		rankedByModel[i] = r
+	}
 
 	metadata := Metadata{
 		CouncilType:       councilTypeName,
 		LabelToModel:      labelToModel,
-		AggregateRankings: aggregateRankings,
+		AggregateRankings: rankedByModel,
 		ConsensusW:        consensusW,
 	}
 

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -10,7 +10,6 @@ import (
 	"time"
 )
 
-var errNotImplemented = errors.New("council: RunFull not yet implemented")
 var errNoChoices = errors.New("council: completion response contained no choices")
 
 // Council orchestrates the full multi-stage deliberation pipeline.
@@ -34,10 +33,76 @@ func NewCouncil(client LLMClient, registry map[string]CouncilType, logger *slog.
 // Compile-time assertion: Council implements Runner.
 var _ Runner = (*Council)(nil)
 
-// RunFull orchestrates a full council deliberation.
-// Stub — returns errNotImplemented until #86 is implemented.
-func (c *Council) RunFull(_ context.Context, _ string, _ string, _ EventFunc) error {
-	return errNotImplemented
+// RunFull orchestrates the full LCCP Core deliberation pipeline:
+// label assignment → Stage 1 → quorum check → Stage 2 → Kendall's W → Stage 3.
+// Events are emitted synchronously via onEvent so the caller can flush after each.
+// Returns *QuorumError immediately if stage 1 quorum is not met (no stage2/3 events).
+// Returns an error for unknown councilTypeName or stage 3 failures.
+func (c *Council) RunFull(ctx context.Context, query string, councilTypeName string, onEvent EventFunc) error {
+	ct, ok := c.registry[councilTypeName]
+	if !ok {
+		return fmt.Errorf("council: unknown council type %q", councilTypeName)
+	}
+
+	// Stage 1 — parallel generation across all configured models.
+	allStage1 := c.runStage1(ctx, query, ct.Models, ct.Temperature)
+
+	// Quorum check — returns *QuorumError if not enough models succeeded.
+	successful, err := checkQuorum(allStage1, ct.QuorumMin)
+	if err != nil {
+		return err
+	}
+
+	// Assign anonymous labels so peer reviewers cannot identify each other.
+	successfulModels := make([]string, len(successful))
+	for i, r := range successful {
+		successfulModels[i] = r.Model
+	}
+	labelToModel, modelToLabel := assignLabels(successfulModels)
+	for i := range successful {
+		successful[i].Label = modelToLabel[successful[i].Model]
+	}
+
+	if onEvent != nil {
+		onEvent("stage1_complete", successful)
+	}
+
+	// Stage 2 — parallel peer review.
+	stage2Results := c.runStage2(ctx, query, successful, ct.Temperature)
+
+	// Compute aggregate rankings and Kendall's W consensus coefficient.
+	allLabels := make([]string, 0, len(labelToModel))
+	for label := range labelToModel {
+		allLabels = append(allLabels, label)
+	}
+	aggregateRankings, consensusW := CalculateAggregateRankings(stage2Results, allLabels)
+
+	metadata := Metadata{
+		CouncilType:       councilTypeName,
+		LabelToModel:      labelToModel,
+		AggregateRankings: aggregateRankings,
+		ConsensusW:        consensusW,
+	}
+
+	if onEvent != nil {
+		onEvent("stage2_complete", Stage2CompleteData{Results: stage2Results, Metadata: metadata})
+	}
+
+	// Stage 3 — Chairman synthesis.
+	labeledResponses := make(map[string]string, len(successful))
+	for _, r := range successful {
+		labeledResponses[r.Label] = r.Content
+	}
+	stage3Result, err := c.runStage3(ctx, query, stage2Results, labelToModel, consensusW, ct.ChairmanModel, ct.Temperature, labeledResponses)
+	if err != nil {
+		return err
+	}
+
+	if onEvent != nil {
+		onEvent("stage3_complete", stage3Result)
+	}
+
+	return nil
 }
 
 // runStage1 sends query to all models concurrently and returns all results.

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -387,3 +387,126 @@ func TestRunStage2_JsonObjectFormatRequested(t *testing.T) {
 		t.Errorf("ResponseFormat.Type: got %q, want %q", gotFormat.Type, "json_object")
 	}
 }
+
+// ── RunFull ───────────────────────────────────────────────────────────────────
+
+// councilFixture returns a registry with one council type containing 3 models.
+func councilFixture() map[string]CouncilType {
+	return map[string]CouncilType{
+		"default": {
+			Name:          "default",
+			Strategy:      PeerReview,
+			Models:        []string{"model-a", "model-b", "model-c"},
+			ChairmanModel: "chairman",
+			Temperature:   0.7,
+		},
+	}
+}
+
+// fullPipelineClient returns a mock client that succeeds for all calls:
+// stage1 returns prose, stage2 returns valid rankings JSON, stage3 returns synthesis.
+func fullPipelineClient(t *testing.T) *mockLLMClient {
+	t.Helper()
+	return &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			if req.ResponseFormat != nil && req.ResponseFormat.Type == "json_object" {
+				// Stage 2 reviewer — return valid rankings (labels not known at test time,
+				// so return an empty array; midrank imputation handles it).
+				return makeResponse(`{"rankings":[]}`), nil
+			}
+			// Stage 1 or Stage 3
+			return makeResponse("answer from " + req.Model), nil
+		},
+	}
+}
+
+func TestRunFull_UnknownCouncilType_ReturnsError(t *testing.T) {
+	c := NewCouncil(&mockLLMClient{}, councilFixture(), nil)
+	err := c.RunFull(context.Background(), "q", "unknown-type", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown council type, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown council type") {
+		t.Errorf("error message: got %q, want 'unknown council type'", err.Error())
+	}
+}
+
+func TestRunFull_QuorumFailure_ReturnsQuorumError(t *testing.T) {
+	// All 3 models fail → quorum not met.
+	client := &mockLLMClient{
+		complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+			return CompletionResponse{}, errors.New("model unavailable")
+		},
+	}
+	c := NewCouncil(client, councilFixture(), nil)
+	err := c.RunFull(context.Background(), "q", "default", nil)
+
+	var qe *QuorumError
+	if !errors.As(err, &qe) {
+		t.Fatalf("expected *QuorumError, got %T: %v", err, err)
+	}
+}
+
+func TestRunFull_QuorumFailure_NoStage2Or3Events(t *testing.T) {
+	client := &mockLLMClient{
+		complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+			return CompletionResponse{}, errors.New("model unavailable")
+		},
+	}
+	c := NewCouncil(client, councilFixture(), nil)
+
+	var emitted []string
+	_ = c.RunFull(context.Background(), "q", "default", func(eventType string, _ any) {
+		emitted = append(emitted, eventType)
+	})
+
+	for _, et := range emitted {
+		if et == "stage2_complete" || et == "stage3_complete" {
+			t.Errorf("unexpected event %q emitted after quorum failure", et)
+		}
+	}
+}
+
+func TestRunFull_HappyPath_EmitsAllThreeEvents(t *testing.T) {
+	c := NewCouncil(fullPipelineClient(t), councilFixture(), nil)
+
+	var emitted []string
+	err := c.RunFull(context.Background(), "q", "default", func(eventType string, _ any) {
+		emitted = append(emitted, eventType)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"stage1_complete", "stage2_complete", "stage3_complete"}
+	if len(emitted) != len(want) {
+		t.Fatalf("events: got %v, want %v", emitted, want)
+	}
+	for i, e := range emitted {
+		if e != want[i] {
+			t.Errorf("events[%d]: got %q, want %q", i, e, want[i])
+		}
+	}
+}
+
+func TestRunFull_Stage2CompletePayload_IsStage2CompleteData(t *testing.T) {
+	c := NewCouncil(fullPipelineClient(t), councilFixture(), nil)
+
+	var stage2Data any
+	_ = c.RunFull(context.Background(), "q", "default", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			stage2Data = data
+		}
+	})
+
+	d, ok := stage2Data.(Stage2CompleteData)
+	if !ok {
+		t.Fatalf("stage2_complete payload: got %T, want Stage2CompleteData", stage2Data)
+	}
+	if d.Metadata.CouncilType != "default" {
+		t.Errorf("Metadata.CouncilType: got %q, want %q", d.Metadata.CouncilType, "default")
+	}
+	if len(d.Metadata.LabelToModel) == 0 {
+		t.Error("Metadata.LabelToModel: empty")
+	}
+}

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -2,6 +2,7 @@ package council
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -403,18 +404,38 @@ func councilFixture() map[string]CouncilType {
 	}
 }
 
+// labelsFromPrompt extracts "Response X" labels from a stage-2 prompt by looking
+// for "## Response " heading lines (format produced by BuildStage2Prompt).
+func labelsFromPrompt(content string) []string {
+	var labels []string
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(line, "## Response ") {
+			labels = append(labels, strings.TrimPrefix(line, "## "))
+		}
+	}
+	return labels
+}
+
 // fullPipelineClient returns a mock client that succeeds for all calls:
-// stage1 returns prose, stage2 returns valid rankings JSON, stage3 returns synthesis.
+// stage1 returns prose, stage2 extracts labels from the prompt and returns them
+// as rankings (so CalculateAggregateRankings produces non-nil output), stage3
+// returns a synthesis string.
 func fullPipelineClient(t *testing.T) *mockLLMClient {
 	t.Helper()
 	return &mockLLMClient{
 		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
 			if req.ResponseFormat != nil && req.ResponseFormat.Type == "json_object" {
-				// Stage 2 reviewer — return valid rankings (labels not known at test time,
-				// so return an empty array; midrank imputation handles it).
-				return makeResponse(`{"rankings":[]}`), nil
+				// Stage 2 reviewer — derive labels from the prompt so rankings are valid.
+				var labels []string
+				if len(req.Messages) > 0 {
+					labels = labelsFromPrompt(req.Messages[0].Content)
+				}
+				type rankResp struct {
+					Rankings []string `json:"rankings"`
+				}
+				b, _ := json.Marshal(rankResp{Rankings: labels})
+				return makeResponse(string(b)), nil
 			}
-			// Stage 1 or Stage 3
 			return makeResponse("answer from " + req.Model), nil
 		},
 	}
@@ -508,5 +529,18 @@ func TestRunFull_Stage2CompletePayload_IsStage2CompleteData(t *testing.T) {
 	}
 	if len(d.Metadata.LabelToModel) == 0 {
 		t.Error("Metadata.LabelToModel: empty")
+	}
+	// AggregateRankings must be non-empty and contain real model names, not labels.
+	if len(d.Metadata.AggregateRankings) == 0 {
+		t.Error("Metadata.AggregateRankings: empty")
+	}
+	expectedModels := map[string]bool{"model-a": true, "model-b": true, "model-c": true}
+	for _, r := range d.Metadata.AggregateRankings {
+		if strings.HasPrefix(r.Model, "Response ") {
+			t.Errorf("AggregateRankings entry %q contains a label instead of a model name", r.Model)
+		}
+		if !expectedModels[r.Model] {
+			t.Errorf("AggregateRankings entry %q is not a known model", r.Model)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Replace `RunFull` stub with full LCCP pipeline: Stage 1 → quorum → labels → Stage 2 → Kendall's W → Stage 3
- Returns error for unknown `councilTypeName`; returns `*QuorumError` immediately on quorum failure (no stage2/3 events)
- Emits `stage1_complete`, `stage2_complete` (`Stage2CompleteData` with consensus metadata), `stage3_complete` via synchronous `onEvent` callback
- Removes the now-unused `errNotImplemented` sentinel

Closes #86

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (5 new cases: unknown type error, quorum failure error, quorum failure emits no stage2/3 events, happy path emits all 3 events, stage2_complete payload is `Stage2CompleteData` with metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)