### PR TITLE
⚖️ feat(api): implement blocking SendMessage handler

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -8,9 +8,15 @@ import (
 	"net/http"
 	"regexp"
 	"time"
+	"unicode/utf8"
 
 	"github.com/valpere/llm-council/internal/council"
 	"github.com/valpere/llm-council/internal/storage"
+)
+
+const (
+	maxRequestBodyBytes = 1 << 20 // 1 MiB
+	maxTitleRunes       = 50
 )
 
 var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
@@ -147,6 +153,7 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 		Content     string `json:"content"`
 		CouncilType string `json:"council_type"`
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Content == "" {
 		h.writeError(w, http.StatusBadRequest, "invalid request body")
 		return
@@ -217,8 +224,9 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	title := msg.Stage3.Content
-	if len(title) > 50 {
-		title = title[:50]
+	if utf8.RuneCountInString(title) > maxTitleRunes {
+		runes := []rune(title)
+		title = string(runes[:maxTitleRunes])
 	}
 	if err := h.storage.SaveTitle(id, title); err != nil {
 		h.logger.Warn("save title", "id", id, "error", err)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -136,9 +136,95 @@ func (h *Handler) getConversation(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, http.StatusOK, conv)
 }
 
-// sendMessage is a stub; implemented in a later milestone.
 func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusNotImplemented)
+	id := r.PathValue("id")
+	if !uuidRE.MatchString(id) {
+		h.writeError(w, http.StatusBadRequest, "invalid conversation id")
+		return
+	}
+
+	var body struct {
+		Content     string `json:"content"`
+		CouncilType string `json:"council_type"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Content == "" {
+		h.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if err := h.storage.SaveUserMessage(id, body.Content); err != nil {
+		var nfe *storage.NotFoundError
+		if errors.As(err, &nfe) {
+			h.writeError(w, http.StatusNotFound, "not found")
+			return
+		}
+		h.logger.Error("save user message", "id", id, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	councilType := body.CouncilType
+	if councilType == "" {
+		councilType = h.defaultCouncilType
+	}
+
+	var (
+		stage1Results []council.StageOneResult
+		stage2Data    council.Stage2CompleteData
+		stage3Result  council.StageThreeResult
+	)
+	onEvent := func(eventType string, data any) {
+		switch eventType {
+		case "stage1_complete":
+			if r, ok := data.([]council.StageOneResult); ok {
+				stage1Results = r
+			}
+		case "stage2_complete":
+			if d, ok := data.(council.Stage2CompleteData); ok {
+				stage2Data = d
+			}
+		case "stage3_complete":
+			if r, ok := data.(council.StageThreeResult); ok {
+				stage3Result = r
+			}
+		}
+	}
+
+	if err := h.runner.RunFull(r.Context(), body.Content, councilType, onEvent); err != nil {
+		var qe *council.QuorumError
+		if errors.As(err, &qe) {
+			h.logger.Warn("council quorum not met", "id", id, "got", qe.Got, "need", qe.Need)
+			h.writeError(w, http.StatusServiceUnavailable, "council quorum not met")
+		} else {
+			h.logger.Error("council run", "id", id, "error", err)
+			h.writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	msg := council.AssistantMessage{
+		Role:     "assistant",
+		Stage1:   stage1Results,
+		Stage2:   stage2Data.Results,
+		Stage3:   stage3Result,
+		Metadata: stage2Data.Metadata,
+	}
+
+	if err := h.storage.SaveAssistantMessage(id, msg); err != nil {
+		h.logger.Error("save assistant message", "id", id, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	title := msg.Stage3.Content
+	if len(title) > 50 {
+		title = title[:50]
+	}
+	if err := h.storage.SaveTitle(id, title); err != nil {
+		h.logger.Warn("save title", "id", id, "error", err)
+	}
+
+	h.writeJSON(w, http.StatusOK, msg)
 }
 
 // sseEnvelope is the JSON shape of every SSE data line.

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -259,6 +259,213 @@ func TestGetConversation(t *testing.T) {
 	}
 }
 
+// ── SendMessage (blocking) ───────────────────────────────────────────────────
+
+func TestSendMessage(t *testing.T) {
+	successRunner := &mockRunner{
+		runFull: func(_ context.Context, query, ct string, onEvent council.EventFunc) error {
+			onEvent("stage1_complete", []council.StageOneResult{
+				{Label: "Response A", Content: "answer A", Model: "model-a"},
+			})
+			onEvent("stage2_complete", council.Stage2CompleteData{
+				Results: []council.StageTwoResult{
+					{ReviewerLabel: "Response A", Rankings: []string{"Response A"}},
+				},
+				Metadata: council.Metadata{
+					CouncilType:  ct,
+					ConsensusW:   0.9,
+					LabelToModel: map[string]string{"Response A": "model-a"},
+				},
+			})
+			onEvent("stage3_complete", council.StageThreeResult{Content: "synthesized answer", Model: "chairman"})
+			return nil
+		},
+	}
+
+	tests := []struct {
+		name      string
+		id        string
+		body      string
+		storer    *mockStorer
+		runner    *mockRunner
+		wantCode  int
+		checkBody func(t *testing.T, body string)
+	}{
+		{
+			name:     "happy path returns 200 AssistantMessage with metadata",
+			id:       testConvID,
+			body:     `{"content":"why is the sky blue?","council_type":"standard"}`,
+			storer:   okStorer(),
+			runner:   successRunner,
+			wantCode: http.StatusOK,
+			checkBody: func(t *testing.T, body string) {
+				var msg council.AssistantMessage
+				if err := json.Unmarshal([]byte(strings.TrimSpace(body)), &msg); err != nil {
+					t.Fatalf("parse body: %v", err)
+				}
+				if msg.Role != "assistant" {
+					t.Errorf("Role: got %q, want %q", msg.Role, "assistant")
+				}
+				if len(msg.Stage1) != 1 {
+					t.Errorf("Stage1 len: got %d, want 1", len(msg.Stage1))
+				}
+				if msg.Stage3.Content != "synthesized answer" {
+					t.Errorf("Stage3.Content: got %q, want %q", msg.Stage3.Content, "synthesized answer")
+				}
+				if msg.Metadata.ConsensusW != 0.9 {
+					t.Errorf("Metadata.ConsensusW: got %f, want 0.9", msg.Metadata.ConsensusW)
+				}
+				if msg.Metadata.LabelToModel["Response A"] != "model-a" {
+					t.Errorf("Metadata.LabelToModel: got %v", msg.Metadata.LabelToModel)
+				}
+			},
+		},
+		{
+			name:   "council_type defaults to handler default when omitted",
+			id:     testConvID,
+			body:   `{"content":"test query"}`,
+			storer: okStorer(),
+			runner: &mockRunner{
+				runFull: func(_ context.Context, _, ct string, onEvent council.EventFunc) error {
+					if ct != "standard" {
+						t.Errorf("council_type: got %q, want %q", ct, "standard")
+					}
+					onEvent("stage3_complete", council.StageThreeResult{Content: "ok"})
+					return nil
+				},
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "400 invalid UUID",
+			id:       "not-a-uuid",
+			body:     `{"content":"test"}`,
+			storer:   &mockStorer{},
+			runner:   &mockRunner{},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "400 missing content",
+			id:       testConvID,
+			body:     `{"content":""}`,
+			storer:   &mockStorer{},
+			runner:   &mockRunner{},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "400 malformed JSON body",
+			id:       testConvID,
+			body:     `not json`,
+			storer:   &mockStorer{},
+			runner:   &mockRunner{},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "404 conversation not found on save user message",
+			id:   testConvID,
+			body: `{"content":"test"}`,
+			storer: &mockStorer{
+				saveUserMessage: func(id, _ string) error {
+					return &storage.NotFoundError{ID: id}
+				},
+			},
+			runner:   &mockRunner{},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name: "503 QuorumError from RunFull",
+			id:   testConvID,
+			body: `{"content":"test"}`,
+			storer: okStorer(),
+			runner: &mockRunner{
+				runFull: func(_ context.Context, _, _ string, _ council.EventFunc) error {
+					return &council.QuorumError{Got: 1, Need: 3}
+				},
+			},
+			wantCode: http.StatusServiceUnavailable,
+			checkBody: func(t *testing.T, body string) {
+				var resp map[string]string
+				if err := json.Unmarshal([]byte(strings.TrimSpace(body)), &resp); err != nil {
+					t.Fatalf("parse body: %v", err)
+				}
+				if resp["error"] == "" {
+					t.Errorf("error field missing: %v", resp)
+				}
+			},
+		},
+		{
+			name: "500 generic RunFull error",
+			id:   testConvID,
+			body: `{"content":"test"}`,
+			storer: okStorer(),
+			runner: &mockRunner{
+				runFull: func(_ context.Context, _, _ string, _ council.EventFunc) error {
+					return errors.New("chairman failed")
+				},
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name: "500 on save assistant message failure",
+			id:   testConvID,
+			body: `{"content":"test"}`,
+			storer: &mockStorer{
+				saveUserMessage: func(string, string) error { return nil },
+				saveAssistantMessage: func(string, council.AssistantMessage) error {
+					return errors.New("disk full")
+				},
+				saveTitle: func(string, string) error { return nil },
+			},
+			runner:   successRunner,
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name: "title truncated to 50 chars",
+			id:   testConvID,
+			body: `{"content":"test"}`,
+			storer: &mockStorer{
+				saveUserMessage:      func(string, string) error { return nil },
+				saveAssistantMessage: func(string, council.AssistantMessage) error { return nil },
+				saveTitle: func(_ string, title string) error {
+					if len(title) > 50 {
+						t.Errorf("title length: got %d, want ≤50", len(title))
+					}
+					return nil
+				},
+			},
+			runner: &mockRunner{
+				runFull: func(_ context.Context, _, _ string, onEvent council.EventFunc) error {
+					onEvent("stage3_complete", council.StageThreeResult{
+						Content: strings.Repeat("x", 100),
+					})
+					return nil
+				},
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(tc.storer, tc.runner)
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/conversations/"+tc.id+"/message",
+				bytes.NewBufferString(tc.body),
+			)
+			req.SetPathValue("id", tc.id)
+			w := httptest.NewRecorder()
+			h.sendMessage(w, req)
+			if w.Code != tc.wantCode {
+				t.Errorf("status: got %d, want %d\nbody: %s", w.Code, tc.wantCode, w.Body.String())
+			}
+			if tc.checkBody != nil {
+				tc.checkBody(t, w.Body.String())
+			}
+		})
+	}
+}
+
 // ── SendMessageStream ────────────────────────────────────────────────────────
 
 // okStorer returns a mockStorer that succeeds silently for all write operations.


### PR DESCRIPTION
## Summary

- Replaces the `NotImplemented` stub in `POST /api/conversations/{id}/message` with a full implementation
- Accepts `{"content": "...", "council_type": "..."}` body; falls back to handler default council type when `council_type` is omitted
- Saves user message → runs `RunFull` collecting all stage events → assembles `AssistantMessage` → persists → generates title synchronously → returns `200 AssistantMessage`
- `QuorumError` → `503 {"error":"council quorum not met"}`; all other errors → `500`
- 10 table-driven tests covering happy path, quorum failure, storage errors, 400/404/500 paths, and title truncation

Closes #90

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)