### PR TITLE
feat(frontend): populate metadata from stored conversation on history load

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,7 +22,15 @@ function App() {
   const loadConversation = async (id) => {
     try {
       const conv = await api.getConversation(id);
-      setCurrentConversation(conv);
+      const messages = (conv.messages ?? []).map((msg) => {
+        if (msg.role !== 'assistant') return msg;
+        return {
+          loading: { stage1: false, stage2: false, stage3: false },
+          error: null,
+          ...msg,
+        };
+      });
+      setCurrentConversation({ ...conv, messages });
     } catch (error) {
       console.error('Failed to load conversation:', error);
     }


### PR DESCRIPTION
## Summary
- Normalise historical assistant messages in `loadConversation` by spreading `loading`/`error` defaults before the stored fields
- Stored `metadata` (including `label_to_model`, `aggregate_rankings`, `consensus_w`) is preserved via `...msg` spread
- Stage 2 de-anonymisation and Kendall's W consensus badge now render correctly when browsing past conversations
- Zero/absent `metadata` still handled gracefully via existing optional chaining in `ChatInterface`
- Architecture rule #3 respected — only `App.jsx` writes assistant message state

Closes #97

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Historical conversation loads show Stage 2 rankings with model names resolved
- [ ] Consensus badge displays for historical conversations with `consensus_w`
- [ ] New conversations still stream and render correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)