### PR TITLE
⚖️ feat(frontend): OWU-inspired redesign — dark theme, collapsible sidebar, stage accordions, syntax highlighting

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>LLM Council</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,11 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "highlight.js": "^11.11.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-markdown": "^10.1.0"
+        "react-markdown": "^10.1.0",
+        "rehype-highlight": "^7.0.2"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1545,6 +1547,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -1565,6 +1580,22 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1596,6 +1627,15 @@
       "dev": true,
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-url-attributes": {
@@ -2060,6 +2100,21 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2902,6 +2957,23 @@
         "react": ">=18"
       }
     },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -3123,6 +3195,20 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,9 +13,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "highlight.js": "^11.11.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "rehype-highlight": "^7.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -7,9 +7,7 @@
   height: 100vh;
   width: 100vw;
   overflow: hidden;
-  background: #ffffff;
-  color: #333;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,16 @@ function App() {
   const [currentConversationId, setCurrentConversationId] = useState(null);
   const [currentConversation, setCurrentConversation] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [theme, setTheme] = useState(() => localStorage.getItem('theme') ?? 'dark');
+  const [sidebarOpen, setSidebarOpen] = useState(() => window.innerWidth > 768);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+  const toggleSidebar = () => setSidebarOpen((o) => !o);
 
   const loadConversations = async () => {
     try {
@@ -161,11 +171,17 @@ function App() {
         currentConversationId={currentConversationId}
         onSelectConversation={handleSelectConversation}
         onNewConversation={handleNewConversation}
+        isOpen={sidebarOpen}
+        onToggle={toggleSidebar}
+        theme={theme}
+        onToggleTheme={toggleTheme}
       />
       <ChatInterface
         conversation={currentConversation}
         onSendMessage={handleSendMessage}
         isLoading={isLoading}
+        sidebarOpen={sidebarOpen}
+        onToggleSidebar={toggleSidebar}
       />
     </div>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@ function App() {
   const [currentConversation, setCurrentConversation] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [theme, setTheme] = useState(() => localStorage.getItem('theme') ?? 'dark');
-  const [sidebarOpen, setSidebarOpen] = useState(() => window.innerWidth > 768);
+  const [sidebarOpen, setSidebarOpen] = useState(() => window.innerWidth >= 768);
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -3,38 +3,79 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
-  background: #ffffff;
+  background: var(--bg-base);
+  min-width: 0;
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-base);
+  flex-shrink: 0;
+  min-height: 52px;
+}
+
+.sidebar-open-btn {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 4px 10px;
+  transition: all 0.15s;
+}
+
+.sidebar-open-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
+
+.chat-title {
+  font-size: 14px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .messages-container {
   flex: 1;
   overflow-y: auto;
-  padding: 24px;
-}
-
-.empty-state {
+  padding: 24px 20px;
   display: flex;
   flex-direction: column;
+}
+
+.messages-container::-webkit-scrollbar {
+  width: 6px;
+}
+
+.messages-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.messages-container::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 9999px;
+}
+
+.no-conversation {
+  flex: 1;
+  display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
-  color: #666;
-  text-align: center;
-}
-
-.empty-state h2 {
-  margin: 0 0 8px 0;
-  font-size: 24px;
-  color: #333;
-}
-
-.empty-state p {
-  margin: 0;
-  font-size: 16px;
+  color: var(--text-muted);
+  font-size: 15px;
 }
 
 .message-group {
-  margin-bottom: 32px;
+  max-width: var(--content-max-width);
+  width: 100%;
+  margin: 0 auto 32px;
 }
 
 .user-message,
@@ -43,54 +84,45 @@
 }
 
 .message-label {
-  font-size: 12px;
-  font-weight: 600;
-  color: #666;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-muted);
   margin-bottom: 8px;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.8px;
 }
 
 .user-message .message-content {
-  background: #f0f7ff;
-  padding: 16px;
-  border-radius: 8px;
-  border: 1px solid #d0e7ff;
-  color: #333;
+  background: var(--bg-user-bubble);
+  padding: 14px 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
   line-height: 1.6;
-  max-width: 80%;
-  white-space: pre-wrap;
-}
-
-.loading-indicator {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 16px;
-  color: #666;
-  font-size: 14px;
+  max-width: 85%;
 }
 
 .stage-loading {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 16px;
-  margin: 12px 0;
-  background: #f9fafb;
-  border-radius: 8px;
-  border: 1px solid #e0e0e0;
-  color: #666;
-  font-size: 14px;
+  gap: 10px;
+  padding: 14px 16px;
+  margin: 8px 0;
+  background: var(--bg-stage);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  font-size: 13px;
   font-style: italic;
 }
 
 .spinner {
-  width: 20px;
-  height: 20px;
-  border: 2px solid #e0e0e0;
-  border-top-color: #4a90e2;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border-color);
+  border-top-color: var(--accent);
   border-radius: 50%;
+  flex-shrink: 0;
   animation: spin 0.8s linear infinite;
 }
 
@@ -103,61 +135,79 @@
 .input-form {
   display: flex;
   align-items: flex-end;
-  gap: 12px;
-  padding: 24px;
-  border-top: 1px solid #e0e0e0;
-  background: #fafafa;
+  gap: 10px;
+  padding: 16px 20px;
+  border-top: 1px solid var(--border-color);
+  background: var(--bg-base);
+  flex-shrink: 0;
+  max-width: calc(var(--content-max-width) + 40px);
+  width: 100%;
+  margin: 0 auto;
+  align-self: center;
+  box-sizing: border-box;
 }
 
 .message-input {
   flex: 1;
-  padding: 14px;
-  background: #ffffff;
-  border: 1px solid #d0d0d0;
-  border-radius: 8px;
-  color: #333;
+  padding: 12px 16px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
   font-size: 15px;
   font-family: inherit;
   line-height: 1.5;
   outline: none;
-  resize: vertical;
-  min-height: 80px;
-  max-height: 300px;
+  resize: none;
+  min-height: 46px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.message-input::placeholder {
+  color: var(--text-muted);
 }
 
 .message-input:focus {
-  border-color: #4a90e2;
-  box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.1);
+  border-color: var(--border-focus);
+  box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.12);
 }
 
 .message-input:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-  background: #f5f5f5;
 }
 
 .send-button {
-  padding: 14px 28px;
-  background: #4a90e2;
-  border: 1px solid #4a90e2;
-  border-radius: 8px;
+  padding: 12px 24px;
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-md);
   color: #fff;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background 0.15s;
   white-space: nowrap;
