### PR TITLE
⚡ fix(frontend): clear context field after message is sent

### DIFF
--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -42,6 +42,8 @@ export default function ChatInterface({
         : text;
       onSendMessage(content);
       setInput('');
+      setContext('');
+      setContextExpanded(false);
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';
       }


### PR DESCRIPTION
## Summary

- After submitting a message, `setInput('')` cleared the question but `context` state was never reset
- The context textarea remained populated (and expanded) on the next send, causing the previous context to silently re-attach to every subsequent message
- Now `setContext('')` and `setContextExpanded(false)` are called on submit alongside `setInput('')`

## Test plan
- [ ] Send a message with context + question — context field clears and collapses after send
- [ ] Next message starts with empty context field
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)