### PR TITLE
docs: remove planned markers from Stage 0 — feature shipped in #155

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,8 +58,8 @@ is written), so a proper HTTP status code is always possible.
 | Council quorum not met | `503` | `"council quorum not met"` |
 | Storage failure (pre-pipeline) | `500` | `"internal server error"` |
 | SSE streaming not supported by server | `500` | `"streaming not supported"` |
-| *(planned — issue #154)* Round-N with already-answered round | `409` | `"clarification round already answered"` |
-| *(planned — issue #154)* Round-N with no pending clarification round | `409` | `"no pending clarification round"` |
+| Round-N with already-answered round | `409` | `"clarification round already answered"` |
+| Round-N with no pending clarification round | `409` | `"no pending clarification round"` |
 
 ### SSE error events
 
@@ -282,11 +282,9 @@ There is no `event:` line — demux by the `"type"` field of the JSON payload.
 ## SSE event sequence
 
 ```
-← planned ──────────────────────────────────────────────────────────────
-data: {"type":"stage0_round_complete","data":{"round":1,"questions":[...]}}   ← stream closes here
+data: {"type":"stage0_round_complete","data":{"round":1,"questions":[...]}}   ← stream closes here (Stage 0 enabled)
   … client submits answers via new POST …
 data: {"type":"stage0_done"}                                                  ← Stage 1 follows
-─────────────────────────────────────────────────────────────────── planned →
 
 data: {"type":"stage1_complete","data":[...StageOneResult]}
 data: {"type":"stage2_complete","data":[...StageTwoResult],"metadata":{...Metadata}}
@@ -305,7 +303,7 @@ data: {"type":"error","message":"human-readable message"}
 
 After an error event the stream ends. No `complete` event follows.
 
-### `stage0_round_complete` *(planned — issue #154)*
+### `stage0_round_complete`
 
 Emitted when the chairman has questions for the user. The SSE stream **closes** after this event. The client must open a new stream with `{answers:[...]}` to continue.
 
@@ -322,7 +320,7 @@ Emitted when the chairman has questions for the user. The SSE stream **closes** 
 }
 ```
 
-### `stage0_done` *(planned — issue #154)*
+### `stage0_done`
 
 Emitted when the Stage 0 loop ends — chairman said "enough", limits were reached, or the user submitted all-empty answers. `stage1_complete` follows immediately on the same stream.
 
@@ -484,7 +482,7 @@ Emitted when the pipeline fails. Stream ends after this event.
 |-------|------|-------------|
 | `title` | string | First 50 bytes of the Stage 3 response, used as the conversation title |
 
-### `ClarificationQuestion` *(planned — issue #154)*
+### `ClarificationQuestion`
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -22,7 +22,7 @@ api.Handler.sendMessage / sendMessageStream      [internal/api/handler.go]
     │   1. validate UUID, body size, content XOR answers
     │   2. persist user message (round-1) OR load+update clarification round (round-N)
     │
-    │   ┌─ Stage 0 (planned — issue #154, gated by CLARIFICATION_MAX_ROUNDS > 0) ──────────┐
+    │   ┌─ Stage 0 (gated by CLARIFICATION_MAX_ROUNDS > 0) ──────────────────────────────┐
     │   │  3. council.RunClarificationRound(ctx, query, history, councilType, onEvent)       │
     │   │     └── emit stage0_round_complete → stream closes (awaiting client answers)       │
     │   │     OR  emit stage0_done → fall through to Stage 1                                 │
@@ -57,7 +57,7 @@ api.Handler:
 
 ---
 
-## 0. Stage 0: Clarification *(planned — issue #154)*
+## 0. Stage 0: Clarification
 
 **Files:** `internal/council/runner.go`, `internal/council/council.go`, `internal/storage/storage.go`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -55,9 +55,9 @@ All configuration is via environment variables. The server reads from `.env` at 
 | `PORT` | `8001` | TCP port the HTTP server listens on. |
 | `DATA_DIR` | `data/conversations` | Directory where conversation JSON files are stored. Relative to the working directory. |
 | `LLM_API_BASE_URL` | *(optional)* | Override the OpenRouter API base URL. Must be an absolute `http`/`https` URL. Useful for pointing at a compatible local proxy. |
-| `CLARIFICATION_MAX_ROUNDS` | `0` | *(planned — issue #154)* Max clarification rounds before Stage 1. `0` disables Stage 0 entirely — the API behaves identically to today. |
-| `CLARIFICATION_MAX_TOTAL_QUESTIONS` | `5` | *(planned)* Hard cap on questions accumulated across all rounds in one query. |
-| `CLARIFICATION_MAX_QUESTIONS_PER_ROUND` | `3` | *(planned)* Chairman trims to this many questions per round. |
+| `CLARIFICATION_MAX_ROUNDS` | `0` | Max clarification rounds before Stage 1. `0` disables Stage 0 entirely — the API behaves identically to before Stage 0. |
+| `CLARIFICATION_MAX_TOTAL_QUESTIONS` | `5` | Hard cap on questions accumulated across all rounds in one query. |
+| `CLARIFICATION_MAX_QUESTIONS_PER_ROUND` | `3` | Chairman trims to this many questions per round. |
 
 ### Default council models
 
@@ -226,7 +226,7 @@ The streaming endpoint emits [Server-Sent Events](https://developer.mozilla.org/
 ← data: {"type":"complete"}
 ```
 
-The `stage0_*` events are only emitted when `CLARIFICATION_MAX_ROUNDS > 0` (planned, issue #154). With the default (`CLARIFICATION_MAX_ROUNDS=0`) the sequence starts at `stage1_complete` as today.
+The `stage0_*` events are only emitted when `CLARIFICATION_MAX_ROUNDS > 0`. With the default (`CLARIFICATION_MAX_ROUNDS=0`) the sequence starts at `stage1_complete`.
 
 There are no `*_start` events — the client receives each stage result only when it is fully complete.
 
@@ -386,7 +386,7 @@ The Chairman model receives the consensus level as part of its synthesis prompt 
 
 ---
 
-## Stage 0: Clarification *(planned — issue #154)*
+## Stage 0: Clarification
 
 When `CLARIFICATION_MAX_ROUNDS` is greater than `0`, the pipeline runs a clarification loop *before* Stage 1. Each council model identifies ambiguities, contradictions, and unstated assumptions in the user's query and proposes questions. The Chairman consolidates and prioritises them (up to `CLARIFICATION_MAX_QUESTIONS_PER_ROUND` per round), then either sends them to the user or skips to generation if enough context exists.
 


### PR DESCRIPTION
## Summary

- Removes all `*(planned — issue #154)*` and `*(planned)*` annotations from `docs/api.md`, `docs/user-guide.md`, and `docs/pipeline.md`
- Stage 0 clarification shipped in PR #155; these markers are now stale

## Test plan
- [ ] No `planned` references remain in Stage 0 doc sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)