### PR TITLE
⚡ feat(frontend): display Kendall's W consensus score in Stage 2

### DIFF
--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -93,6 +93,7 @@ export default function ChatInterface({
                       rankings={msg.stage2}
                       labelToModel={msg.metadata?.label_to_model}
                       aggregateRankings={msg.metadata?.aggregate_rankings}
+                      consensusW={msg.metadata?.consensus_w}
                     />
                   )}
 

--- a/frontend/src/components/Stage2.css
+++ b/frontend/src/components/Stage2.css
@@ -151,3 +151,30 @@
   color: #999;
   font-size: 12px;
 }
+
+.consensus-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.consensus-strong {
+  background: #e6f4ea;
+  color: #1e7e34;
+  border: 1px solid #a8d5b5;
+}
+
+.consensus-moderate {
+  background: #fff8e1;
+  color: #8a6d00;
+  border: 1px solid #ffe082;
+}
+
+.consensus-weak {
+  background: #fdecea;
+  color: #b71c1c;
+  border: 1px solid #f5c6c6;
+}

--- a/frontend/src/components/Stage2.jsx
+++ b/frontend/src/components/Stage2.jsx
@@ -5,7 +5,13 @@ function modelShortName(model) {
   return model.split('/')[1] || model;
 }
 
-export default function Stage2({ rankings, labelToModel, aggregateRankings }) {
+function consensusLabel(w) {
+  if (w >= 0.70) return 'strong';
+  if (w >= 0.40) return 'moderate';
+  return 'weak';
+}
+
+export default function Stage2({ rankings, labelToModel, aggregateRankings, consensusW }) {
   const [activeTab, setActiveTab] = useState(0);
 
   if (!rankings || rankings.length === 0) {
@@ -15,6 +21,12 @@ export default function Stage2({ rankings, labelToModel, aggregateRankings }) {
   return (
     <div className="stage stage2">
       <h3 className="stage-title">Stage 2: Peer Rankings</h3>
+
+      {consensusW != null && consensusW > 0 && (
+        <div className={`consensus-badge consensus-${consensusLabel(consensusW)}`}>
+          Consensus: {consensusW.toFixed(2)} ({consensusLabel(consensusW)})
+        </div>
+      )}
 
       <h4>Individual Rankings</h4>
       <p className="stage-description">

--- a/frontend/src/components/Stage2.jsx
+++ b/frontend/src/components/Stage2.jsx
@@ -22,11 +22,14 @@ export default function Stage2({ rankings, labelToModel, aggregateRankings, cons
     <div className="stage stage2">
       <h3 className="stage-title">Stage 2: Peer Rankings</h3>
 
-      {consensusW != null && consensusW > 0 && (
-        <div className={`consensus-badge consensus-${consensusLabel(consensusW)}`}>
-          Consensus: {consensusW.toFixed(2)} ({consensusLabel(consensusW)})
-        </div>
-      )}
+      {consensusW != null && consensusW > 0 && (() => {
+        const label = consensusLabel(consensusW);
+        return (
+          <div className={`consensus-badge consensus-${label}`}>
+            Consensus: {consensusW.toFixed(2)} ({label})
+          </div>
+        );
+      })()}
 
       <h4>Individual Rankings</h4>
       <p className="stage-description">


### PR DESCRIPTION
## Summary

- Pipes `consensus_w` from `stage2_complete` SSE event metadata through `ChatInterface` to `Stage2`
- Renders a colour-coded inline badge: `"Consensus: 0.72 (strong)"` — green/amber/red for strong/moderate/weak
- Thresholds match backend: ≥0.70 strong, 0.40–0.69 moderate, <0.40 weak
- Badge is hidden when `consensus_w` is `0` or absent (graceful no-op for loaded history)

Closes #96

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)