### PR TITLE
⚡ task(ci): add GitHub Actions CI workflow for Go backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  go:
+    name: Go backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Staticcheck
+        run: staticcheck ./...
+
+      - name: Test
+        run: go test ./... -race -count=1
+
+      - name: Build
+        run: go build ./...
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   go:
     name: Go backend
@@ -20,7 +23,7 @@ jobs:
           cache: true
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
 
       - name: Vet
         run: go vet ./...
@@ -29,7 +32,7 @@ jobs:
         run: staticcheck ./...
 
       - name: Test
-        run: go test ./... -race -count=1
+        run: go test -race -count=1 ./...
 
       - name: Build
         run: go build ./...


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with two parallel jobs: Go backend and frontend
- Go job: Go 1.26, `go vet`, `staticcheck` (installed via `go install`), `go test -race -count=1`, `go build`
- Frontend job: Node 20, `npm ci`, `npm run lint`, `npm run build` from `frontend/` directory
- Both jobs run in parallel and fail independently
- Go module cache and npm cache (`frontend/package-lock.json`) configured

Closes #98

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `npm run lint` passes
- [ ] CI jobs appear in GitHub Actions on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)