### PR TITLE
⚖️ feat(council,api): RoleBasedReview pipeline and /review endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,15 @@ DEFAULT_COUNCIL_TYPE=default
 # Range: 0.0 (deterministic) – 2.0 (very creative). Default: 0.7
 DEFAULT_COUNCIL_TEMPERATURE=0.7
 
+# ── Code-review council (RoleBasedReview strategy) ─────────────────────────
+# Models assigned to the 4 reviewer roles: security, logic, simplicity, architecture.
+# One model per role recommended; fewer models are assigned round-robin.
+# Defaults to COUNCIL_MODELS when not set.
+# CODE_REVIEW_MODELS=openai/gpt-4o-mini,anthropic/claude-haiku-4-5,google/gemini-flash-1.5,openai/gpt-4o-mini
+
+# Chairman model for code-review synthesis. Defaults to CHAIRMAN_MODEL when not set.
+# CODE_REVIEW_CHAIRMAN_MODEL=anthropic/claude-sonnet-4-5
+
 # ── Storage ─────────────────────────────────────────────────────────────────
 # Directory where conversation JSON files are stored.
 # Created automatically if it does not exist. Default: data/conversations

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ User query
   all responses *and* the peer rankings, giving it the full picture to write the
   best possible answer.
 
+### Code review variant (`/review`)
+
+A second pipeline uses **specialised roles** instead of peer review. Four roles
+(security, logic, simplicity, architecture) analyse a code diff in parallel; the
+chairman synthesises their findings into a single consolidated review. Stage 2 is
+skipped — roles are complementary, not competing, so ranking makes no sense.
+
+See [`docs/code-review.md`](docs/code-review.md) for usage.
+
 ---
 
 ## Tech stack
@@ -117,8 +126,10 @@ All configuration is done via environment variables. Copy `.env.example` to
 | `OPENROUTER_API_KEY` | **Yes** | — | Your OpenRouter API key. |
 | `COUNCIL_MODELS` | No | 3 small dev fallbacks¹ | Comma-separated list of OpenRouter model IDs for council members. |
 | `CHAIRMAN_MODEL` | No | `openai/gpt-4o-mini`¹ | Model used for Stage 3 synthesis. |
-| `DEFAULT_COUNCIL_TYPE` | No | `default` | Council pipeline variant. Only `default` is currently supported. |
+| `DEFAULT_COUNCIL_TYPE` | No | `default` | Council pipeline variant (`default` = PeerReview). |
 | `DEFAULT_COUNCIL_TEMPERATURE` | No | `0.7` | Sampling temperature for all LLM calls (0.0–2.0). |
+| `CODE_REVIEW_MODELS` | No | `COUNCIL_MODELS` | Models for the 4 code-review roles (round-robin if fewer than 4). |
+| `CODE_REVIEW_CHAIRMAN_MODEL` | No | `CHAIRMAN_MODEL` | Chairman model for code-review synthesis. |
 | `DATA_DIR` | No | `data/conversations` | Directory where conversation JSON files are stored. |
 | `PORT` | No | `8001` | TCP port the server listens on. |
 
@@ -161,6 +172,8 @@ make fr-lint    # ESLint
 | `GET` | `/api/conversations/{id}` | Get a conversation with all messages |
 | `POST` | `/api/conversations/{id}/message` | Send a message, wait for the full result |
 | `POST` | `/api/conversations/{id}/message/stream` | Send a message, receive stage results via SSE |
+| `POST` | `/api/conversations/{id}/review` | Code review: run 4 specialist roles, wait for the full result |
+| `POST` | `/api/conversations/{id}/review/stream` | Code review: stream each role and the synthesis via SSE |
 
 ### Streaming events (`/message/stream`)
 
@@ -207,8 +220,11 @@ llm-council/
 │   ├── config/config.go          Config struct and Load() from environment variables
 │   ├── openrouter/client.go      HTTP client for OpenRouter (parallel and single queries)
 │   ├── council/
-│   │   ├── council.go            3-stage pipeline: RunFull(), stage functions, ranking
-│   │   └── types.go              Result types: StageOneResult, StageTwoResult, etc.
+│   │   ├── runner.go             RunFull() dispatcher + PeerReview pipeline stages
+│   │   ├── rolebased.go          RoleBased/RoleBasedReview pipeline
+│   │   ├── review_roles.go       DefaultReviewRoles + NewCodeReviewCouncilType
+│   │   ├── prompts.go            Prompt builders for all pipeline stages
+│   │   └── types.go              Result types: CouncilType, Strategy, Role, StageOneResult, etc.
 │   ├── storage/storage.go        JSON file persistence with atomic writes and per-conv locks
 │   └── api/handler.go            HTTP handlers, CORS middleware, SSE streaming
 ├── frontend/                     React 19 + Vite 8 single-page app (see below)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,6 +43,11 @@ func main() {
 			ChairmanModel: cfg.DefaultCouncilChairmanModel,
 			Temperature:   cfg.DefaultCouncilTemperature,
 		},
+		"code-review": council.NewCodeReviewCouncilType(
+			cfg.CodeReviewModels,
+			cfg.CodeReviewChairmanModel,
+			cfg.DefaultCouncilTemperature,
+		),
 	}
 
 	client := openrouter.NewClient(cfg.OpenRouterAPIKey, cfg.LLMBaseURL, 120*time.Second)

--- a/docs/api.md
+++ b/docs/api.md
@@ -56,6 +56,7 @@ is written), so a proper HTTP status code is always possible.
 | Malformed or missing request body | `400` | `"invalid request body"` |
 | Conversation not found | `404` | `"not found"` |
 | Council quorum not met | `503` | `"council quorum not met"` |
+| Review: one or more roles failed (all 4 required) | `503` | `"council quorum not met"` |
 | Storage failure (pre-pipeline) | `500` | `"internal server error"` |
 | SSE streaming not supported by server | `500` | `"streaming not supported"` |
 | Round-N with already-answered round | `409` | `"clarification round already answered"` |
@@ -259,6 +260,7 @@ Each event is flushed immediately as the stage completes — no polling required
 
 **Request body** — same as `/message`.
 
+
 **Response headers**
 
 ```
@@ -276,6 +278,51 @@ data: {"type":"<event_type>",...}\n\n
 ```
 
 There is no `event:` line — demux by the `"type"` field of the JSON payload.
+
+---
+
+### `POST /api/conversations/{id}/review`
+
+Run a code review using the `RoleBasedReview` pipeline and receive the full result in a
+single JSON response (blocking).
+
+**Path parameter** — `id`: UUID v4.
+
+**Request body**
+
+```json
+{ "content": "<code diff or snippet to review>" }
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | string | yes | The code diff or snippet to review |
+
+The council type is always `"code-review"` — there is no `council_type` field.
+
+**Response `200 OK`** — `AssistantMessage` (same shape as `/message`).
+
+Stage 1 `label` fields are **role names** (`security`, `logic`, `simplicity`,
+`architecture`) rather than `Response A`/`B`/…. Stage 2 `data` is `[]` and
+`metadata.aggregate_rankings` is `[]`, `metadata.consensus_w` is `1.0`
+(roles are complementary, not competing).
+
+**Errors:** `400` (invalid body/UUID), `404` (not found), `503` (role quorum not met — all 4 roles must succeed), `500`.
+
+---
+
+### `POST /api/conversations/{id}/review/stream`
+
+Run a code review and receive results as a Server-Sent Events stream. Identical to
+`/review` but streams each stage as it completes.
+
+**Path parameter** — `id`: UUID v4.
+
+**Request body** — same as `/review`.
+
+**Response headers** — same as `/message/stream`.
+
+**SSE event sequence** — see [Review SSE event sequence](#review-sse-event-sequence).
 
 ---
 
@@ -430,6 +477,105 @@ Emitted when the pipeline fails. Stream ends after this event.
 
 ```json
 { "type": "error", "message": "council quorum not met" }
