### PR TITLE
⚡ fix(config): enable Stage 0 clarification by default (2 rounds)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	DefaultCouncilChairmanModel string
 	DefaultCouncilTemperature   float64
 
-	// Stage 0 clarification loop. ClarificationMaxRounds == 0 disables the feature.
+	// Stage 0 clarification loop. ClarificationMaxRounds == 0 disables the feature (set CLARIFICATION_MAX_ROUNDS=0 to disable).
 	ClarificationMaxRounds            int
 	ClarificationMaxTotalQuestions    int
 	ClarificationMaxQuestionsPerRound int
@@ -93,7 +93,7 @@ func Load() (*Config, error) {
 		llmBaseURL = raw
 	}
 
-	clarificationMaxRounds := 0
+	clarificationMaxRounds := 2
 	if raw := os.Getenv("CLARIFICATION_MAX_ROUNDS"); raw != "" {
 		if v, err := strconv.Atoi(raw); err == nil {
 			clarificationMaxRounds = v


### PR DESCRIPTION
## Summary

- `CLARIFICATION_MAX_ROUNDS` defaulted to `0`, silently disabling Stage 0 for any deployment without an explicit env override
- Changed default to `2` — clarification now runs out of the box
- `CLARIFICATION_MAX_ROUNDS=0` still explicitly opts out

Fixes: new conversations skipping the clarification step entirely.

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (97 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)