### PR TITLE
⚖️ feat(storage,api,frontend): close conversation after council answer delivered

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -68,7 +68,7 @@ function App() {
         }
       }
 
-      setCurrentConversation({ ...conv, messages });
+      setCurrentConversation({ ...conv, messages, closed: conv.closed ?? false });
     } catch (error) {
       console.error('Failed to load conversation:', error);
     }
@@ -141,10 +141,14 @@ function App() {
       msg.loading.stage2 = false;
     }),
     stage3_start: () => updateLast((msg) => { msg.loading.stage3 = true; }),
-    stage3_complete: (event) => updateLast((msg) => {
-      msg.stage3 = event.data;
-      msg.loading.stage3 = false;
-    }),
+    stage3_complete: (event) => {
+      updateLast((msg) => {
+        msg.stage3 = event.data;
+        msg.loading.stage3 = false;
+      });
+      setCurrentConversation((prev) => prev ? { ...prev, closed: true } : prev);
+      loadConversations();
+    },
     title_complete: () => loadConversations(),
     complete: () => { loadConversations(); setIsLoading(false); },
     error: (event) => {
@@ -249,6 +253,7 @@ function App() {
         conversation={currentConversation}
         onSendMessage={handleSendMessage}
         onAnswerSubmit={handleAnswerSubmit}
+        isConversationClosed={!!currentConversation?.closed}
         isLoading={isLoading}
         sidebarOpen={sidebarOpen}
         onToggleSidebar={toggleSidebar}

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -14,6 +14,7 @@ export default function ChatInterface({
   onSendMessage,
   onAnswerSubmit,
   isLoading,
+  isConversationClosed,
   sidebarOpen,
   onToggleSidebar,
 }) {
@@ -161,7 +162,7 @@ export default function ChatInterface({
             onClick={() => setContextExpanded((e) => !e)}
             aria-expanded={contextExpanded}
             aria-controls="context-textarea"
-            disabled={isLoading || !!conversation.messages.at(-1)?.pendingClarification}
+            disabled={isConversationClosed || isLoading || !!conversation.messages.at(-1)?.pendingClarification}
           >
             <span className="context-toggle-chevron">{contextExpanded ? '▲' : '▼'}</span>
             Context
@@ -173,7 +174,7 @@ export default function ChatInterface({
               placeholder="Background information, constraints, or examples…"
               value={context}
               onChange={(e) => setContext(e.target.value)}
-              disabled={isLoading || !!conversation.messages.at(-1)?.pendingClarification}
+              disabled={isConversationClosed || isLoading || !!conversation.messages.at(-1)?.pendingClarification}
               rows={3}
             />
           )}
@@ -183,20 +184,22 @@ export default function ChatInterface({
             ref={textareaRef}
             className="message-input"
             placeholder={
-              conversation.messages.at(-1)?.pendingClarification
-                ? 'Answer the questions above to continue…'
-                : 'Ask a question… (Enter to send, Shift+Enter for new line)'
+              isConversationClosed
+                ? 'This conversation has ended'
+                : conversation.messages.at(-1)?.pendingClarification
+                  ? 'Answer the questions above to continue…'
+                  : 'Ask a question… (Enter to send, Shift+Enter for new line)'
             }
             value={input}
             onInput={handleInput}
             onKeyDown={handleKeyDown}
-            disabled={isLoading || !!conversation.messages.at(-1)?.pendingClarification}
+            disabled={isConversationClosed || isLoading || !!conversation.messages.at(-1)?.pendingClarification}
             rows={1}
           />
           <button
             type="submit"
             className="send-button"
-            disabled={!input.trim() || isLoading || !!conversation.messages.at(-1)?.pendingClarification}
+            disabled={isConversationClosed || !input.trim() || isLoading || !!conversation.messages.at(-1)?.pendingClarification}
           >
             Send
           </button>

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -440,6 +440,10 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 	} else {
 		originalQuery = body.Content
 		if err := h.storage.SaveUserMessage(id, body.Content); err != nil {
+			if errors.Is(err, storage.ErrConversationClosed) {
+				h.writeError(w, http.StatusConflict, "conversation is closed")
+				return
+			}
 			if _, ok := errors.AsType[*storage.NotFoundError](err); ok {
 				h.writeError(w, http.StatusNotFound, "not found")
 				return
@@ -599,6 +603,11 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 		h.logger.Error("save assistant message", "id", id, "error", err)
 		sendErrorSSE("internal server error")
 		return
+	}
+
+	if err := h.storage.CloseConversation(id); err != nil {
+		h.logger.Error("close conversation", "id", id, "error", err)
+		// Do not abort — response is already committed; log and continue.
 	}
 
 	// Title generation: run in a goroutine to avoid blocking the ResponseWriter.

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -23,6 +23,7 @@ type mockStorer struct {
 	saveUserMessage            func(string, string) error
 	saveAssistantMessage       func(string, council.AssistantMessage) error
 	saveTitle                  func(string, string) error
+	closeConversation          func(string) error
 	saveClarificationRound     func(string, int, []council.ClarificationQuestion, string) error
 	updateClarificationAnswers func(string, int, []council.ClarificationAnswer) error
 	getLastClarificationRound  func(string) (*council.ClarificationRound, error)
@@ -61,6 +62,12 @@ func (m *mockStorer) SaveAssistantMessage(id string, msg council.AssistantMessag
 func (m *mockStorer) SaveTitle(id, title string) error {
 	if m.saveTitle != nil {
 		return m.saveTitle(id, title)
+	}
+	return nil
+}
+func (m *mockStorer) CloseConversation(id string) error {
+	if m.closeConversation != nil {
+		return m.closeConversation(id)
 	}
 	return nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -24,12 +25,16 @@ func (e NotFoundError) Error() string {
 	return fmt.Sprintf("conversation not found: %s", e.ID)
 }
 
+// ErrConversationClosed is returned when a message is sent to a closed conversation.
+var ErrConversationClosed = errors.New("conversation is closed")
+
 // ConversationMeta holds lightweight metadata for list responses.
 type ConversationMeta struct {
 	ID           string    `json:"id"`
 	CreatedAt    time.Time `json:"created_at"`
 	Title        string    `json:"title"`
 	MessageCount int       `json:"message_count"`
+	Closed       bool      `json:"closed"`
 }
 
 // Conversation is the full stored record including the message history.
@@ -40,6 +45,7 @@ type Conversation struct {
 	ID        string            `json:"id"`
 	CreatedAt time.Time         `json:"created_at"`
 	Title     string            `json:"title"`
+	Closed    bool              `json:"closed"`
 	Messages  []json.RawMessage `json:"messages"`
 }
 
@@ -52,6 +58,7 @@ type Storer interface {
 	SaveUserMessage(id, content string) error
 	SaveAssistantMessage(id string, msg council.AssistantMessage) error
 	SaveTitle(id, title string) error
+	CloseConversation(id string) error
 	SaveClarificationRound(id string, round int, questions []council.ClarificationQuestion, councilType string) error
 	UpdateClarificationAnswers(id string, round int, answers []council.ClarificationAnswer) error
 	GetLastClarificationRound(id string) (*council.ClarificationRound, error)
@@ -197,6 +204,7 @@ func (s *Store) ListConversations() ([]ConversationMeta, error) {
 			CreatedAt:    c.CreatedAt,
 			Title:        c.Title,
 			MessageCount: len(c.Messages),
+			Closed:       c.Closed,
 		})
 	}
 	sort.Slice(metas, func(i, j int) bool {
@@ -219,7 +227,21 @@ func (s *Store) SaveUserMessage(id, content string) error {
 	if err != nil {
 		return err
 	}
+	if c.Closed {
+		return ErrConversationClosed
+	}
 	c.Messages = append(c.Messages, raw)
+	return s.writeConversation(c)
+}
+
+func (s *Store) CloseConversation(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, err := s.readConversation(id)
+	if err != nil {
+		return err
+	}
+	c.Closed = true
 	return s.writeConversation(c)
 }
 

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -401,6 +402,88 @@ func TestGetLastClarificationRound_ReturnsLast(t *testing.T) {
 	}
 	if len(got.Questions) != 1 || got.Questions[0].ID != "q2" {
 		t.Errorf("Questions: got %v, want [{q2 Second?}]", got.Questions)
+	}
+}
+
+func TestStore_SaveUserMessage_RejectsAfterClose(t *testing.T) {
+	s := newTestStore(t)
+	c, err := s.CreateConversation()
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if err := s.SaveUserMessage(c.ID, "hello"); err != nil {
+		t.Fatalf("SaveUserMessage: %v", err)
+	}
+	if err := s.CloseConversation(c.ID); err != nil {
+		t.Fatalf("CloseConversation: %v", err)
+	}
+	err = s.SaveUserMessage(c.ID, "should fail")
+	if !errors.Is(err, storage.ErrConversationClosed) {
+		t.Errorf("expected ErrConversationClosed, got %v", err)
+	}
+	// Verify the closed flag is persisted.
+	got, err := s.GetConversation(c.ID)
+	if err != nil {
+		t.Fatalf("GetConversation: %v", err)
+	}
+	if !got.Closed {
+		t.Error("expected Closed=true after CloseConversation")
+	}
+}
+
+func TestStore_CloseConversation_RaceWithSaveUserMessage(t *testing.T) {
+	s := newTestStore(t)
+	c, err := s.CreateConversation()
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+
+	const goroutines = 8
+	errs := make([]error, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines + 1)
+
+	// N goroutines try to save user messages concurrently.
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = s.SaveUserMessage(c.ID, "msg")
+		}(i)
+	}
+	// One goroutine closes the conversation.
+	go func() {
+		defer wg.Done()
+		if err := s.CloseConversation(c.ID); err != nil {
+			t.Errorf("CloseConversation: %v", err)
+		}
+	}()
+	wg.Wait()
+
+	// Every error must be nil (saved before close) or ErrConversationClosed.
+	for i, err := range errs {
+		if err != nil && !errors.Is(err, storage.ErrConversationClosed) {
+			t.Errorf("goroutine %d: unexpected error %v", i, err)
+		}
+	}
+
+	// Count successful saves.
+	saved := 0
+	for _, err := range errs {
+		if err == nil {
+			saved++
+		}
+	}
+
+	// File must parse as valid JSON with a consistent message count.
+	got, err := s.GetConversation(c.ID)
+	if err != nil {
+		t.Fatalf("GetConversation after race: %v", err)
+	}
+	if len(got.Messages) != saved {
+		t.Errorf("message count mismatch: file has %d, expected %d (successful saves)", len(got.Messages), saved)
+	}
+	if !got.Closed {
+		t.Error("expected Closed=true after CloseConversation")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `Closed bool \`json:"closed"\`` to `Conversation` and `ConversationMeta`
- `SaveUserMessage` checks `Closed` under `s.mu.Lock()` and returns `ErrConversationClosed` — atomic gate prevents TOCTOU race
- `CloseConversation` sets the flag via the same tmp→rename pattern (lock held for the entire sequence)
- Handler maps `ErrConversationClosed` to HTTP 409 **before** SSE headers are written
- `CloseConversation` called after `SaveAssistantMessage`, before title goroutine and `complete` event
- Frontend marks closed on `stage3_complete` (not `complete`) to avoid false closure from Stage 0 stream
- `ChatInterface` disables the full input form with placeholder "This conversation has ended"

Closes #159

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test -race ./...` passes (99 tests, 2 new: `TestStore_SaveUserMessage_RejectsAfterClose`, `TestStore_CloseConversation_RaceWithSaveUserMessage`)
- [ ] `npm run lint && npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)