-  align-self: flex-end;
+  flex-shrink: 0;
+  height: 46px;
 }
 
 .send-button:hover:not(:disabled) {
-  background: #357abd;
-  border-color: #357abd;
+  background: var(--accent-hover);
 }
 
 .send-button:disabled {
-  opacity: 0.5;
+  opacity: 0.4;
   cursor: not-allowed;
-  background: #ccc;
-  border-color: #ccc;
+}
+
+@media (max-width: 768px) {
+  .messages-container {
+    padding: 16px 12px;
+  }
+
+  .input-form {
+    padding: 12px;
+  }
 }

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -1,17 +1,21 @@
 import { useState, useEffect, useRef } from 'react';
-import ReactMarkdown from 'react-markdown';
+import Markdown from './Markdown';
 import Stage1 from './Stage1';
 import Stage2 from './Stage2';
 import Stage3 from './Stage3';
+import EmptyState from './EmptyState';
 import './ChatInterface.css';
 
 export default function ChatInterface({
   conversation,
   onSendMessage,
   isLoading,
+  sidebarOpen,
+  onToggleSidebar,
 }) {
   const [input, setInput] = useState('');
   const messagesEndRef = useRef(null);
+  const textareaRef = useRef(null);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -23,26 +27,42 @@ export default function ChatInterface({
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (input.trim() && !isLoading) {
-      onSendMessage(input);
+    const text = input.trim();
+    if (text && !isLoading) {
+      // Create new conversation if none is active — handled upstream; guard here
+      onSendMessage(text);
       setInput('');
+      if (textareaRef.current) {
+        textareaRef.current.style.height = 'auto';
+      }
     }
   };
 
   const handleKeyDown = (e) => {
-    // Submit on Enter (without Shift)
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSubmit(e);
     }
   };
 
+  const handleInput = (e) => {
+    setInput(e.target.value);
+    e.target.style.height = 'auto';
+    e.target.style.height = `${Math.min(e.target.scrollHeight, 200)}px`;
+  };
+
   if (!conversation) {
     return (
       <div className="chat-interface">
-        <div className="empty-state">
-          <h2>Welcome to LLM Council</h2>
-          <p>Create a new conversation to get started</p>
+        <div className="chat-header">
+          {!sidebarOpen && (
+            <button className="sidebar-open-btn" onClick={onToggleSidebar} title="Open sidebar">
+              ☰
+            </button>
+          )}
+        </div>
+        <div className="no-conversation">
+          <p>Select or create a conversation to get started</p>
         </div>
       </div>
     );
@@ -50,12 +70,20 @@ export default function ChatInterface({
 
   return (
     <div className="chat-interface">
+      <div className="chat-header">
+        {!sidebarOpen && (
+          <button className="sidebar-open-btn" onClick={onToggleSidebar} title="Open sidebar">
+            ☰
+          </button>
+        )}
+        {conversation.title && (
+          <span className="chat-title">{conversation.title}</span>
+        )}
+      </div>
+
       <div className="messages-container">
         {conversation.messages.length === 0 ? (
-          <div className="empty-state">
-            <h2>Start a conversation</h2>
-            <p>Ask a question to consult the LLM Council</p>
-          </div>
+          <EmptyState onSendMessage={onSendMessage} />
         ) : (
           conversation.messages.map((msg, index) => (
             <div key={index} className="message-group">
@@ -64,7 +92,7 @@ export default function ChatInterface({
                   <div className="message-label">You</div>
                   <div className="message-content">
                     <div className="markdown-content">
-                      <ReactMarkdown>{msg.content}</ReactMarkdown>
+                      <Markdown>{msg.content}</Markdown>
                     </div>
                   </div>
                 </div>
@@ -73,35 +101,25 @@ export default function ChatInterface({
                   <div className="message-label">LLM Council</div>
 
                   {/* Stage 1 */}
-                  {msg.loading?.stage1 && (
-                    <div className="stage-loading">
-                      <div className="spinner"></div>
-                      <span>Running Stage 1: Collecting individual responses...</span>
-                    </div>
-                  )}
-                  {msg.stage1 && <Stage1 responses={msg.stage1} />}
+                  <Stage1
+                    responses={msg.stage1}
+                    isLoading={msg.loading?.stage1}
+                  />
 
                   {/* Stage 2 */}
-                  {msg.loading?.stage2 && (
-                    <div className="stage-loading">
-                      <div className="spinner"></div>
-                      <span>Running Stage 2: Peer rankings...</span>
-                    </div>
-                  )}
-                  {msg.stage2 && (
-                    <Stage2
-                      rankings={msg.stage2}
-                      labelToModel={msg.metadata?.label_to_model}
-                      aggregateRankings={msg.metadata?.aggregate_rankings}
-                      consensusW={msg.metadata?.consensus_w}
-                    />
-                  )}
+                  <Stage2
+                    rankings={msg.stage2}
+                    labelToModel={msg.metadata?.label_to_model}
+                    aggregateRankings={msg.metadata?.aggregate_rankings}
+                    consensusW={msg.metadata?.consensus_w}
+                    isLoading={msg.loading?.stage2}
+                  />
 
                   {/* Stage 3 */}
                   {msg.loading?.stage3 && (
                     <div className="stage-loading">
                       <div className="spinner"></div>
-                      <span>Running Stage 3: Final synthesis...</span>
+                      <span>Synthesising final answer...</span>
                     </div>
                   )}
                   {(msg.stage3 || msg.error) && (
@@ -113,36 +131,30 @@ export default function ChatInterface({
           ))
         )}
 
-        {isLoading && (
-          <div className="loading-indicator">
-            <div className="spinner"></div>
-            <span>Consulting the council...</span>
-          </div>
-        )}
-
         <div ref={messagesEndRef} />
       </div>
 
-      {conversation.messages.length === 0 && (
-        <form className="input-form" onSubmit={handleSubmit}>
-          <textarea
-            className="message-input"
-            placeholder="Ask your question... (Shift+Enter for new line, Enter to send)"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            disabled={isLoading}
-            rows={3}
-          />
-          <button
-            type="submit"
-            className="send-button"
-            disabled={!input.trim() || isLoading}
-          >
-            Send
-          </button>
-        </form>
-      )}
+      {/* Input is always visible when a conversation is active */}
+      <form className="input-form" onSubmit={handleSubmit}>
+        <textarea
+          ref={textareaRef}
+          className="message-input"
+          placeholder="Ask a question… (Enter to send, Shift+Enter for new line)"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onInput={handleInput}
+          onKeyDown={handleKeyDown}
+          disabled={isLoading}
+          rows={1}
+        />
+        <button
+          type="submit"
+          className="send-button"
+          disabled={!input.trim() || isLoading}
+        >
+          Send
+        </button>
+      </form>
     </div>
   );
 }

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -56,7 +56,7 @@ export default function ChatInterface({
       <div className="chat-interface">
         <div className="chat-header">
           {!sidebarOpen && (
-            <button className="sidebar-open-btn" onClick={onToggleSidebar} title="Open sidebar">
+            <button className="sidebar-open-btn" onClick={onToggleSidebar} aria-label="Open sidebar">
               ☰
             </button>
           )}
@@ -72,7 +72,7 @@ export default function ChatInterface({
     <div className="chat-interface">
       <div className="chat-header">
         {!sidebarOpen && (
-          <button className="sidebar-open-btn" onClick={onToggleSidebar} title="Open sidebar">
+          <button className="sidebar-open-btn" onClick={onToggleSidebar} aria-label="Open sidebar">
             ☰
           </button>
         )}
@@ -83,7 +83,7 @@ export default function ChatInterface({
 
       <div className="messages-container">
         {conversation.messages.length === 0 ? (
-          <EmptyState onSendMessage={onSendMessage} />
+          <EmptyState onSendMessage={onSendMessage} isLoading={isLoading} />
         ) : (
           conversation.messages.map((msg, index) => (
             <div key={index} className="message-group">
@@ -141,7 +141,6 @@ export default function ChatInterface({
           className="message-input"
           placeholder="Ask a question… (Enter to send, Shift+Enter for new line)"
           value={input}
-          onChange={(e) => setInput(e.target.value)}
           onInput={handleInput}
           onKeyDown={handleKeyDown}
           disabled={isLoading}

--- a/frontend/src/components/EmptyState.css
+++ b/frontend/src/components/EmptyState.css
@@ -1,0 +1,63 @@
+.empty-state-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 40px 24px;
+  text-align: center;
+}
+
+.empty-state-hero {
+  margin-bottom: 40px;
+}
+
+.empty-state-title {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 12px 0;
+  letter-spacing: -0.5px;
+}
+
+.empty-state-subtitle {
+  font-size: 15px;
+  color: var(--text-secondary);
+  max-width: 480px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.prompt-chips {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  max-width: 560px;
+  width: 100%;
+}
+
+.prompt-chip {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 13px;
+  font-family: inherit;
+  padding: 14px 16px;
+  text-align: left;
+  transition: all 0.15s;
+  line-height: 1.4;
+}
+
+.prompt-chip:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+  background: var(--bg-input);
+}
+
+@media (max-width: 480px) {
+  .prompt-chips {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/EmptyState.jsx
+++ b/frontend/src/components/EmptyState.jsx
@@ -7,7 +7,7 @@ const SUGGESTED_PROMPTS = [
   'Compare merge sort and quicksort',
 ];
 
-export default function EmptyState({ onSendMessage }) {
+export default function EmptyState({ onSendMessage, isLoading }) {
   return (
     <div className="empty-state-container">
       <div className="empty-state-hero">
@@ -23,6 +23,7 @@ export default function EmptyState({ onSendMessage }) {
             key={prompt}
             className="prompt-chip"
             onClick={() => onSendMessage(prompt)}
+            disabled={isLoading}
           >
             {prompt}
           </button>

--- a/frontend/src/components/EmptyState.jsx
+++ b/frontend/src/components/EmptyState.jsx
@@ -1,0 +1,33 @@
+import './EmptyState.css';
+
+const SUGGESTED_PROMPTS = [
+  'Explain the trolley problem',
+  'How does TCP differ from UDP?',
+  'What is quantum entanglement?',
+  'Compare merge sort and quicksort',
+];
+
+export default function EmptyState({ onSendMessage }) {
+  return (
+    <div className="empty-state-container">
+      <div className="empty-state-hero">
+        <h2 className="empty-state-title">LLM Council</h2>
+        <p className="empty-state-subtitle">
+          Ask a question — multiple models answer independently, peer-review each other,
+          and a chairman synthesises the final answer.
+        </p>
+      </div>
+      <div className="prompt-chips">
+        {SUGGESTED_PROMPTS.map((prompt) => (
+          <button
+            key={prompt}
+            className="prompt-chip"
+            onClick={() => onSendMessage(prompt)}
+          >
+            {prompt}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Markdown.jsx
+++ b/frontend/src/components/Markdown.jsx
@@ -1,0 +1,11 @@
+import ReactMarkdown from 'react-markdown';
+import rehypeHighlight from 'rehype-highlight';
+import 'highlight.js/styles/github-dark-dimmed.css';
+
+export default function Markdown({ children }) {
+  return (
+    <ReactMarkdown rehypePlugins={[rehypeHighlight]}>
+      {children}
+    </ReactMarkdown>
+  );
+}

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -1,78 +1,170 @@
 .sidebar {
-  width: 260px;
-  background: #f8f8f8;
-  border-right: 1px solid #e0e0e0;
+  width: var(--sidebar-width);
+  min-width: var(--sidebar-width);
+  background: var(--bg-sidebar);
+  border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
   height: 100vh;
+  transition: var(--transition-sidebar);
+  overflow: hidden;
+}
+
+.sidebar.collapsed {
+  width: 0;
+  min-width: 0;
+  border-right: none;
 }
 
 .sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 16px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
-.sidebar-header h1 {
+.sidebar-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: 0.3px;
+}
+
+.sidebar-toggle {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
   font-size: 18px;
-  margin: 0 0 12px 0;
-  color: #333;
+  line-height: 1;
+  padding: 2px 8px;
+  transition: all 0.15s;
+}
+
+.sidebar-toggle:hover {
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
+
+.sidebar-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 12px;
+  white-space: nowrap;
 }
 
 .new-conversation-btn {
   width: 100%;
   padding: 10px;
-  background: #4a90e2;
-  border: 1px solid #4a90e2;
-  border-radius: 6px;
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-sm);
   color: #fff;
   cursor: pointer;
   font-size: 14px;
-  transition: background 0.2s;
   font-weight: 500;
+  transition: background 0.15s;
+  margin-bottom: 12px;
+  flex-shrink: 0;
 }
 
 .new-conversation-btn:hover {
-  background: #357abd;
-  border-color: #357abd;
+  background: var(--accent-hover);
 }
 
 .conversation-list {
   flex: 1;
   overflow-y: auto;
-  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.conversation-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.conversation-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.conversation-list::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 9999px;
 }
 
 .no-conversations {
-  padding: 16px;
+  padding: 16px 0;
   text-align: center;
-  color: #999;
-  font-size: 14px;
+  color: var(--text-muted);
+  font-size: 13px;
 }
 
 .conversation-item {
-  padding: 12px;
-  margin-bottom: 4px;
-  border-radius: 6px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background 0.15s;
+  border: 1px solid transparent;
 }
 
 .conversation-item:hover {
-  background: #f0f0f0;
+  background: var(--bg-surface);
 }
 
 .conversation-item.active {
-  background: #e8f0fe;
-  border: 1px solid #4a90e2;
+  background: var(--bg-surface);
+  border-color: var(--accent);
 }
 
 .conversation-title {
-  color: #333;
-  font-size: 14px;
-  margin-bottom: 4px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .conversation-meta {
-  color: #999;
-  font-size: 12px;
+  color: var(--text-muted);
+  font-size: 11px;
+  margin-top: 3px;
+}
+
+.sidebar-footer {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-color);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.theme-toggle {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 6px 10px;
+  transition: all 0.15s;
+}
+
+.theme-toggle:hover {
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    position: absolute;
+    z-index: 100;
+    height: 100%;
+  }
 }

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -107,6 +107,10 @@
 }
 
 .conversation-item {
+  width: 100%;
+  background: none;
+  text-align: left;
+  font: inherit;
   padding: 10px 12px;
   border-radius: var(--radius-sm);
   cursor: pointer;

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -20,7 +20,11 @@ export default function Sidebar({
     <div className={`sidebar${isOpen ? '' : ' collapsed'}`}>
       <div className="sidebar-header">
         <span className="sidebar-title">LLM Council</span>
-        <button className="sidebar-toggle" onClick={onToggle} title="Toggle sidebar">
+        <button
+          className="sidebar-toggle"
+          onClick={onToggle}
+          aria-label={isOpen ? 'Collapse sidebar' : 'Expand sidebar'}
+        >
           {isOpen ? '‹' : '›'}
         </button>
       </div>
@@ -35,7 +39,7 @@ export default function Sidebar({
             <div className="no-conversations">No conversations yet</div>
           ) : (
             conversations.map((conv) => (
-              <div
+              <button
                 key={conv.id}
                 className={`conversation-item${conv.id === currentConversationId ? ' active' : ''}`}
                 onClick={() => onSelectConversation(conv.id)}
@@ -46,14 +50,18 @@ export default function Sidebar({
                 <div className="conversation-meta">
                   {formatDate(conv.created_at)}
                 </div>
-              </div>
+              </button>
             ))
           )}
         </div>
       </div>
 
       <div className="sidebar-footer">
-        <button className="theme-toggle" onClick={onToggleTheme} title="Toggle theme">
+        <button
+          className="theme-toggle"
+          onClick={onToggleTheme}
+          aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+        >
           {theme === 'dark' ? '☀' : '☾'}
         </button>
       </div>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,41 +1,61 @@
 import './Sidebar.css';
 
+function formatDate(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
 export default function Sidebar({
   conversations,
   currentConversationId,
   onSelectConversation,
   onNewConversation,
+  isOpen,
+  onToggle,
+  theme,
+  onToggleTheme,
 }) {
   return (
-    <div className="sidebar">
+    <div className={`sidebar${isOpen ? '' : ' collapsed'}`}>
       <div className="sidebar-header">
-        <h1>LLM Council</h1>
-        <button className="new-conversation-btn" onClick={onNewConversation}>
-          + New Conversation
+        <span className="sidebar-title">LLM Council</span>
+        <button className="sidebar-toggle" onClick={onToggle} title="Toggle sidebar">
+          {isOpen ? '‹' : '›'}
         </button>
       </div>
 
-      <div className="conversation-list">
-        {conversations.length === 0 ? (
-          <div className="no-conversations">No conversations yet</div>
-        ) : (
-          conversations.map((conv) => (
-            <div
-              key={conv.id}
-              className={`conversation-item ${
-                conv.id === currentConversationId ? 'active' : ''
-              }`}
-              onClick={() => onSelectConversation(conv.id)}
-            >
-              <div className="conversation-title">
-                {conv.title || 'New Conversation'}
+      <div className="sidebar-body">
+        <button className="new-conversation-btn" onClick={onNewConversation}>
+          + New Conversation
+        </button>
+
+        <div className="conversation-list">
+          {conversations.length === 0 ? (
+            <div className="no-conversations">No conversations yet</div>
+          ) : (
+            conversations.map((conv) => (
+              <div
+                key={conv.id}
+                className={`conversation-item${conv.id === currentConversationId ? ' active' : ''}`}
+                onClick={() => onSelectConversation(conv.id)}
+              >
+                <div className="conversation-title">
+                  {conv.title || 'New Conversation'}
+                </div>
+                <div className="conversation-meta">
+                  {formatDate(conv.created_at)}
+                </div>
               </div>
-              <div className="conversation-meta">
-                {conv.message_count} messages
-              </div>
-            </div>
-          ))
-        )}
+            ))
+          )}
+        </div>
+      </div>
+
+      <div className="sidebar-footer">
+        <button className="theme-toggle" onClick={onToggleTheme} title="Toggle theme">
+          {theme === 'dark' ? '☀' : '☾'}
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/Stage1.css
+++ b/frontend/src/components/Stage1.css
@@ -1,65 +1,111 @@
 .stage {
-  margin: 24px 0;
-  padding: 20px;
-  background: #fafafa;
-  border-radius: 8px;
-  border: 1px solid #e0e0e0;
+  margin: 8px 0;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  overflow: hidden;
 }
 
-.stage-title {
-  margin: 0 0 16px 0;
-  color: #333;
-  font-size: 16px;
-  font-weight: 600;
+.stage-accordion {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 12px 16px;
+  background: var(--bg-stage);
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-align: left;
+  transition: background 0.15s, color 0.15s;
+  gap: 8px;
+}
+
+.stage-accordion:hover {
+  background: var(--bg-surface);
+  color: var(--text-primary);
+}
+
+.stage-accordion-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stage-accordion-chevron {
+  font-size: 10px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.spinner-sm {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--border-color);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.stage-body {
+  padding: 16px;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border-color);
 }
 
 .tabs {
   display: flex;
-  gap: 8px;
-  margin-bottom: 16px;
+  gap: 6px;
+  margin-bottom: 12px;
   flex-wrap: wrap;
 }
 
 .tab {
-  padding: 8px 16px;
-  background: #ffffff;
-  border: 1px solid #d0d0d0;
-  border-radius: 6px 6px 0 0;
-  color: #666;
+  padding: 6px 14px;
+  background: var(--bg-stage);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
   cursor: pointer;
-  font-size: 14px;
-  transition: all 0.2s;
+  font-size: 13px;
+  font-family: inherit;
+  transition: all 0.15s;
 }
 
 .tab:hover {
-  background: #f0f0f0;
-  color: #333;
-  border-color: #4a90e2;
+  color: var(--text-primary);
+  border-color: var(--accent);
 }
 
 .tab.active {
-  background: #ffffff;
-  color: #4a90e2;
-  border-color: #4a90e2;
-  border-bottom-color: #ffffff;
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
   font-weight: 600;
 }
 
 .tab-content {
-  background: #ffffff;
-  padding: 16px;
-  border-radius: 6px;
-  border: 1px solid #e0e0e0;
+  background: var(--bg-stage);
+  padding: 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
 }
 
 .model-name {
-  color: #888;
-  font-size: 12px;
-  margin-bottom: 12px;
+  color: var(--text-muted);
+  font-size: 11px;
   font-family: monospace;
+  margin-bottom: 10px;
 }
 
 .response-text {
-  color: #333;
+  color: var(--text-primary);
   line-height: 1.6;
 }

--- a/frontend/src/components/Stage1.jsx
+++ b/frontend/src/components/Stage1.jsx
@@ -22,7 +22,7 @@ export default function Stage1({ responses, isLoading }) {
         <span className="stage-accordion-label">
           {isLoading ? (
             <>
-              <span className="spinner spinner-sm" />
+              <span className="spinner-sm" />
               Collecting individual responses…
             </>
           ) : (

--- a/frontend/src/components/Stage1.jsx
+++ b/frontend/src/components/Stage1.jsx
@@ -1,36 +1,61 @@
 import { useState } from 'react';
-import ReactMarkdown from 'react-markdown';
+import Markdown from './Markdown';
 import './Stage1.css';
 
-export default function Stage1({ responses }) {
+export default function Stage1({ responses, isLoading }) {
+  const [expanded, setExpanded] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
 
-  if (!responses || responses.length === 0) {
+  if (!isLoading && (!responses || responses.length === 0)) {
     return null;
   }
 
+  const count = responses?.length ?? 0;
+
   return (
     <div className="stage stage1">
-      <h3 className="stage-title">Stage 1: Individual Responses</h3>
+      <button
+        className="stage-accordion"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+      >
+        <span className="stage-accordion-label">
+          {isLoading ? (
+            <>
+              <span className="spinner spinner-sm" />
+              Collecting individual responses…
+            </>
+          ) : (
+            `Stage 1: Individual Responses (${count} model${count !== 1 ? 's' : ''})`
+          )}
+        </span>
+        {!isLoading && (
+          <span className="stage-accordion-chevron">{expanded ? '▲' : '▼'}</span>
+        )}
+      </button>
 
-      <div className="tabs">
-        {responses.map((resp, index) => (
-          <button
-            key={index}
-            className={`tab ${activeTab === index ? 'active' : ''}`}
-            onClick={() => setActiveTab(index)}
-          >
-            {resp.model.split('/')[1] || resp.model}
-          </button>
-        ))}
-      </div>
+      {expanded && responses && responses.length > 0 && (
+        <div className="stage-body">
+          <div className="tabs">
+            {responses.map((resp, index) => (
+              <button
+                key={index}
+                className={`tab${activeTab === index ? ' active' : ''}`}
+                onClick={() => setActiveTab(index)}
+              >
+                {resp.model.split('/')[1] || resp.model}
+              </button>
+            ))}
+          </div>
 
-      <div className="tab-content">
-        <div className="model-name">{responses[activeTab].model}</div>
-        <div className="response-text markdown-content">
-          <ReactMarkdown>{responses[activeTab].content}</ReactMarkdown>
+          <div className="tab-content">
+            <div className="model-name">{responses[activeTab].model}</div>
+            <div className="response-text markdown-content">
+              <Markdown>{responses[activeTab].content}</Markdown>
+            </div>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Stage2.css
+++ b/frontend/src/components/Stage2.css
@@ -1,180 +1,128 @@
-.stage2 {
-  background: #fafafa;
-}
+/* Stage2 reuses .stage, .stage-accordion, .stage-body, .tabs, .tab, .tab-content,
+   .model-name, .spinner-sm from Stage1.css via the shared .stage class hierarchy */
 
-.stage2 h4 {
-  margin: 20px 0 8px 0;
-  color: #333;
-  font-size: 14px;
+.consensus-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 11px;
   font-weight: 600;
+  margin-left: 8px;
+  vertical-align: middle;
 }
 
-.stage2 h4:first-of-type {
-  margin-top: 0;
+.consensus-strong {
+  background: rgba(76, 175, 80, 0.2);
+  color: #4caf50;
+  border: 1px solid rgba(76, 175, 80, 0.3);
 }
 
-.stage-description {
-  margin: 0 0 12px 0;
-  color: #666;
+.consensus-moderate {
+  background: rgba(255, 193, 7, 0.15);
+  color: #ffc107;
+  border: 1px solid rgba(255, 193, 7, 0.3);
+}
+
+.consensus-weak {
+  background: rgba(244, 67, 54, 0.15);
+  color: #ef5350;
+  border: 1px solid rgba(244, 67, 54, 0.3);
+}
+
+[data-theme="light"] .consensus-strong {
+  background: #e6f4ea;
+  color: #1e7e34;
+  border-color: #a8d5b5;
+}
+
+[data-theme="light"] .consensus-moderate {
+  background: #fff8e1;
+  color: #8a6d00;
+  border-color: #ffe082;
+}
+
+[data-theme="light"] .consensus-weak {
+  background: #fdecea;
+  color: #b71c1c;
+  border-color: #f5c6c6;
+}
+
+.parsed-ranking {
+  margin-top: 12px;
+}
+
+.parsed-ranking strong {
+  color: var(--text-secondary);
+  font-size: 12px;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.parsed-ranking ol {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--text-primary);
+}
+
+.parsed-ranking li {
+  margin: 4px 0;
   font-size: 13px;
-  line-height: 1.5;
+  font-family: monospace;
+}
+
+.ranking-missing {
+  color: var(--text-muted);
+  font-size: 13px;
+  font-style: italic;
 }
 
 .aggregate-rankings {
-  background: #f0f7ff;
-  padding: 16px;
-  border-radius: 8px;
-  margin-bottom: 20px;
-  border: 2px solid #d0e7ff;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-color);
 }
 
-.aggregate-rankings h4 {
-  margin: 0 0 12px 0;
-  color: #2a7ae2;
-  font-size: 15px;
+.aggregate-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
 .aggregate-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .aggregate-item {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px;
-  background: #ffffff;
-  border-radius: 6px;
-  border: 1px solid #d0e7ff;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--bg-stage);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
 }
 
 .rank-position {
-  color: #2a7ae2;
+  color: var(--accent);
   font-weight: 700;
-  font-size: 16px;
-  min-width: 35px;
+  font-size: 13px;
+  min-width: 30px;
 }
 
 .rank-model {
   flex: 1;
-  color: #333;
+  color: var(--text-primary);
   font-family: monospace;
-  font-size: 14px;
-  font-weight: 500;
+  font-size: 13px;
 }
 
 .rank-score {
-  color: #666;
-  font-size: 13px;
-  font-family: monospace;
-}
-
-.stage2 .tabs {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 16px;
-  flex-wrap: wrap;
-}
-
-.stage2 .tab {
-  padding: 8px 16px;
-  background: #ffffff;
-  border: 1px solid #d0d0d0;
-  border-radius: 6px 6px 0 0;
-  color: #666;
-  cursor: pointer;
-  font-size: 14px;
-  transition: all 0.2s;
-}
-
-.stage2 .tab:hover {
-  background: #f0f0f0;
-  color: #333;
-  border-color: #4a90e2;
-}
-
-.stage2 .tab.active {
-  background: #ffffff;
-  color: #4a90e2;
-  border-color: #4a90e2;
-  border-bottom-color: #ffffff;
-  font-weight: 600;
-}
-
-.stage2 .tab-content {
-  background: #ffffff;
-  padding: 16px;
-  border-radius: 6px;
-  border: 1px solid #e0e0e0;
-  margin-bottom: 20px;
-}
-
-.ranking-model {
-  color: #888;
+  color: var(--text-muted);
   font-size: 12px;
   font-family: monospace;
-  margin-bottom: 12px;
-}
-
-.ranking-content {
-  color: #333;
-  line-height: 1.6;
-  font-size: 14px;
-}
-
-.parsed-ranking {
-  margin-top: 16px;
-  padding-top: 16px;
-  border-top: 2px solid #e0e0e0;
-}
-
-.parsed-ranking strong {
-  color: #2a7ae2;
-  font-size: 13px;
-}
-
-.parsed-ranking ol {
-  margin: 8px 0 0 0;
-  padding-left: 24px;
-  color: #333;
-}
-
-.parsed-ranking li {
-  margin: 4px 0;
-  font-family: monospace;
-  font-size: 13px;
-}
-
-.rank-count {
-  color: #999;
-  font-size: 12px;
-}
-
-.consensus-badge {
-  display: inline-block;
-  padding: 4px 10px;
-  border-radius: 12px;
-  font-size: 13px;
-  font-weight: 600;
-  margin-bottom: 16px;
-}
-
-.consensus-strong {
-  background: #e6f4ea;
-  color: #1e7e34;
-  border: 1px solid #a8d5b5;
-}
-
-.consensus-moderate {
-  background: #fff8e1;
-  color: #8a6d00;
-  border: 1px solid #ffe082;
-}
-
-.consensus-weak {
-  background: #fdecea;
-  color: #b71c1c;
-  border: 1px solid #f5c6c6;
 }

--- a/frontend/src/components/Stage2.jsx
+++ b/frontend/src/components/Stage2.jsx
@@ -11,82 +11,97 @@ function consensusLabel(w) {
   return 'weak';
 }
 
-export default function Stage2({ rankings, labelToModel, aggregateRankings, consensusW }) {
+export default function Stage2({ rankings, labelToModel, aggregateRankings, consensusW, isLoading }) {
+  const [expanded, setExpanded] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
 
-  if (!rankings || rankings.length === 0) {
+  if (!isLoading && (!rankings || rankings.length === 0)) {
     return null;
   }
 
+  const hasConsensus = consensusW != null && consensusW > 0;
+  const label = hasConsensus ? consensusLabel(consensusW) : null;
+
   return (
     <div className="stage stage2">
-      <h3 className="stage-title">Stage 2: Peer Rankings</h3>
-
-      {consensusW != null && consensusW > 0 && (() => {
-        const label = consensusLabel(consensusW);
-        return (
-          <div className={`consensus-badge consensus-${label}`}>
-            Consensus: {consensusW.toFixed(2)} ({label})
-          </div>
-        );
-      })()}
-
-      <h4>Individual Rankings</h4>
-      <p className="stage-description">
-        Each model ranked all responses (anonymized as Response A, B, C, etc.).
-        Model names shown below are resolved via the label map.
-      </p>
-
-      <div className="tabs">
-        {rankings.map((rank, index) => {
-          const reviewerModel = labelToModel?.[rank.reviewer_label] ?? rank.reviewer_label;
-          return (
-            <button
-              key={index}
-              className={`tab ${activeTab === index ? 'active' : ''}`}
-              onClick={() => setActiveTab(index)}
-            >
-              {modelShortName(reviewerModel)}
-            </button>
-          );
-        })}
-      </div>
-
-      <div className="tab-content">
-        <div className="ranking-model">
-          {labelToModel?.[rankings[activeTab].reviewer_label] ?? rankings[activeTab].reviewer_label}
-        </div>
-        {rankings[activeTab].rankings && rankings[activeTab].rankings.length > 0 ? (
-          <div className="parsed-ranking">
-            <strong>Ranking (best to worst):</strong>
-            <ol>
-              {rankings[activeTab].rankings.map((label, i) => (
-                <li key={i}>
-                  {labelToModel?.[label] ? modelShortName(labelToModel[label]) : label}
-                </li>
-              ))}
-            </ol>
-          </div>
-        ) : (
-          <p className="ranking-missing">No rankings submitted by this reviewer.</p>
+      <button
+        className="stage-accordion"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+      >
+        <span className="stage-accordion-label">
+          {isLoading ? (
+            <>
+              <span className="spinner spinner-sm" />
+              Running peer rankings…
+            </>
+          ) : (
+            <>
+              Stage 2: Peer Rankings
+              {hasConsensus && (
+                <span className={`consensus-pill consensus-${label}`}>
+                  W={consensusW.toFixed(2)} {label}
+                </span>
+              )}
+            </>
+          )}
+        </span>
+        {!isLoading && (
+          <span className="stage-accordion-chevron">{expanded ? '▲' : '▼'}</span>
         )}
-      </div>
+      </button>
 
-      {aggregateRankings && aggregateRankings.length > 0 && (
-        <div className="aggregate-rankings">
-          <h4>Aggregate Rankings</h4>
-          <p className="stage-description">
-            Combined results across all peer evaluations (lower score is better):
-          </p>
-          <div className="aggregate-list">
-            {aggregateRankings.map((agg, index) => (
-              <div key={index} className="aggregate-item">
-                <span className="rank-position">#{index + 1}</span>
-                <span className="rank-model">{modelShortName(agg.model)}</span>
-                <span className="rank-score">Score: {agg.score.toFixed(2)}</span>
-              </div>
-            ))}
+      {expanded && rankings && rankings.length > 0 && (
+        <div className="stage-body">
+          <div className="tabs">
+            {rankings.map((rank, index) => {
+              const reviewerModel = labelToModel?.[rank.reviewer_label] ?? rank.reviewer_label;
+              return (
+                <button
+                  key={index}
+                  className={`tab${activeTab === index ? ' active' : ''}`}
+                  onClick={() => setActiveTab(index)}
+                >
+                  {modelShortName(reviewerModel)}
+                </button>
+              );
+            })}
           </div>
+
+          <div className="tab-content">
+            <div className="model-name">
+              {labelToModel?.[rankings[activeTab].reviewer_label] ?? rankings[activeTab].reviewer_label}
+            </div>
+            {rankings[activeTab].rankings && rankings[activeTab].rankings.length > 0 ? (
+              <div className="parsed-ranking">
+                <strong>Ranking (best → worst):</strong>
+                <ol>
+                  {rankings[activeTab].rankings.map((lbl, i) => (
+                    <li key={i}>
+                      {labelToModel?.[lbl] ? modelShortName(labelToModel[lbl]) : lbl}
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            ) : (
+              <p className="ranking-missing">No rankings submitted by this reviewer.</p>
+            )}
+          </div>
+
+          {aggregateRankings && aggregateRankings.length > 0 && (
+            <div className="aggregate-rankings">
+              <div className="aggregate-title">Aggregate Rankings</div>
+              <div className="aggregate-list">
+                {aggregateRankings.map((agg, index) => (
+                  <div key={index} className="aggregate-item">
+                    <span className="rank-position">#{index + 1}</span>
+                    <span className="rank-model">{modelShortName(agg.model)}</span>
+                    <span className="rank-score">{agg.score.toFixed(2)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/Stage2.jsx
+++ b/frontend/src/components/Stage2.jsx
@@ -32,7 +32,7 @@ export default function Stage2({ rankings, labelToModel, aggregateRankings, cons
         <span className="stage-accordion-label">
           {isLoading ? (
             <>
-              <span className="spinner spinner-sm" />
+              <span className="spinner-sm" />
               Running peer rankings…
             </>
           ) : (

--- a/frontend/src/components/Stage3.css
+++ b/frontend/src/components/Stage3.css
@@ -1,50 +1,80 @@
-.stage3 {
-  background: #f0fff0;
-  border-color: #c8e6c8;
+.stage3-hero {
+  margin: 12px 0;
+  background: var(--bg-stage-hero);
+  border: 1px solid var(--border-hero);
+  border-left: 4px solid var(--accent-green);
+  border-radius: var(--radius-md);
+  overflow: hidden;
 }
 
-.final-response {
-  background: #ffffff;
-  padding: 20px;
-  border-radius: 6px;
-  border: 1px solid #c8e6c8;
+.stage3-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border-hero);
 }
 
-.chairman-label {
-  color: #2d8a2d;
+.stage3-label {
   font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--accent-green);
+}
+
+.stage3-model {
+  font-size: 11px;
+  color: var(--text-muted);
   font-family: monospace;
-  margin-bottom: 12px;
-  font-weight: 600;
 }
 
 .final-text {
-  color: #333;
+  padding: 4px 0;
+  color: var(--text-primary);
   line-height: 1.7;
   font-size: 15px;
 }
 
 .stage3-error {
-  background: #fff8f0;
-  border: 1px solid #f5c6a0;
-  border-radius: 6px;
   padding: 16px;
   display: flex;
   align-items: flex-start;
   gap: 10px;
+  background: rgba(244, 67, 54, 0.08);
+  border-top: 1px solid rgba(244, 67, 54, 0.2);
 }
 
 .stage3-error-icon {
-  color: #b84800;
+  color: #ef5350;
   font-size: 16px;
   flex-shrink: 0;
   line-height: 1.4;
 }
 
 .stage3-error-message {
-  color: #b84800;
+  color: #ef5350;
   font-family: monospace;
   font-size: 13px;
   line-height: 1.5;
   word-break: break-word;
+}
+
+[data-theme="light"] .stage3-hero {
+  border-left-color: #2d8a2d;
+  border-color: var(--border-hero);
+}
+
+[data-theme="light"] .stage3-label {
+  color: #2d8a2d;
+}
+
+[data-theme="light"] .stage3-error {
+  background: #fff8f0;
+  border-color: #f5c6a0;
+}
+
+[data-theme="light"] .stage3-error-icon,
+[data-theme="light"] .stage3-error-message {
+  color: #b84800;
 }

--- a/frontend/src/components/Stage3.jsx
+++ b/frontend/src/components/Stage3.jsx
@@ -1,4 +1,4 @@
-import ReactMarkdown from 'react-markdown';
+import Markdown from './Markdown';
 import './Stage3.css';
 
 export default function Stage3({ finalResponse, error }) {
@@ -7,21 +7,24 @@ export default function Stage3({ finalResponse, error }) {
   }
 
   return (
-    <div className="stage stage3">
-      <h3 className="stage-title">Stage 3: Final Council Answer</h3>
+    <div className="stage3-hero">
+      <div className="stage3-header">
+        <span className="stage3-label">Final Answer</span>
+        {finalResponse && (
+          <span className="stage3-model">
+            {finalResponse.model.split('/')[1] || finalResponse.model}
+          </span>
+        )}
+      </div>
+
       {error ? (
         <div className="stage3-error">
           <span className="stage3-error-icon">⚠</span>
           <span className="stage3-error-message">{error}</span>
         </div>
       ) : (
-        <div className="final-response">
-          <div className="chairman-label">
-            Chairman: {finalResponse.model.split('/')[1] || finalResponse.model}
-          </div>
-          <div className="final-text markdown-content">
-            <ReactMarkdown>{finalResponse.content}</ReactMarkdown>
-          </div>
+        <div className="final-text markdown-content">
+          <Markdown>{finalResponse.content}</Markdown>
         </div>
       )}
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,5 @@
+@import './theme.css';
+
 :root {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   line-height: 1.5;
@@ -19,7 +21,8 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background: #f5f5f5;
+  background: var(--bg-base);
+  color: var(--text-primary);
 }
 
 #root {
@@ -48,6 +51,7 @@ body {
 .markdown-content h5,
 .markdown-content h6 {
   margin: 16px 0 8px 0;
+  color: var(--text-primary);
 }
 
 .markdown-content h1:first-child,
@@ -70,19 +74,20 @@ body {
 }
 
 .markdown-content pre {
-  background: #f5f5f5;
+  background: #1a1a1a;
+  border: 1px solid var(--border-color);
   padding: 12px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   overflow-x: auto;
   margin: 0 0 12px 0;
 }
 
 .markdown-content code {
-  background: #f5f5f5;
+  background: rgba(255, 255, 255, 0.08);
   padding: 2px 6px;
   border-radius: 3px;
-  font-family: monospace;
-  font-size: 0.9em;
+  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-size: 0.875em;
 }
 
 .markdown-content pre code {
@@ -93,6 +98,38 @@ body {
 .markdown-content blockquote {
   margin: 0 0 12px 0;
   padding-left: 16px;
-  border-left: 4px solid #ddd;
-  color: #666;
+  border-left: 3px solid var(--accent);
+  color: var(--text-secondary);
+}
+
+.markdown-content table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 0 0 12px 0;
+}
+
+.markdown-content th,
+.markdown-content td {
+  border: 1px solid var(--border-color);
+  padding: 8px 12px;
+  text-align: left;
+}
+
+.markdown-content th {
+  background: var(--bg-stage);
+  font-weight: 600;
+}
+
+/* highlight.js light mode override */
+[data-theme="light"] .hljs {
+  background: #f6f8fa;
+  color: #24292e;
+}
+
+[data-theme="light"] .markdown-content pre {
+  background: #f6f8fa;
+}
+
+[data-theme="light"] .markdown-content code {
+  background: rgba(0, 0, 0, 0.06);
 }

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -1,0 +1,49 @@
+/* Design tokens — dark theme is the default */
+:root {
+  --bg-base: #0f0f0f;
+  --bg-sidebar: #111111;
+  --bg-surface: #1e1e1e;
+  --bg-input: #242424;
+  --bg-user-bubble: #1a2a3a;
+  --bg-stage: #161616;
+  --bg-stage-hero: #0d1f0d;
+
+  --text-primary: #e5e5e5;
+  --text-secondary: #a0a0a0;
+  --text-muted: #606060;
+
+  --border-color: #2e2e2e;
+  --border-focus: #4a90e2;
+  --border-hero: #2d5a2d;
+
+  --accent: #4a90e2;
+  --accent-hover: #357abd;
+  --accent-green: #4caf50;
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+
+  --sidebar-width: 260px;
+  --content-max-width: 820px;
+
+  --transition-sidebar: width 220ms ease;
+}
+
+[data-theme="light"] {
+  --bg-base: #f5f5f5;
+  --bg-sidebar: #f8f8f8;
+  --bg-surface: #ffffff;
+  --bg-input: #ffffff;
+  --bg-user-bubble: #f0f7ff;
+  --bg-stage: #fafafa;
+  --bg-stage-hero: #f0fff0;
+
+  --text-primary: #1a1a1a;
+  --text-secondary: #555555;
+  --text-muted: #999999;
+
+  --border-color: #e0e0e0;
+  --border-focus: #4a90e2;
+  --border-hero: #c8e6c8;
+}


### PR DESCRIPTION
## Summary
- Dark theme by default with light/dark toggle; preference persisted in `localStorage`
- Collapsible sidebar with smooth CSS transition (width 0/260px); defaults collapsed on mobile < 768px; reopens via hamburger button in chat header
- **Bug fix:** input is now always visible — follow-up questions work in existing conversations
- Stage 1 and Stage 2 rendered as collapsed accordions (spinner in header during streaming); Stage 3 is the hero card — always expanded with green accent border
- Empty state shows 4 suggested prompt chips that submit on click
- Syntax highlighting in code blocks via `rehype-highlight` + `highlight.js`
- Shared `Markdown.jsx` wrapper (children-only) replaces all direct `<ReactMarkdown>` calls
- `theme.css` with CSS custom properties as single source of truth for all color/spacing tokens
- Auto-resize textarea; sidebar shows conversation dates instead of message count

Closes #121

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Dark mode loads by default; toggle switches to light and back; persists on reload
- [ ] Sidebar collapses/expands with smooth animation; hamburger button restores it
- [ ] Typing a follow-up in an existing conversation works (input always visible)
- [ ] Stage 1 and 2 collapsed by default; clicking header expands them
- [ ] Stage 3 shown as prominent hero card
- [ ] Code block in a response renders with syntax highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)