### PR TITLE
fix(council): strip markdown code fences before JSON parsing

### DIFF
--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -7,11 +7,28 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
 
 var errNoChoices = errors.New("council: completion response contained no choices")
+
+// stripCodeFence removes markdown code fences that some models wrap around JSON.
+// Handles ```json\n...\n``` and ```\n...\n``` patterns.
+func stripCodeFence(s string) string {
+	s = strings.TrimSpace(s)
+	for _, prefix := range []string{"```json", "```"} {
+		if strings.HasPrefix(s, prefix) {
+			s = strings.TrimSpace(s[len(prefix):])
+			if idx := strings.LastIndex(s, "```"); idx >= 0 {
+				s = strings.TrimSpace(s[:idx])
+			}
+			break
+		}
+	}
+	return s
+}
 
 // Council orchestrates the full multi-stage deliberation pipeline.
 // Full implementation is provided in a later milestone.
@@ -192,7 +209,7 @@ func (c *Council) runStage2(ctx context.Context, query string, stage1 []StageOne
 			var parsed struct {
 				Rankings []string `json:"rankings"`
 			}
-			if err := json.Unmarshal([]byte(resp.Choices[0].Message.Content), &parsed); err != nil {
+			if err := json.Unmarshal([]byte(stripCodeFence(resp.Choices[0].Message.Content)), &parsed); err != nil {
 				if c.logger != nil {
 					c.logger.Warn("stage2: parse failure", slog.String("reviewer", s1.Label), slog.Any("error", err))
 				}
@@ -338,7 +355,7 @@ func (c *Council) runStage0Generators(ctx context.Context, prompt []ChatMessage,
 					Text string `json:"text"`
 				} `json:"questions"`
 			}
-			if err := json.Unmarshal([]byte(resp.Choices[0].Message.Content), &parsed); err != nil {
+			if err := json.Unmarshal([]byte(stripCodeFence(resp.Choices[0].Message.Content)), &parsed); err != nil {
 				if c.logger != nil {
 					c.logger.Warn("stage0: generator parse failure", "model", model, "error", err)
 				}
@@ -375,7 +392,7 @@ func (c *Council) runStage0Chairman(ctx context.Context, query string, candidate
 		return nil, true, fmt.Errorf("stage0 chairman: %w", err)
 	}
 
-	content := resp.Choices[0].Message.Content
+	content := stripCodeFence(resp.Choices[0].Message.Content)
 	var parsed struct {
 		Questions []ClarificationQuestion `json:"questions"`
 		Enough    bool                    `json:"enough"`


### PR DESCRIPTION
## Summary

- `claude-sonnet-4.5` (and potentially others) wraps JSON responses in ` ```json ` code fences, causing `json.Unmarshal` to fail with `invalid character '`'`
- Added `stripCodeFence` helper that removes ` ```json ` / ` ``` ` wrappers before parsing
- Applied at all three LLM JSON parse sites: Stage 2 rankings, Stage 0 generator questions, Stage 0 chairman decision

Observed in production logs:
```
stage0: generator parse failure  error="invalid character '`' looking for beginning of value"
stage2: parse failure             error="invalid character '`' looking for beginning of value"
```

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (99 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)