### PR TITLE
⚡ fix(frontend): show Stage 1 spinner immediately on message send

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -106,7 +106,7 @@ function App() {
         stage3: null,
         metadata: null,
         loading: {
-          stage1: false,
+          stage1: true,
           stage2: false,
           stage3: false,
         },


### PR DESCRIPTION
## Summary
- Initialize `loading.stage1` to `true` when the assistant message block is first created
- The \"Collecting individual responses…\" spinner in Stage1 now appears immediately after sending, instead of after the first SSE event
- Removes the frozen-looking blank state during Stage 1 processing

Closes #

## Test plan
- [ ] Send a message — Stage 1 spinner appears immediately
- [ ] Spinner disappears and results populate when `stage1_complete` fires
- [ ] `npm run lint` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)