### PR TITLE
⚡ fix(api): standardise request body field to 'content' in streaming SendMessage

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -102,7 +102,7 @@ export const api = {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ message: content, council_type: councilType }),
+        body: JSON.stringify({ content, council_type: councilType }),
       }
     );
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -258,6 +258,7 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 		Content     string `json:"content"`
 		CouncilType string `json:"council_type"`
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Content == "" {
 		h.writeError(w, http.StatusBadRequest, "invalid request body")
 		return

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -255,15 +255,15 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Message     string `json:"message"`
+		Content     string `json:"content"`
 		CouncilType string `json:"council_type"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Message == "" {
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Content == "" {
 		h.writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 
-	if err := h.storage.SaveUserMessage(id, body.Message); err != nil {
+	if err := h.storage.SaveUserMessage(id, body.Content); err != nil {
 		var nfe *storage.NotFoundError
 		if errors.As(err, &nfe) {
 			h.writeError(w, http.StatusNotFound, "not found")
@@ -366,7 +366,7 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := h.runner.RunFull(r.Context(), body.Message, councilType, onEvent); err != nil {
+	if err := h.runner.RunFull(r.Context(), body.Content, councilType, onEvent); err != nil {
 		var qe *council.QuorumError
 		if errors.As(err, &qe) {
 			h.logger.Warn("council quorum not met", "id", id, "got", qe.Got, "need", qe.Need)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -488,7 +488,7 @@ func TestSendMessageStream(t *testing.T) {
 	}{
 		{
 			name:   "event sequence with metadata in stage2_complete",
-			body:   `{"message":"what is Go?","council_type":"standard"}`,
+			body:   `{"content":"what is Go?","council_type":"standard"}`,
 			storer: okStorer(),
 			runner: &mockRunner{
 				runFull: func(ctx context.Context, query, ct string, onEvent council.EventFunc) error {
@@ -558,7 +558,7 @@ func TestSendMessageStream(t *testing.T) {
 		},
 		{
 			name:   "QuorumError emits error event",
-			body:   `{"message":"test","council_type":"standard"}`,
+			body:   `{"content":"test","council_type":"standard"}`,
 			storer: okStorer(),
 			runner: &mockRunner{
 				runFull: func(ctx context.Context, query, ct string, onEvent council.EventFunc) error {


### PR DESCRIPTION
## Summary
- Streaming handler (`sendMessageStream`) now reads `content` from the request body, matching the blocking handler and `docs/frontend/api-contract.md`
- `body.Message` field replaced with `body.Content` in struct tag, validation, and `RunFull` call
- Two streaming handler tests updated to send `{"content":"..."}` instead of `{"message":"..."}`
- `frontend/src/api.js` updated: `{ message: content, ... }` → `{ content, ... }`

Closes #115

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)