### PR TITLE
⚡ feat(frontend): optional collapsible context field above question input

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1498,10 +1498,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2228,9 +2229,10 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -134,8 +134,8 @@
 
 .input-form {
   display: flex;
-  align-items: flex-end;
-  gap: 10px;
+  flex-direction: column;
+  gap: 8px;
   padding: 16px 20px;
   border-top: 1px solid var(--border-color);
   background: var(--bg-base);
@@ -145,6 +145,78 @@
   margin: 0 auto;
   align-self: center;
   box-sizing: border-box;
+}
+
+.input-context {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.context-toggle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  align-self: flex-start;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.context-toggle:hover:not(:disabled) {
+  color: var(--text-secondary);
+  border-color: var(--text-muted);
+}
+
+.context-toggle:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.context-toggle-chevron {
+  font-size: 9px;
+}
+
+.context-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 14px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.5;
+  outline: none;
+  resize: vertical;
+  min-height: 72px;
+}
+
+.context-textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.context-textarea:focus {
+  border-color: var(--border-focus);
+  box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.12);
+}
+
+.context-textarea:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.input-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
 }
 
 .message-input {

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -18,6 +18,8 @@ export default function ChatInterface({
   onToggleSidebar,
 }) {
   const [input, setInput] = useState('');
+  const [context, setContext] = useState('');
+  const [contextExpanded, setContextExpanded] = useState(false);
   const messagesContainerRef = useRef(null);
   const textareaRef = useRef(null);
 
@@ -26,12 +28,19 @@ export default function ChatInterface({
     if (el) el.scrollTop = el.scrollHeight;
   }, [conversation?.messages]);
 
+  useEffect(() => {
+    setContext('');
+    setContextExpanded(false);
+  }, [conversation?.id]);
+
   const handleSubmit = (e) => {
     e.preventDefault();
     const text = input.trim();
     if (text && !isLoading) {
-      // Create new conversation if none is active — handled upstream; guard here
-      onSendMessage(text);
+      const content = context.trim()
+        ? `Context:\n${context.trim()}\n\nQuestion:\n${text}`
+        : text;
+      onSendMessage(content);
       setInput('');
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';
@@ -143,27 +152,53 @@ export default function ChatInterface({
 
       {/* Input is always visible when a conversation is active */}
       <form className="input-form" onSubmit={handleSubmit}>
-        <textarea
-          ref={textareaRef}
-          className="message-input"
-          placeholder={
-            conversation.messages.at(-1)?.pendingClarification
-              ? 'Answer the questions above to continue…'
-              : 'Ask a question… (Enter to send, Shift+Enter for new line)'
-          }
-          value={input}
-          onInput={handleInput}
-          onKeyDown={handleKeyDown}
-          disabled={isLoading || !!conversation.messages.at(-1)?.pendingClarification}
-          rows={1}
-        />
-        <button
-          type="submit"
-          className="send-button"
-          disabled={!input.trim() || isLoading || !!conversation.messages.at(-1)?.pendingClarification}
-        >
-          Send
-        </button>
+        <div className="input-context">
+          <button
+            type="button"
+            className="context-toggle"
+            onClick={() => setContextExpanded((e) => !e)}
+            aria-expanded={contextExpanded}
+            aria-controls="context-textarea"
+            disabled={isLoading || !!conversation.messages.at(-1)?.pendingClarification}
+          >
+            <span className="context-toggle-chevron">{contextExpanded ? '▲' : '▼'}</span>
+            Context
+          </button>
+          {contextExpanded && (
+            <textarea
+              id="context-textarea"
+              className="context-textarea"
+              placeholder="Background information, constraints, or examples…"
+              value={context}
+              onChange={(e) => setContext(e.target.value)}
+              disabled={isLoading || !!conversation.messages.at(-1)?.pendingClarification}
+              rows={3}
+            />
+          )}
+        </div>
+        <div className="input-row">
+          <textarea
+            ref={textareaRef}
+            className="message-input"
+            placeholder={
+              conversation.messages.at(-1)?.pendingClarification
+                ? 'Answer the questions above to continue…'
+                : 'Ask a question… (Enter to send, Shift+Enter for new line)'
+            }
+            value={input}
+            onInput={handleInput}
+            onKeyDown={handleKeyDown}
+            disabled={isLoading || !!conversation.messages.at(-1)?.pendingClarification}
+            rows={1}
+          />
+          <button
+            type="submit"
+            className="send-button"
+            disabled={!input.trim() || isLoading || !!conversation.messages.at(-1)?.pendingClarification}
+          >
+            Send
+          </button>
+        </div>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds an optional **Context** field above the question textarea, collapsed by default
- Toggled with a labelled button (`aria-expanded` + `aria-controls` for accessibility)
- When context is non-empty, content sent to the pipeline is `Context:\n<context>\n\nQuestion:\n<question>`; when empty only the question is sent
- Context persists across multiple messages in the same conversation; resets when switching conversations
- Context textarea and toggle button are both disabled during loading or pending-clarification states
- Collapsing does not clear the buffered context text
- Also bumps `flatted` and `mdast-util-to-hast` via `npm audit fix` (1 high, 1 moderate CVE)

Closes #157

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] `npm audit` reports 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)