+```
+
+---
+
+## Review SSE event sequence
+
+Used by `POST /api/conversations/{id}/review/stream`. Stage 2 is skipped by the
+`RoleBasedReview` pipeline; a minimal `stage2_complete` is emitted for SSE
+compatibility.
+
+```
+data: {"type":"stage1_complete","data":[...RoleResult]}
+data: {"type":"stage2_complete","data":[],"metadata":{...Metadata}}
+data: {"type":"stage3_complete","data":{...StageThreeResult}}
+data: {"type":"title_complete","data":{"title":"..."}}     ← may be absent
+data: {"type":"complete"}
+```
+
+On failure:
+
+```
+data: {"type":"error","message":"council quorum not met"}
+```
+
+All 4 roles must succeed — if any role call fails, the stream ends with an error event.
+
+### `stage1_complete` (review)
+
+Labels are **role names** (`security`, `logic`, `simplicity`, `architecture`), not
+`Response A`/`B`/…. Each model returns a JSON array of findings.
+
+```json
+{
+  "type": "stage1_complete",
+  "data": [
+    {
+      "label": "security",
+      "content": "[{\"file\":\"cmd/server/main.go\",\"line\":42,\"severity\":\"high\",\"body\":\"...\"}]",
+      "model": "openai/gpt-4o-mini",
+      "duration_ms": 1540
+    },
+    {
+      "label": "logic",
+      "content": "[]",
+      "model": "anthropic/claude-haiku-4-5",
+      "duration_ms": 980
+    },
+    {
+      "label": "simplicity",
+      "content": "[{\"file\":\"internal/api/handler.go\",\"line\":88,\"severity\":\"low\",\"body\":\"...\"}]",
+      "model": "google/gemini-flash-1.5",
+      "duration_ms": 760
+    },
+    {
+      "label": "architecture",
+      "content": "[]",
+      "model": "openai/gpt-4o-mini",
+      "duration_ms": 1120
+    }
+  ]
+}
+```
+
+### `stage2_complete` (review)
+
+Stage 2 is skipped. The event is emitted with an empty `data` array and a metadata
+block where `aggregate_rankings` is `[]` and `consensus_w` is `1.0`.
+
+```json
+{
+  "type": "stage2_complete",
+  "data": [],
+  "metadata": {
+    "council_type": "code-review",
+    "label_to_model": {
+      "security":     "openai/gpt-4o-mini",
+      "logic":        "anthropic/claude-haiku-4-5",
+      "simplicity":   "google/gemini-flash-1.5",
+      "architecture": "openai/gpt-4o-mini"
+    },
+    "aggregate_rankings": [],
+    "consensus_w": 1.0
+  }
+}
+```
+
+### `stage3_complete` (review)
+
+The chairman reads all role findings and produces a consolidated review.
+
+```json
+{
+  "type": "stage3_complete",
+  "data": {
+    "content": "## Code Review Summary\n\n**Security** found 1 high-severity issue...",
+    "model": "anthropic/claude-sonnet-4-5",
+    "duration_ms": 2100
+  }
+}
 ```
 
 ---

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,0 +1,207 @@
+# LLM Council — Code Review
+
+The `RoleBasedReview` pipeline runs four specialised reviewer roles in parallel and
+asks a chairman to consolidate their findings. Use it via `POST /api/conversations/{id}/review`.
+
+---
+
+## How it works
+
+```
+Code diff (content)
+    │
+    ▼
+┌──────────────────────────────────────────────────────────┐
+│ Stage 1 — Parallel role execution                        │
+│                                                          │
+│  security      →  OWASP Top 10, injection, secrets, …   │
+│  logic         →  nil dereferences, race conditions, …   │
+│  simplicity    →  DRY/KISS/YAGNI, naming, duplication    │
+│  architecture  →  SOLID violations, layer boundaries, …  │
+│                                                          │
+│  Each role returns a JSON array of findings              │
+└─────────────────────────┬────────────────────────────────┘
+                           │
+                           ▼
+                    Stage 2 — skipped
+                    (roles are complementary, not competing)
+                           │
+                           ▼
+┌──────────────────────────────────────────────────────────┐
+│ Stage 3 — Chairman synthesis                             │
+│  Reads all four role outputs → consolidated review       │
+└──────────────────────────────────────────────────────────┘
+```
+
+All four roles must succeed. If any role call fails, the pipeline returns `503 council
+quorum not met` (or an SSE `error` event on the streaming path).
+
+---
+
+## The four roles
+
+| Role | Focus |
+|------|-------|
+| `security` | OWASP Top 10, auth/authz flaws, input validation, SQL/command injection, hardcoded secrets, cryptography misuse, unsafe API usage |
+| `logic` | Edge cases, nil/null pointer dereferences, off-by-one errors, race conditions, incorrect error propagation, missing bounds checks |
+| `simplicity` | DRY violations, overly complex logic (KISS), premature abstraction (YAGNI), poor naming, missing or misleading comments |
+| `architecture` | Layer boundary violations, dependency direction, tight coupling, low cohesion, interface design, SOLID principle violations |
+
+Each role is instructed to return **only** a JSON array of findings:
+
+```json
+[
+  {
+    "file": "internal/api/handler.go",
+    "line": 42,
+    "severity": "high",
+    "body": "User-controlled input passed to os.Exec without sanitisation."
+  }
+]
+```
+
+An empty array (`[]`) means no findings for that role.
+
+---
+
+## Configuration
+
+```bash
+# .env — code review models (optional, defaults to COUNCIL_MODELS)
+
+# One model per role recommended; fewer are assigned round-robin.
+CODE_REVIEW_MODELS=openai/gpt-4o-mini,anthropic/claude-haiku-4-5,google/gemini-flash-1.5,openai/gpt-4o-mini
+
+# Chairman model for synthesis (optional, defaults to CHAIRMAN_MODEL)
+CODE_REVIEW_CHAIRMAN_MODEL=anthropic/claude-sonnet-4-5
+```
+
+**Model assignment:** `models[i % len(models)]`
+
+- 1 model → all 4 roles use it
+- 2 models → security+simplicity get model[0], logic+architecture get model[1]
+- 4 models → one model per role (recommended for best coverage)
+
+> Provider diversity matters: different model families catch different classes of bugs.
+
+---
+
+## Usage
+
+### Synchronous (blocking)
+
+```bash
+CONV_ID=$(curl -s -X POST http://localhost:8001/api/conversations | jq -r .id)
+
+curl -s -X POST http://localhost:8001/api/conversations/$CONV_ID/review \
+  -H "Content-Type: application/json" \
+  -d "{\"content\": \"$(git diff -U8 | jq -Rs .)\"}" \
+  | jq .stage3.content
+```
+
+### Streaming (SSE)
+
+```bash
+curl -N http://localhost:8001/api/conversations/$CONV_ID/review/stream \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d "{\"content\": \"$(git diff -U8 | jq -Rs .)\"}"
+```
+
+Events arrive in order:
+
+```
+data: {"type":"stage1_complete","data":[{"label":"security","content":"[...]",...},
+                                        {"label":"logic","content":"[]",...},
+                                        {"label":"simplicity","content":"[...]",...},
+                                        {"label":"architecture","content":"[]",...}]}
+
+data: {"type":"stage2_complete","data":[],"metadata":{"council_type":"code-review",
+       "label_to_model":{...},"aggregate_rankings":[],"consensus_w":1.0}}
+
+data: {"type":"stage3_complete","data":{"content":"## Code Review Summary\n\n...","model":"...","duration_ms":2100}}
+
+data: {"type":"title_complete","data":{"title":"Code Review Summary"}}
+
+data: {"type":"complete"}
+```
+
+### Recommended diff format
+
+```bash
+# Current uncommitted changes (8 lines of context for better analysis)
+git diff -U8
+
+# Specific commit
+git show <sha> -U8
+
+# PR diff
+git diff main...feature/my-branch -U8
+```
+
+---
+
+## Response structure
+
+`stage3.content` is a markdown document produced by the chairman. Typical structure:
+
+```markdown
+## Code Review Summary
+
+### Critical Issues
+
+**[security]** `cmd/server/main.go:42` (high)
+User-controlled input passed to os.Exec without sanitisation.
+
+### Warnings
+
+**[simplicity]** `internal/api/handler.go:88` (low)
+Function `handleRequest` is 120 lines — consider splitting by concern.
+
+### No Issues Found
+
+- **logic** — no logical errors detected
+- **architecture** — no structural problems detected
+
+### Overall Assessment
+
+The diff is safe to merge after addressing the one critical security finding.
+```
+
+---
+
+## Raw role output
+
+`stage1_complete` contains each role's raw JSON findings array. Useful for
+programmatic processing before the chairman's narrative.
+
+```bash
+# Extract all high/critical findings across all roles
+curl -s ... | jq '
+  .stage1
+  | map(.content | fromjson)
+  | flatten
+  | map(select(.severity == "critical" or .severity == "high"))
+'
+```
+
+---
+
+## Error handling
+
+| Condition | HTTP | SSE |
+|-----------|------|-----|
+| Empty `content` field | `400 Bad Request` | — |
+| Invalid conversation UUID | `400 Bad Request` | — |
+| Conversation not found | `404 Not Found` | — |
+| Any role call fails (quorum=4, all required) | `503 Service Unavailable` | `{"type":"error","message":"council quorum not met"}` |
+| Chairman call fails | `500 Internal Server Error` | `{"type":"error","message":"internal server error"}` |
+
+---
+
+## See also
+
+- [`docs/api.md`](api.md) — full HTTP API reference including SSE event shapes
+- [`docs/pipeline.md`](pipeline.md) — code-level walkthrough of both pipelines
+- [`internal/council/review_roles.go`](../internal/council/review_roles.go) — role definitions
+- [`internal/council/rolebased.go`](../internal/council/rolebased.go) — pipeline implementation

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -712,7 +712,7 @@ Metadata{
 }
 ```
 
-`Stage2CompleteData.Results` is `nil` (serialises as `null` in the JSON `data` field).
+`Stage2CompleteData.Results` is an empty slice (serialises as `[]` in the JSON `data` field) — never `null` — so SSE clients can safely iterate without a nil check.
 
 ### Stage 3 — chairman synthesis
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -5,10 +5,16 @@ pipeline — from the HTTP request landing on the Go server to the final SSE `co
 event being flushed to the browser. It is a code-anchored walkthrough; every step
 references the function and file responsible for it.
 
-The current implementation supports a single `Strategy = PeerReview` (an `iota` enum
-with no other variants). Three external models are involved per request: **N council
-members** (Stage 1 generators + Stage 2 peer reviewers) and **1 chairman** (Stage 3
-synthesiser).
+Two pipeline strategies are implemented, selected by `CouncilType.Strategy`:
+
+- **`PeerReview`** (default) — N council members independently answer, then anonymously
+  rank each other, and a chairman synthesises the result. Three external-model stages.
+- **`RoleBased` / `RoleBasedReview`** — M specialised roles run in parallel (Stage 1),
+  Stage 2 is skipped, and a chairman synthesises all role outputs (Stage 3). Used by the
+  `/review` endpoints for code review.
+
+For the PeerReview pipeline: **N council members** (Stage 1 generators + Stage 2 peer
+reviewers) and **1 chairman** (Stage 3 synthesiser).
 
 ---
 
@@ -619,16 +625,131 @@ the several seconds while council models are running.
 
 ---
 
+---
+
+## RoleBased pipeline (RoleBased / RoleBasedReview)
+
+**File:** `internal/council/rolebased.go` — `runRoleBased`
+
+`RunFull` dispatches to `runRoleBased` when `ct.Strategy == RoleBased || RoleBasedReview`.
+
+### High-level flow
+
+```
+POST /api/conversations/{id}/review[/stream]
+    │
+    ▼
+api.Handler.sendReview / sendReviewStream        [internal/api/handler.go]
+    │   1. validate UUID, body size, content non-empty
+    │   2. persist user message
+    │
+    ▼
+council.Council.RunFull("code-review")            [internal/council/runner.go]
+    │   resolves ct = NewCodeReviewCouncilType(...)
+    │   dispatches to runRoleBased
+    │
+    ▼
+council.runRoleBased                              [internal/council/rolebased.go]
+    │
+    ├── Stage 1: runRoleBasedStage1 (parallel, M goroutines — one per role)
+    │     │
+    │     └── checkQuorum(stage1, ct.QuorumMin)  — all M roles required
+    │     └── emit stage1_complete  (labels = role names, not A/B/C)
+    │
+    ├── Stage 2: skipped
+    │     └── emit stage2_complete  (data=[], ConsensusW=1.0, AggregateRankings=[])
+    │
+    └── Stage 3: runRoleBasedStage3 (single chairman call)
+          └── emit stage3_complete
+    │
+    ▼
+api.Handler:
+    3. persist assistant message
+    4. spawn title goroutine; select on 30s deadline
+    5. emit title_complete (if title generated in time)
+    6. emit complete
+```
+
+### Stage 1 — parallel role execution
+
+**File:** `internal/council/rolebased.go` — `runRoleBasedStage1`
+**Prompt:** `internal/council/prompts.go` — `BuildRoleStage1Prompt`
+
+Each `Role` in `ct.Roles` maps to one goroutine. Model assignment:
+
+```go
+model := ct.Models[idx % len(ct.Models)]
+```
+
+One model handles all roles; 4 models give one per role; any count wraps round-robin.
+
+`BuildRoleStage1Prompt(role Role, query string)` returns:
+
+```
+[ { "role": "system", "content": role.Instruction },
+  { "role": "user",   "content": query } ]
+```
+
+The `StageOneResult.Label` is set to the role's `Name` (`"security"`, `"logic"`, etc.),
+not an anonymous `Response X` label.
+
+**Quorum:** `checkQuorum(results, ct.QuorumMin)` with `QuorumMin = len(DefaultReviewRoles)` (4 for
+`code-review`). Every role must succeed — unlike `PeerReview` where partial success is
+allowed, each role covers a unique concern and a missing role silently drops coverage.
+
+### Stage 2 — skipped
+
+The `RoleBased` pipeline has no peer-ranking step: roles are complementary, not
+competing, so ranking is semantically meaningless. A minimal `stage2_complete` event is
+emitted to keep SSE clients compatible:
+
+```go
+Metadata{
+    CouncilType:       ct.Name,
+    LabelToModel:      labelToModel,    // role name → model
+    AggregateRankings: []RankedModel{}, // empty — not applicable
+    ConsensusW:        1.0,             // placeholder
+}
+```
+
+`Stage2CompleteData.Results` is `nil` (serialises as `null` in the JSON `data` field).
+
+### Stage 3 — chairman synthesis
+
+**File:** `internal/council/rolebased.go` — `runRoleBasedStage3`
+**Prompt:** `internal/council/prompts.go` — `BuildRoleChairmanPrompt`
+
+`BuildRoleChairmanPrompt(query string, results []StageOneResult)` formats each role's
+output into a labelled section:
+
+```
+The following is a code review of the provided code diff.
+Each section is the output of a specialised reviewer role.
+
+## security
+<content>
+
+## logic
+<content>
+...
+
+Based on all reviewer findings above, produce a consolidated code review.
+```
+
+---
+
 ## File reference index
 
 | File | Key symbols |
 |------|------------|
-| `internal/api/handler.go` | `sendMessage`, `sendMessageStream` |
+| `internal/api/handler.go` | `sendMessage`, `sendMessageStream`, `sendReview`, `sendReviewStream` |
 | `internal/council/runner.go` | `Council.RunFull`, `runStage1`, `runStage2`, `runStage3` |
+| `internal/council/rolebased.go` | `runRoleBased`, `runRoleBasedStage1`, `runRoleBasedStage3` |
+| `internal/council/review_roles.go` | `DefaultReviewRoles`, `NewCodeReviewCouncilType` |
 | `internal/council/council.go` | `checkQuorum`, `assignLabels`, `QuorumError` |
 | `internal/council/rankings.go` | `CalculateAggregateRankings` |
-| `internal/council/prompts.go` | `BuildStage1Prompt`, `BuildStage2Prompt`, `BuildStage3Prompt` |
-| `internal/council/types.go` | `CouncilType`, `Strategy`, `StageOneResult`, `StageTwoResult`, `StageThreeResult`, `Metadata`, `EventFunc` |
+| `internal/council/prompts.go` | `BuildStage1Prompt`, `BuildStage2Prompt`, `BuildStage3Prompt`, `BuildRoleStage1Prompt`, `BuildRoleChairmanPrompt` |
+| `internal/council/types.go` | `CouncilType`, `Strategy`, `Role`, `StageOneResult`, `StageTwoResult`, `StageThreeResult`, `Metadata`, `EventFunc` |
 | `internal/openrouter/client.go` | `Client.Complete` |
 | `internal/storage/storage.go` | `Store.Get`, `AppendMessage`, `SaveTitle` |
 | `frontend/src/api.js` | `sendMessageStream` |

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -859,6 +859,11 @@ func (h *Handler) sendReviewStream(w http.ResponseWriter, r *http.Request) {
 		sendErrorSSE("internal server error")
 		return
 	}
+
+	// Spec: { "type": "complete" } with no payload. Frontend SSE handlers rely on
+	// this terminal event to clear loading state. Mirrors /message/stream.
+	fmt.Fprintf(w, "data: {\"type\":\"complete\"}\n\n")
+	flusher.Flush()
 }
 
 // handleRunError translates RunFull errors to HTTP responses.

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -761,9 +761,51 @@ func (h *Handler) sendReviewStream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Accel-Buffering", "no")
 
 	sendSSE := func(eventType string, data any) {
-		b, _ := json.Marshal(data)
-		envelope, _ := json.Marshal(sseEnvelope{Type: eventType, Data: b})
-		fmt.Fprintf(w, "data: %s\n\n", envelope)
+		dataJSON, err := json.Marshal(data)
+		if err != nil {
+			h.logger.Error("marshal SSE event data", "type", eventType, "error", err)
+			return
+		}
+		env := sseEnvelope{Type: eventType, Data: json.RawMessage(dataJSON)}
+		envJSON, err := json.Marshal(env)
+		if err != nil {
+			h.logger.Error("marshal SSE envelope", "type", eventType, "error", err)
+			return
+		}
+		fmt.Fprintf(w, "data: %s\n\n", envJSON)
+		flusher.Flush()
+	}
+
+	sendStage2SSE := func(d council.Stage2CompleteData) {
+		type stage2Payload struct {
+			Type     string                   `json:"type"`
+			Data     []council.StageTwoResult `json:"data"`
+			Metadata council.Metadata         `json:"metadata"`
+		}
+		b, err := json.Marshal(stage2Payload{
+			Type:     "stage2_complete",
+			Data:     d.Results,
+			Metadata: d.Metadata,
+		})
+		if err != nil {
+			h.logger.Error("marshal stage2 SSE payload", "error", err)
+			return
+		}
+		fmt.Fprintf(w, "data: %s\n\n", b)
+		flusher.Flush()
+	}
+
+	sendErrorSSE := func(msg string) {
+		type errPayload struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		}
+		b, err := json.Marshal(errPayload{Type: "error", Message: msg})
+		if err != nil {
+			h.logger.Error("marshal error SSE payload", "error", err)
+			return
+		}
+		fmt.Fprintf(w, "data: %s\n\n", b)
 		flusher.Flush()
 	}
 
@@ -779,18 +821,28 @@ func (h *Handler) sendReviewStream(w http.ResponseWriter, r *http.Request) {
 			if v, ok := data.([]council.StageOneResult); ok {
 				stage1Results = v
 			}
+			sendSSE(eventType, data)
 		case "stage2_complete":
 			if v, ok := data.(council.Stage2CompleteData); ok {
 				stage2Data = v
+				sendStage2SSE(v)
 			}
 		case "stage3_complete":
 			if v, ok := data.(council.StageThreeResult); ok {
 				stage3Result = v
 			}
+			sendSSE(eventType, data)
+		default:
+			sendSSE(eventType, data)
 		}
-		sendSSE(eventType, data)
 	}); err != nil {
-		sendSSE("error", map[string]string{"message": err.Error()})
+		if qe, ok := errors.AsType[*council.QuorumError](err); ok {
+			h.logger.Warn("review council quorum not met", "id", id, "got", qe.Got, "need", qe.Need)
+			sendErrorSSE("council quorum not met")
+		} else {
+			h.logger.Error("review council run", "id", id, "error", err)
+			sendErrorSSE("internal server error")
+		}
 		return
 	}
 
@@ -801,7 +853,12 @@ func (h *Handler) sendReviewStream(w http.ResponseWriter, r *http.Request) {
 		Stage3:   stage3Result,
 		Metadata: stage2Data.Metadata,
 	}
-	_ = h.storage.SaveAssistantMessage(id, msg)
+
+	if err := h.storage.SaveAssistantMessage(id, msg); err != nil {
+		h.logger.Error("save review assistant message (stream)", "id", id, "error", err)
+		sendErrorSSE("internal server error")
+		return
+	}
 }
 
 // handleRunError translates RunFull errors to HTTP responses.

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -82,6 +83,8 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/conversations/{id}", h.wrap(h.getConversation))
 	mux.Handle("POST /api/conversations/{id}/message", h.wrap(h.sendMessage))
 	mux.Handle("POST /api/conversations/{id}/message/stream", h.wrap(h.sendMessageStream))
+	mux.Handle("POST /api/conversations/{id}/review", h.wrap(h.sendReview))
+	mux.Handle("POST /api/conversations/{id}/review/stream", h.wrap(h.sendReviewStream))
 }
 
 // wrap applies CORS and security headers to every route.
@@ -634,6 +637,171 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 	// Spec: { "type": "complete" } with no payload.
 	fmt.Fprintf(w, "data: {\"type\":\"complete\"}\n\n")
 	flusher.Flush()
+}
+
+// reviewRequest is the body for code-review endpoints.
+type reviewRequest struct {
+	Content string `json:"content"`
+}
+
+func (req reviewRequest) validate() error {
+	if strings.TrimSpace(req.Content) == "" {
+		return errors.New("content is required")
+	}
+	return nil
+}
+
+func (h *Handler) sendReview(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !uuidRE.MatchString(id) {
+		h.writeError(w, http.StatusBadRequest, "invalid conversation id")
+		return
+	}
+
+	var body reviewRequest
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := body.validate(); err != nil {
+		h.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := h.storage.SaveUserMessage(id, body.Content); err != nil {
+		if _, ok := errors.AsType[*storage.NotFoundError](err); ok {
+			h.writeError(w, http.StatusNotFound, "not found")
+			return
+		}
+		h.logger.Error("save review user message", "id", id, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	var (
+		stage1Results []council.StageOneResult
+		stage2Data    council.Stage2CompleteData
+		stage3Result  council.StageThreeResult
+	)
+
+	if err := h.runner.RunFull(r.Context(), body.Content, "code-review", func(eventType string, data any) {
+		switch eventType {
+		case "stage1_complete":
+			if v, ok := data.([]council.StageOneResult); ok {
+				stage1Results = v
+			}
+		case "stage2_complete":
+			if v, ok := data.(council.Stage2CompleteData); ok {
+				stage2Data = v
+			}
+		case "stage3_complete":
+			if v, ok := data.(council.StageThreeResult); ok {
+				stage3Result = v
+			}
+		}
+	}); err != nil {
+		h.handleRunError(w, id, err)
+		return
+	}
+
+	msg := council.AssistantMessage{
+		Role:     "assistant",
+		Stage1:   stage1Results,
+		Stage2:   stage2Data.Results,
+		Stage3:   stage3Result,
+		Metadata: stage2Data.Metadata,
+	}
+
+	if err := h.storage.SaveAssistantMessage(id, msg); err != nil {
+		h.logger.Error("save review assistant message", "id", id, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, msg)
+}
+
+func (h *Handler) sendReviewStream(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		h.writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	id := r.PathValue("id")
+	if !uuidRE.MatchString(id) {
+		h.writeError(w, http.StatusBadRequest, "invalid conversation id")
+		return
+	}
+
+	var body reviewRequest
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := body.validate(); err != nil {
+		h.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := h.storage.SaveUserMessage(id, body.Content); err != nil {
+		if _, ok := errors.AsType[*storage.NotFoundError](err); ok {
+			h.writeError(w, http.StatusNotFound, "not found")
+			return
+		}
+		h.logger.Error("save review user message (stream)", "id", id, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	sendSSE := func(eventType string, data any) {
+		b, _ := json.Marshal(data)
+		envelope, _ := json.Marshal(sseEnvelope{Type: eventType, Data: b})
+		fmt.Fprintf(w, "data: %s\n\n", envelope)
+		flusher.Flush()
+	}
+
+	var (
+		stage1Results []council.StageOneResult
+		stage2Data    council.Stage2CompleteData
+		stage3Result  council.StageThreeResult
+	)
+
+	if err := h.runner.RunFull(r.Context(), body.Content, "code-review", func(eventType string, data any) {
+		switch eventType {
+		case "stage1_complete":
+			if v, ok := data.([]council.StageOneResult); ok {
+				stage1Results = v
+			}
+		case "stage2_complete":
+			if v, ok := data.(council.Stage2CompleteData); ok {
+				stage2Data = v
+			}
+		case "stage3_complete":
+			if v, ok := data.(council.StageThreeResult); ok {
+				stage3Result = v
+			}
+		}
+		sendSSE(eventType, data)
+	}); err != nil {
+		sendSSE("error", map[string]string{"message": err.Error()})
+		return
+	}
+
+	msg := council.AssistantMessage{
+		Role:     "assistant",
+		Stage1:   stage1Results,
+		Stage2:   stage2Data.Results,
+		Stage3:   stage3Result,
+		Metadata: stage2Data.Metadata,
+	}
+	_ = h.storage.SaveAssistantMessage(id, msg)
 }
 
 // handleRunError translates RunFull errors to HTTP responses.

--- a/internal/api/review_handler_test.go
+++ b/internal/api/review_handler_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/valpere/llm-council/internal/council"
+)
+
+func TestSendReview_Returns200WithStage3Content(t *testing.T) {
+	runner := &mockRunner{
+		runFull: func(ctx context.Context, query, councilType string, onEvent council.EventFunc) error {
+			if councilType != "code-review" {
+				t.Errorf("expected council_type=code-review, got %q", councilType)
+			}
+			onEvent("stage1_complete", []council.StageOneResult{})
+			onEvent("stage2_complete", council.Stage2CompleteData{})
+			onEvent("stage3_complete", council.StageThreeResult{Content: "## Review\n\nLGTM"})
+			return nil
+		},
+	}
+	h := newTestHandler(okStorer(), runner)
+
+	body := bytes.NewBufferString(`{"content": "diff --git a/main.go..."}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/review", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+	h.sendReview(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var msg council.AssistantMessage
+	if err := json.NewDecoder(w.Body).Decode(&msg); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if msg.Stage3.Content != "## Review\n\nLGTM" {
+		t.Errorf("unexpected stage3 content: %q", msg.Stage3.Content)
+	}
+}
+
+func TestSendReview_AlwaysUsesCodeReviewCouncilType(t *testing.T) {
+	var capturedType string
+	runner := &mockRunner{
+		runFull: func(_ context.Context, _, councilType string, onEvent council.EventFunc) error {
+			capturedType = councilType
+			onEvent("stage3_complete", council.StageThreeResult{Content: "ok"})
+			return nil
+		},
+	}
+	h := newTestHandler(okStorer(), runner)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/review",
+		bytes.NewBufferString(`{"content":"diff"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+	h.sendReview(w, req)
+
+	if capturedType != "code-review" {
+		t.Errorf("expected council type 'code-review', got %q", capturedType)
+	}
+}
+
+func TestSendReview_EmptyContent_Returns400(t *testing.T) {
+	h := newTestHandler(okStorer(), &mockRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/review",
+		bytes.NewBufferString(`{"content":""}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+	h.sendReview(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestSendReview_InvalidUUID_Returns400(t *testing.T) {
+	h := newTestHandler(okStorer(), &mockRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/not-a-uuid/review",
+		bytes.NewBufferString(`{"content":"diff"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", "not-a-uuid")
+	w := httptest.NewRecorder()
+	h.sendReview(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestSendReviewStream_EmitsSSEEvents(t *testing.T) {
+	runner := &mockRunner{
+		runFull: func(_ context.Context, _, _ string, onEvent council.EventFunc) error {
+			onEvent("stage1_complete", []council.StageOneResult{})
+			onEvent("stage2_complete", council.Stage2CompleteData{})
+			onEvent("stage3_complete", council.StageThreeResult{Content: "final"})
+			return nil
+		},
+	}
+	h := newTestHandler(okStorer(), runner)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/review/stream",
+		bytes.NewBufferString(`{"content":"diff"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+	h.sendReviewStream(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{"stage1_complete", "stage2_complete", "stage3_complete"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("SSE body missing event %q", want)
+		}
+	}
+}

--- a/internal/api/review_handler_test.go
+++ b/internal/api/review_handler_test.go
@@ -116,7 +116,7 @@ func TestSendReviewStream_EmitsSSEEvents(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 	body := w.Body.String()
-	for _, want := range []string{"stage1_complete", "stage2_complete", "stage3_complete"} {
+	for _, want := range []string{"stage1_complete", "stage2_complete", "stage3_complete", `"type":"complete"`} {
 		if !strings.Contains(body, want) {
 			t.Errorf("SSE body missing event %q", want)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,11 @@ type Config struct {
 	DefaultCouncilChairmanModel string
 	DefaultCouncilTemperature   float64
 
+	// Code-review council (RoleBasedReview strategy).
+	// Defaults to DefaultCouncilModels / DefaultCouncilChairmanModel when not set.
+	CodeReviewModels        []string
+	CodeReviewChairmanModel string
+
 	// Stage 0 clarification loop. ClarificationMaxRounds == 0 disables the feature (set CLARIFICATION_MAX_ROUNDS=0 to disable).
 	ClarificationMaxRounds            int
 	ClarificationMaxTotalQuestions    int
@@ -72,6 +77,24 @@ func Load() (*Config, error) {
 	if chairmanModel == "" {
 		slog.Warn("CHAIRMAN_MODEL not set; using local-dev fallback model")
 		chairmanModel = "openai/gpt-4o-mini"
+	}
+
+	// Code-review models — defaults to council models when CODE_REVIEW_MODELS is not set.
+	var codeReviewModels []string
+	if raw := os.Getenv("CODE_REVIEW_MODELS"); raw != "" {
+		for _, m := range strings.Split(raw, ",") {
+			if m = strings.TrimSpace(m); m != "" {
+				codeReviewModels = append(codeReviewModels, m)
+			}
+		}
+	}
+	if len(codeReviewModels) == 0 {
+		codeReviewModels = models
+	}
+
+	codeReviewChairmanModel := os.Getenv("CODE_REVIEW_CHAIRMAN_MODEL")
+	if codeReviewChairmanModel == "" {
+		codeReviewChairmanModel = chairmanModel
 	}
 
 	temperature := 0.7
@@ -132,6 +155,8 @@ func Load() (*Config, error) {
 		DefaultCouncilModels:        models,
 		DefaultCouncilChairmanModel: chairmanModel,
 		DefaultCouncilTemperature:   temperature,
+		CodeReviewModels:            codeReviewModels,
+		CodeReviewChairmanModel:     codeReviewChairmanModel,
 
 		ClarificationMaxRounds:            clarificationMaxRounds,
 		ClarificationMaxTotalQuestions:    clarificationMaxTotalQuestions,

--- a/internal/council/prompts.go
+++ b/internal/council/prompts.go
@@ -255,3 +255,39 @@ func BuildStage3Prompt(query string, rankings []StageTwoResult, labelToModel map
 		{Role: "user", Content: sb.String()},
 	}
 }
+
+// BuildRoleStage1Prompt returns messages for a role participant.
+// The system message carries the role instruction; the user message carries the query.
+func BuildRoleStage1Prompt(role Role, query string) []ChatMessage {
+	return []ChatMessage{
+		{Role: "system", Content: role.Instruction},
+		{Role: "user", Content: query},
+	}
+}
+
+// BuildRoleChairmanPrompt returns messages for the chairman to synthesise role findings.
+// Each role's findings appear in a labelled section. The chairman produces the final review.
+func BuildRoleChairmanPrompt(query string, results []StageOneResult) []ChatMessage {
+	var sb strings.Builder
+	sb.WriteString("You are the lead reviewer. Synthesise the findings below into a clear, ")
+	sb.WriteString("prioritised review. Remove duplicates. Group by file. Order by severity ")
+	sb.WriteString("(critical → high → medium → low). Note which role(s) flagged each issue.\n\n")
+	sb.WriteString("ORIGINAL QUERY:\n")
+	sb.WriteString(query)
+	sb.WriteString("\n\n")
+
+	for _, r := range results {
+		sb.WriteString("=== ")
+		sb.WriteString(r.Label)
+		sb.WriteString(" REVIEWER FINDINGS ===\n")
+		sb.WriteString(r.Content)
+		sb.WriteString("\n\n")
+	}
+
+	sb.WriteString("Write your synthesised review in Markdown. ")
+	sb.WriteString("If there are no findings across all reviewers, state that explicitly.")
+
+	return []ChatMessage{
+		{Role: "user", Content: sb.String()},
+	}
+}

--- a/internal/council/prompts_role_test.go
+++ b/internal/council/prompts_role_test.go
@@ -1,0 +1,62 @@
+package council
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildRoleStage1Prompt_ContainsInstruction(t *testing.T) {
+	role := Role{Name: "security", Instruction: "Find security vulnerabilities."}
+	msgs := BuildRoleStage1Prompt(role, "Review this diff: +foo()")
+
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages (system + user), got %d", len(msgs))
+	}
+	if msgs[0].Role != "system" {
+		t.Errorf("first message must be system, got %q", msgs[0].Role)
+	}
+	if !strings.Contains(msgs[0].Content, "Find security vulnerabilities.") {
+		t.Errorf("system message must contain role instruction, got: %q", msgs[0].Content)
+	}
+	if msgs[1].Role != "user" {
+		t.Errorf("second message must be user, got %q", msgs[1].Role)
+	}
+	if !strings.Contains(msgs[1].Content, "+foo()") {
+		t.Errorf("user message must contain query, got: %q", msgs[1].Content)
+	}
+}
+
+func TestBuildRoleChairmanPrompt_ContainsRoleNames(t *testing.T) {
+	results := []StageOneResult{
+		{Label: "security", Content: `[{"file":"main.go","line":10,"severity":"high","body":"SQL injection"}]`},
+		{Label: "logic", Content: `[{"file":"main.go","line":20,"severity":"medium","body":"nil dereference"}]`},
+	}
+	msgs := BuildRoleChairmanPrompt("Review this diff", results)
+
+	if len(msgs) == 0 {
+		t.Fatal("expected at least one message")
+	}
+	combined := ""
+	for _, m := range msgs {
+		combined += m.Content
+	}
+	if !strings.Contains(combined, "security") {
+		t.Error("chairman prompt must include role name 'security'")
+	}
+	if !strings.Contains(combined, "logic") {
+		t.Error("chairman prompt must include role name 'logic'")
+	}
+	if !strings.Contains(combined, "SQL injection") {
+		t.Error("chairman prompt must include findings content")
+	}
+	if !strings.Contains(combined, "Review this diff") {
+		t.Error("chairman prompt must include original query")
+	}
+}
+
+func TestBuildRoleChairmanPrompt_EmptyResults(t *testing.T) {
+	msgs := BuildRoleChairmanPrompt("some query", nil)
+	if len(msgs) == 0 {
+		t.Fatal("must return messages even with empty results")
+	}
+}

--- a/internal/council/review_roles.go
+++ b/internal/council/review_roles.go
@@ -1,0 +1,52 @@
+package council
+
+// DefaultReviewRoles are the four specialised roles used by the RoleBasedReview strategy.
+// Each role independently reviews a code diff for a specific class of issues.
+var DefaultReviewRoles = []Role{
+	{
+		Name: "security",
+		Instruction: `You are a security code reviewer. Analyse the code diff for security vulnerabilities.
+Focus on: OWASP Top 10, authentication/authorisation flaws, input validation, SQL/command injection,
+hardcoded secrets, insecure dependencies, cryptography misuse, and unsafe API usage.
+Return ONLY a JSON array of findings. Each finding: {"file":"...","line":N,"severity":"critical|high|medium|low","body":"..."}.
+If no issues found, return an empty array: []`,
+	},
+	{
+		Name: "logic",
+		Instruction: `You are a logic and correctness reviewer. Analyse the code diff for logical errors.
+Focus on: edge cases, nil/null pointer dereferences, off-by-one errors, race conditions,
+incorrect error propagation, wrong algorithm assumptions, and missing bounds checks.
+Return ONLY a JSON array of findings. Each finding: {"file":"...","line":N,"severity":"high|medium|low","body":"..."}.
+If no issues found, return an empty array: []`,
+	},
+	{
+		Name: "simplicity",
+		Instruction: `You are a code quality reviewer. Analyse the code diff for unnecessary complexity and poor readability.
+Focus on: code duplication (DRY violations), overly complex logic (KISS violations),
+premature abstraction (YAGNI violations), poor naming, and missing or misleading comments.
+Return ONLY a JSON array of findings. Each finding: {"file":"...","line":N,"severity":"medium|low","body":"..."}.
+If no issues found, return an empty array: []`,
+	},
+	{
+		Name: "architecture",
+		Instruction: `You are an architecture reviewer. Analyse the code diff for design and structural problems.
+Focus on: layer boundary violations, dependency direction issues, tight coupling, low cohesion,
+interface design problems, missing abstractions, and SOLID principle violations.
+Return ONLY a JSON array of findings. Each finding: {"file":"...","line":N,"severity":"high|medium|low","body":"..."}.
+If no issues found, return an empty array: []`,
+	},
+}
+
+// NewCodeReviewCouncilType returns a CouncilType configured for RoleBasedReview.
+// models are assigned to roles by index (models[i % len(models)]).
+// Pass at least 1 model; passing 4 models assigns one per role.
+func NewCodeReviewCouncilType(models []string, chairmanModel string, temperature float64) CouncilType {
+	return CouncilType{
+		Name:          "code-review",
+		Strategy:      RoleBasedReview,
+		Models:        models,
+		Roles:         DefaultReviewRoles,
+		ChairmanModel: chairmanModel,
+		Temperature:   temperature,
+	}
+}

--- a/internal/council/review_roles.go
+++ b/internal/council/review_roles.go
@@ -48,5 +48,6 @@ func NewCodeReviewCouncilType(models []string, chairmanModel string, temperature
 		Roles:         DefaultReviewRoles,
 		ChairmanModel: chairmanModel,
 		Temperature:   temperature,
+		QuorumMin:     len(DefaultReviewRoles),
 	}
 }

--- a/internal/council/review_roles_test.go
+++ b/internal/council/review_roles_test.go
@@ -1,0 +1,51 @@
+package council
+
+import "testing"
+
+func TestDefaultReviewRoles_Count(t *testing.T) {
+	if len(DefaultReviewRoles) < 3 {
+		t.Fatalf("expected at least 3 default review roles, got %d", len(DefaultReviewRoles))
+	}
+}
+
+func TestDefaultReviewRoles_UniqueNames(t *testing.T) {
+	seen := map[string]bool{}
+	for _, r := range DefaultReviewRoles {
+		if r.Name == "" {
+			t.Error("role has empty name")
+		}
+		if seen[r.Name] {
+			t.Errorf("duplicate role name: %q", r.Name)
+		}
+		seen[r.Name] = true
+	}
+}
+
+func TestDefaultReviewRoles_InstructionsNonEmpty(t *testing.T) {
+	for _, r := range DefaultReviewRoles {
+		if r.Instruction == "" {
+			t.Errorf("role %q has empty instruction", r.Name)
+		}
+	}
+}
+
+func TestNewCodeReviewCouncilType_Strategy(t *testing.T) {
+	models := []string{"model-a", "model-b", "model-c", "model-d"}
+	chairman := "chairman-model"
+	ct := NewCodeReviewCouncilType(models, chairman, 0.7)
+
+	if ct.Strategy != RoleBasedReview {
+		t.Errorf("expected RoleBasedReview strategy, got %d", ct.Strategy)
+	}
+	if ct.Name != "code-review" {
+		t.Errorf("expected name 'code-review', got %q", ct.Name)
+	}
+	if len(ct.Roles) != len(DefaultReviewRoles) {
+		t.Errorf("expected %d roles, got %d", len(DefaultReviewRoles), len(ct.Roles))
+	}
+	for i, r := range ct.Roles {
+		if r.Name != DefaultReviewRoles[i].Name {
+			t.Errorf("role[%d]: expected %q, got %q", i, DefaultReviewRoles[i].Name, r.Name)
+		}
+	}
+}

--- a/internal/council/rolebased.go
+++ b/internal/council/rolebased.go
@@ -44,7 +44,7 @@ func (c *Council) runRoleBased(ctx context.Context, query string, ct CouncilType
 		ConsensusW:        1.0, // roles are complementary, not competing
 	}
 	if onEvent != nil {
-		onEvent("stage2_complete", Stage2CompleteData{Results: nil, Metadata: meta})
+		onEvent("stage2_complete", Stage2CompleteData{Results: []StageTwoResult{}, Metadata: meta})
 	}
 
 	// Stage 3: chairman synthesis.

--- a/internal/council/rolebased.go
+++ b/internal/council/rolebased.go
@@ -1,0 +1,124 @@
+package council
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// runRoleBased executes the role-based 2-stage pipeline (Stage 1 + Stage 3).
+// Stage 2 is skipped; a minimal Stage2CompleteData event is emitted for SSE compatibility.
+func (c *Council) runRoleBased(ctx context.Context, query string, ct CouncilType, onEvent EventFunc) error {
+	if len(ct.Roles) == 0 {
+		return fmt.Errorf("council type %q has no roles configured", ct.Name)
+	}
+	if len(ct.Models) == 0 {
+		return fmt.Errorf("council type %q has no models configured", ct.Name)
+	}
+
+	// Stage 1: parallel role execution.
+	stage1 := c.runRoleBasedStage1(ctx, query, ct)
+
+	successful, err := checkQuorum(stage1, ct.QuorumMin)
+	if err != nil {
+		return err
+	}
+
+	// Build labelToModel map (role name → model used).
+	labelToModel := make(map[string]string, len(successful))
+	for _, r := range successful {
+		labelToModel[r.Label] = r.Model
+	}
+
+	if onEvent != nil {
+		onEvent("stage1_complete", successful)
+	}
+
+	// Stage 2: skipped for role-based strategies.
+	// Emit a minimal Stage2CompleteData so SSE clients receive the expected event.
+	meta := Metadata{
+		CouncilType:  ct.Name,
+		LabelToModel: labelToModel,
+		ConsensusW:   1.0, // roles are complementary, not competing
+	}
+	if onEvent != nil {
+		onEvent("stage2_complete", Stage2CompleteData{Results: nil, Metadata: meta})
+	}
+
+	// Stage 3: chairman synthesis.
+	stage3, err := c.runRoleBasedStage3(ctx, query, successful, ct.ChairmanModel, ct.Temperature)
+	if err != nil {
+		return err
+	}
+	if onEvent != nil {
+		onEvent("stage3_complete", stage3)
+	}
+	return nil
+}
+
+// runRoleBasedStage1 executes all roles concurrently.
+// Model assignment: ct.Models[i % len(ct.Models)].
+func (c *Council) runRoleBasedStage1(ctx context.Context, query string, ct CouncilType) []StageOneResult {
+	results := make([]StageOneResult, len(ct.Roles))
+	var wg sync.WaitGroup
+
+	for i, role := range ct.Roles {
+		wg.Add(1)
+		go func(idx int, r Role) {
+			defer wg.Done()
+			model := ct.Models[idx%len(ct.Models)]
+			start := time.Now()
+
+			msgs := BuildRoleStage1Prompt(r, query)
+			resp, err := c.client.Complete(ctx, CompletionRequest{
+				Model:       model,
+				Messages:    msgs,
+				Temperature: ct.Temperature,
+			})
+
+			result := StageOneResult{
+				Label:      r.Name,
+				Model:      model,
+				DurationMs: time.Since(start).Milliseconds(),
+			}
+			if err != nil {
+				result.Error = err
+			} else if len(resp.Choices) == 0 {
+				result.Error = fmt.Errorf("role %q: empty response from %s", r.Name, model)
+			} else {
+				result.Content = resp.Choices[0].Message.Content
+			}
+			results[idx] = result
+		}(i, role)
+	}
+	wg.Wait()
+	return results
+}
+
+// runRoleBasedStage3 asks the chairman to synthesise all role findings.
+func (c *Council) runRoleBasedStage3(ctx context.Context, query string, roleResults []StageOneResult, chairmanModel string, temperature float64) (StageThreeResult, error) {
+	start := time.Now()
+	msgs := BuildRoleChairmanPrompt(query, roleResults)
+
+	resp, err := c.client.Complete(ctx, CompletionRequest{
+		Model:       chairmanModel,
+		Messages:    msgs,
+		Temperature: temperature,
+	})
+
+	result := StageThreeResult{
+		Model:      chairmanModel,
+		DurationMs: time.Since(start).Milliseconds(),
+	}
+	if err != nil {
+		result.Error = err
+		return result, fmt.Errorf("role-based chairman (%s): %w", chairmanModel, err)
+	}
+	if len(resp.Choices) == 0 {
+		result.Error = fmt.Errorf("empty response from chairman %s", chairmanModel)
+		return result, result.Error
+	}
+	result.Content = resp.Choices[0].Message.Content
+	return result, nil
+}

--- a/internal/council/rolebased.go
+++ b/internal/council/rolebased.go
@@ -38,9 +38,10 @@ func (c *Council) runRoleBased(ctx context.Context, query string, ct CouncilType
 	// Stage 2: skipped for role-based strategies.
 	// Emit a minimal Stage2CompleteData so SSE clients receive the expected event.
 	meta := Metadata{
-		CouncilType:  ct.Name,
-		LabelToModel: labelToModel,
-		ConsensusW:   1.0, // roles are complementary, not competing
+		CouncilType:       ct.Name,
+		LabelToModel:      labelToModel,
+		AggregateRankings: []RankedModel{},
+		ConsensusW:        1.0, // roles are complementary, not competing
 	}
 	if onEvent != nil {
 		onEvent("stage2_complete", Stage2CompleteData{Results: nil, Metadata: meta})

--- a/internal/council/rolebased_test.go
+++ b/internal/council/rolebased_test.go
@@ -3,6 +3,7 @@ package council
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -198,5 +199,122 @@ func TestRunRoleBased_ModelsAssignedByIndex(t *testing.T) {
 	}
 	if modelUsed["Role 2"] != "model-a" {
 		t.Errorf("role 2 should cycle back to model-a, got %q", modelUsed["Role 2"])
+	}
+}
+
+func TestRunRoleBasedReview_FullPipeline_EmitsAllEvents(t *testing.T) {
+	registry := map[string]CouncilType{
+		"code-review": NewCodeReviewCouncilType(
+			[]string{"model-a", "model-b", "model-c", "model-d"},
+			"chairman",
+			0.7,
+		),
+	}
+	c := NewCouncil(&mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			if req.Model == "chairman" {
+				return makeResponse("## Review\n\nNo critical issues."), nil
+			}
+			return makeResponse(`[{"file":"main.go","line":1,"severity":"low","body":"ok"}]`), nil
+		},
+	}, registry, nil)
+
+	var events []string
+	var stage3Content string
+	err := c.RunFull(context.Background(), "git diff HEAD...", "code-review", func(eventType string, data any) {
+		events = append(events, eventType)
+		if eventType == "stage3_complete" {
+			if r, ok := data.(StageThreeResult); ok {
+				stage3Content = r.Content
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"stage1_complete", "stage2_complete", "stage3_complete"}
+	if len(events) != len(want) {
+		t.Fatalf("expected events %v, got %v", want, events)
+	}
+	for i, e := range want {
+		if events[i] != e {
+			t.Errorf("event[%d]: want %q, got %q", i, e, events[i])
+		}
+	}
+	if stage3Content == "" {
+		t.Error("stage3 content must not be empty")
+	}
+}
+
+func TestRunRoleBasedReview_Stage1HasFourRoles(t *testing.T) {
+	registry := map[string]CouncilType{
+		"code-review": NewCodeReviewCouncilType(
+			[]string{"model-a"},
+			"chairman",
+			0.7,
+		),
+	}
+
+	var stage1Results any
+	c := NewCouncil(&mockLLMClient{
+		complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+			return makeResponse("[]"), nil
+		},
+	}, registry, nil)
+
+	_ = c.RunFull(context.Background(), "diff", "code-review", func(eventType string, data any) {
+		if eventType == "stage1_complete" {
+			stage1Results = data
+		}
+	})
+
+	results, ok := stage1Results.([]StageOneResult)
+	if !ok {
+		t.Fatalf("stage1_complete data must be []StageOneResult, got %T", stage1Results)
+	}
+	if len(results) != len(DefaultReviewRoles) {
+		t.Errorf("expected %d role results, got %d", len(DefaultReviewRoles), len(results))
+	}
+
+	labels := map[string]bool{}
+	for _, r := range results {
+		labels[r.Label] = true
+	}
+	for _, role := range DefaultReviewRoles {
+		if !labels[role.Name] {
+			t.Errorf("missing role %q in stage1 results", role.Name)
+		}
+	}
+}
+
+func TestRunRoleBasedReview_ChairmanReceivesAllFindings(t *testing.T) {
+	registry := map[string]CouncilType{
+		"code-review": NewCodeReviewCouncilType(
+			[]string{"model-a"},
+			"chairman",
+			0.7,
+		),
+	}
+
+	var chairmanPrompt string
+	c := NewCouncil(&mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			if req.Model == "chairman" {
+				for _, m := range req.Messages {
+					chairmanPrompt += m.Content
+				}
+				return makeResponse("final review"), nil
+			}
+			return makeResponse(`[{"file":"x.go","line":1,"severity":"high","body":"issue"}]`), nil
+		},
+	}, registry, nil)
+
+	_ = c.RunFull(context.Background(), "diff", "code-review", func(string, any) {})
+
+	for _, role := range DefaultReviewRoles {
+		if !strings.Contains(chairmanPrompt, role.Name) {
+			t.Errorf("chairman prompt must mention role %q", role.Name)
+		}
 	}
 }

--- a/internal/council/rolebased_test.go
+++ b/internal/council/rolebased_test.go
@@ -1,0 +1,202 @@
+package council
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// roleCouncilFixture returns a Council wired for RoleBased strategy with 2 roles.
+func roleCouncilFixture(complete func(ctx context.Context, req CompletionRequest) (CompletionResponse, error)) *Council {
+	registry := map[string]CouncilType{
+		"roles": {
+			Name:          "roles",
+			Strategy:      RoleBased,
+			Models:        []string{"model-a", "model-b"},
+			ChairmanModel: "chairman",
+			Temperature:   0.7,
+			Roles: []Role{
+				{Name: "security", Instruction: "Find security issues."},
+				{Name: "logic", Instruction: "Find logic errors."},
+			},
+		},
+	}
+	return NewCouncil(&mockLLMClient{complete: complete}, registry, nil)
+}
+
+func TestRunRoleBased_Stage1_ParallelRoles(t *testing.T) {
+	var mu sync.Mutex
+	called := map[string]int{}
+
+	c := roleCouncilFixture(func(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+		mu.Lock()
+		called[req.Model]++
+		mu.Unlock()
+		return makeResponse(`[{"file":"a.go","line":1,"severity":"low","body":"ok"}]`), nil
+	})
+
+	var events []string
+	err := c.RunFull(context.Background(), "diff here", "roles", func(eventType string, _ any) {
+		events = append(events, eventType)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 2 role models + 1 chairman = 3 calls total
+	total := 0
+	for _, n := range called {
+		total += n
+	}
+	if total != 3 {
+		t.Errorf("expected 3 LLM calls (2 roles + chairman), got %d", total)
+	}
+}
+
+func TestRunRoleBased_EmitsAllThreeEvents(t *testing.T) {
+	c := roleCouncilFixture(func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+		return makeResponse("findings"), nil
+	})
+
+	var events []string
+	err := c.RunFull(context.Background(), "query", "roles", func(eventType string, _ any) {
+		events = append(events, eventType)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"stage1_complete", "stage2_complete", "stage3_complete"}
+	if len(events) != len(want) {
+		t.Fatalf("expected events %v, got %v", want, events)
+	}
+	for i, e := range want {
+		if events[i] != e {
+			t.Errorf("event[%d]: want %q, got %q", i, e, events[i])
+		}
+	}
+}
+
+func TestRunRoleBased_QuorumFailure_ReturnsError(t *testing.T) {
+	c := roleCouncilFixture(func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+		if req.Model != "chairman" {
+			return CompletionResponse{}, errors.New("role model down")
+		}
+		return makeResponse("ok"), nil
+	})
+
+	err := c.RunFull(context.Background(), "query", "roles", func(string, any) {})
+	if err == nil {
+		t.Fatal("expected quorum error, got nil")
+	}
+	var qe *QuorumError
+	if !errors.As(err, &qe) {
+		t.Errorf("expected *QuorumError, got %T: %v", err, err)
+	}
+}
+
+func TestRunRoleBased_Stage1UsesRoleInstructions(t *testing.T) {
+	var systemPrompts []string
+	var mu sync.Mutex
+
+	c := roleCouncilFixture(func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+		for _, m := range req.Messages {
+			if m.Role == "system" {
+				mu.Lock()
+				systemPrompts = append(systemPrompts, m.Content)
+				mu.Unlock()
+			}
+		}
+		return makeResponse("[]"), nil
+	})
+
+	_ = c.RunFull(context.Background(), "query", "roles", func(string, any) {})
+
+	if len(systemPrompts) < 2 {
+		t.Fatalf("expected at least 2 system prompts (one per role), got %d", len(systemPrompts))
+	}
+	found := map[string]bool{}
+	for _, p := range systemPrompts {
+		if p == "Find security issues." {
+			found["security"] = true
+		}
+		if p == "Find logic errors." {
+			found["logic"] = true
+		}
+	}
+	if !found["security"] {
+		t.Error("security role instruction not sent to any model")
+	}
+	if !found["logic"] {
+		t.Error("logic role instruction not sent to any model")
+	}
+}
+
+func TestRunRoleBased_Stage2CompleteData_HasLabelToModel(t *testing.T) {
+	c := roleCouncilFixture(func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+		return makeResponse("[]"), nil
+	})
+
+	var stage2Data any
+	_ = c.RunFull(context.Background(), "query", "roles", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			stage2Data = data
+		}
+	})
+
+	d, ok := stage2Data.(Stage2CompleteData)
+	if !ok {
+		t.Fatalf("stage2_complete data must be Stage2CompleteData, got %T", stage2Data)
+	}
+	if d.Metadata.LabelToModel == nil {
+		t.Fatal("LabelToModel must not be nil")
+	}
+	if _, ok := d.Metadata.LabelToModel["security"]; !ok {
+		t.Error("LabelToModel must contain 'security' role")
+	}
+}
+
+func TestRunRoleBased_ModelsAssignedByIndex(t *testing.T) {
+	// 3 roles, 2 models → models assigned: role0→model-a, role1→model-b, role2→model-a
+	registry := map[string]CouncilType{
+		"three-roles": {
+			Name:          "three-roles",
+			Strategy:      RoleBased,
+			Models:        []string{"model-a", "model-b"},
+			ChairmanModel: "chairman",
+			Temperature:   0.7,
+			Roles: []Role{
+				{Name: "r0", Instruction: "Role 0"},
+				{Name: "r1", Instruction: "Role 1"},
+				{Name: "r2", Instruction: "Role 2"},
+			},
+		},
+	}
+	var mu sync.Mutex
+	modelUsed := map[string]string{} // system instruction → model used
+
+	c := NewCouncil(&mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			for _, m := range req.Messages {
+				if m.Role == "system" {
+					mu.Lock()
+					modelUsed[m.Content] = req.Model
+					mu.Unlock()
+				}
+			}
+			return makeResponse("[]"), nil
+		},
+	}, registry, nil)
+
+	_ = c.RunFull(context.Background(), "q", "three-roles", func(string, any) {})
+
+	if modelUsed["Role 0"] != "model-a" {
+		t.Errorf("role 0 should use model-a, got %q", modelUsed["Role 0"])
+	}
+	if modelUsed["Role 1"] != "model-b" {
+		t.Errorf("role 1 should use model-b, got %q", modelUsed["Role 1"])
+	}
+	if modelUsed["Role 2"] != "model-a" {
+		t.Errorf("role 2 should cycle back to model-a, got %q", modelUsed["Role 2"])
+	}
+}

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -61,6 +61,8 @@ func (c *Council) RunFull(ctx context.Context, query string, councilTypeName str
 	switch ct.Strategy {
 	case PeerReview:
 		return c.runPeerReview(ctx, query, ct, onEvent)
+	case RoleBased, RoleBasedReview:
+		return c.runRoleBased(ctx, query, ct, onEvent)
 	default:
 		return fmt.Errorf("council: strategy %d not implemented", ct.Strategy)
 	}

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -52,17 +52,22 @@ func NewCouncil(client LLMClient, registry map[string]CouncilType, logger *slog.
 var _ Runner = (*Council)(nil)
 var _ Stage0Runner = (*Council)(nil)
 
-// RunFull orchestrates the full LCCP Core deliberation pipeline:
-// label assignment → Stage 1 → quorum check → Stage 2 → Kendall's W → Stage 3.
-// Events are emitted synchronously via onEvent so the caller can flush after each.
-// Returns *QuorumError immediately if stage 1 quorum is not met (no stage2/3 events).
-// Returns an error for unknown councilTypeName or stage 3 failures.
+// RunFull dispatches to the pipeline implementation for the council type's strategy.
 func (c *Council) RunFull(ctx context.Context, query string, councilTypeName string, onEvent EventFunc) error {
 	ct, ok := c.registry[councilTypeName]
 	if !ok {
 		return fmt.Errorf("council: unknown council type %q", councilTypeName)
 	}
+	switch ct.Strategy {
+	case PeerReview:
+		return c.runPeerReview(ctx, query, ct, onEvent)
+	default:
+		return fmt.Errorf("council: strategy %d not implemented", ct.Strategy)
+	}
+}
 
+// runPeerReview runs the Karpathy-style 3-stage peer review pipeline.
+func (c *Council) runPeerReview(ctx context.Context, query string, ct CouncilType, onEvent EventFunc) error {
 	// Stage 1 — parallel generation across all configured models.
 	allStage1 := c.runStage1(ctx, query, ct.Models, ct.Temperature)
 
@@ -90,7 +95,6 @@ func (c *Council) RunFull(ctx context.Context, query string, councilTypeName str
 	stage2Results := c.runStage2(ctx, query, successful, ct.Temperature)
 
 	// Compute aggregate rankings and Kendall's W consensus coefficient.
-	// Sort labels for deterministic ranking output across runs.
 	allLabels := make([]string, 0, len(labelToModel))
 	for label := range labelToModel {
 		allLabels = append(allLabels, label)
@@ -108,7 +112,7 @@ func (c *Council) RunFull(ctx context.Context, query string, councilTypeName str
 	}
 
 	metadata := Metadata{
-		CouncilType:       councilTypeName,
+		CouncilType:       ct.Name,
 		LabelToModel:      labelToModel,
 		AggregateRankings: rankedByModel,
 		ConsensusW:        consensusW,

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -5,14 +5,23 @@ type Strategy int
 
 const (
 	PeerReview Strategy = iota
+	RoleBased
+	RoleBasedReview
 )
+
+// Role defines a named participant with a specific mandate in a role-based council.
+type Role struct {
+	Name        string `json:"name"`
+	Instruction string `json:"instruction"` // system-level prompt for this role
+}
 
 // CouncilType describes a named council configuration.
 // QuorumMin of 0 means use the formula: max(2, ⌈N/2⌉+1).
 type CouncilType struct {
 	Name          string
 	Strategy      Strategy
-	Models        []string
+	Models        []string // PeerReview: all council members; RoleBased: assigned to Roles by index mod len
+	Roles         []Role   // RoleBased / RoleBasedReview: role definitions with instructions
 	ChairmanModel string
 	Temperature   float64
 	QuorumMin     int // 0 = use formula: max(2, ⌈N/2⌉+1)

--- a/internal/council/types_role_test.go
+++ b/internal/council/types_role_test.go
@@ -1,0 +1,31 @@
+package council
+
+import "testing"
+
+func TestRoleBasedStrategyConstants(t *testing.T) {
+	if RoleBased == PeerReview {
+		t.Fatal("RoleBased must differ from PeerReview")
+	}
+	if RoleBasedReview == PeerReview {
+		t.Fatal("RoleBasedReview must differ from PeerReview")
+	}
+	if RoleBased == RoleBasedReview {
+		t.Fatal("RoleBased must differ from RoleBasedReview")
+	}
+}
+
+func TestCouncilTypeHasRoles(t *testing.T) {
+	ct := CouncilType{
+		Name:     "test",
+		Strategy: RoleBased,
+		Roles: []Role{
+			{Name: "critic", Instruction: "Find bugs."},
+		},
+	}
+	if len(ct.Roles) != 1 {
+		t.Fatalf("expected 1 role, got %d", len(ct.Roles))
+	}
+	if ct.Roles[0].Name != "critic" {
+		t.Fatalf("unexpected role name %q", ct.Roles[0].Name)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the **RoleBasedReview** deliberation strategy and the `/review` HTTP endpoints that drive it. Four specialised reviewer roles (`security`, `logic`, `simplicity`, `architecture`) analyse a code diff in parallel; the chairman synthesises their findings into a single consolidated review. Stage 2 (peer ranking) is skipped — roles are complementary, not competing.

This PR consolidates work that was previously committed directly to the local `main` branch but never landed on remote. It bundles the 9 implementation commits with the matching documentation commit so the feature ships with its docs.

References (already closed manually as "implemented in commit X"):
- #165 — `Role` type + `RoleBased`/`RoleBasedReview` strategy constants
- #166 — `BuildRoleStage1Prompt` + `BuildRoleChairmanPrompt`
- #167 — refactor: extract `runPeerReview`; `RunFull` dispatches by strategy
- #168 — RoleBased pipeline implementation
- #169 — `DefaultReviewRoles` + `NewCodeReviewCouncilType`
- #170 — register code-review council type, `CODE_REVIEW_*` env vars
- #171 — RoleBasedReview integration tests
- #172 — `POST /review` and `/review/stream` endpoints

Plus one follow-on bug fix:
- Quorum correction for role-based councils (`QuorumMin = len(Roles)`); `AggregateRankings` `nil` → `[]RankedModel{}`; SSE helper fixes in `sendReviewStream`.

And one documentation commit covering all of the above.

## Design notes

- **Strategy dispatch** in `runner.go`: `RunFull` switches on `ct.Strategy`; `PeerReview` → `runPeerReview`, `RoleBased`/`RoleBasedReview` → `runRoleBased`.
- **Quorum:** `QuorumMin = len(DefaultReviewRoles) = 4` for code-review. Each role covers a unique class of issues — partial quorum would silently drop a specialist.
- **SSE compatibility:** `RoleBasedReview` emits a minimal `stage2_complete` event with `data: []` and `consensus_w: 1.0` so the existing frontend dispatcher continues to work without conditionals.
- **Stage 1 labels** for code-review are role names (`security`, etc.) rather than `Response A`/`B`/…; clients can rely on the names.
- **Models → roles** assignment: round-robin (`models[i % len(models)]`). Pass 4 models to get one per role; pass 1 model and all roles run on it.
- **Configuration:** `CODE_REVIEW_MODELS` / `CODE_REVIEW_CHAIRMAN_MODEL` default to the regular `COUNCIL_MODELS` / `CHAIRMAN_MODEL` when unset.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -count=1 ./...` — 122 tests pass across 7 packages, including `TestRunFull_RoleBasedReview_*` and `TestSendReviewStream_*`
- [x] Compile-time `var _ Runner = (*Council)(nil)` assertion still holds for both strategies
- [x] Quorum check: `QuorumMin = len(DefaultReviewRoles)` is asserted in `NewCodeReviewCouncilType`

## Files changed (high level)

- `internal/council/types.go` — `Role`, `RoleBased`, `RoleBasedReview` constants
- `internal/council/prompts.go` — `BuildRoleStage1Prompt`, `BuildRoleChairmanPrompt`
- `internal/council/runner.go` — `runPeerReview` extracted; `RunFull` dispatches
- `internal/council/rolebased.go` — NEW: `runRoleBased` + stages
- `internal/council/review_roles.go` — NEW: `DefaultReviewRoles`, `NewCodeReviewCouncilType`
- `internal/council/rolebased_test.go` — integration tests
- `internal/api/handler.go` — `sendReview`, `sendReviewStream` handlers
- `cmd/server/main.go` — register `code-review` council type
- `internal/config/config.go` — `CODE_REVIEW_*` env vars
- `README.md`, `docs/api.md`, `docs/pipeline.md`, `docs/code-review.md` — full pipeline + endpoint docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)