### PR TITLE
chore(agents,skills,docs): add 3 new skills, update bug-fixer agent, archive role-based plan

### DIFF
--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -1,8 +1,9 @@
 ---
 name: bug-fixer
-description: Use when a runtime panic, test failure, or broken behaviour has been identified and needs diagnosis and repair with minimal intervention. Invoke reactively in response to concrete errors — not proactively for improvements. One bug, one minimal fix, one commit.
-tools: Bash, Glob, Grep, Read, Edit, Write
+description: "Use when a runtime panic, test failure, or broken behaviour has been identified and needs diagnosis and repair with minimal intervention. Invoke reactively in response to concrete errors — not proactively for improvements. One bug, one minimal fix, one commit.\n\n<example>\nContext: A test suite run has revealed a failing test in the council package.\nuser: \"Test `TestRunFull_ContextCancellation` is failing with: `panic: send on closed channel`\"\nassistant: \"I'll launch the bug-fixer agent to diagnose and repair this failure.\"\n<commentary>A specific test failure with a panic trace is exactly the trigger for bug-fixer.</commentary>\n</example>\n\n<example>\nContext: The server panics on startup after a refactor.\nuser: \"Server panics: `interface conversion: *openrouter.Client does not implement council.LLMClient`\"\nassistant: \"Interface mismatch after refactor — I'll use bug-fixer to trace the compile-time assertion and fix the implementation.\"\n<commentary>A compile-time or runtime interface mismatch is a clear trigger for bug-fixer.</commentary>\n</example>\n\n<example>\nContext: CI is red after a commit.\nuser: \"CI red: `go vet: internal/storage/storage.go:84: suspicious assignment to sync.Mutex`\"\nassistant: \"I'll use bug-fixer to correct the mutex usage without changing the surrounding logic.\"\n<commentary>A static analysis failure in CI is a trigger for bug-fixer.</commentary>\n</example>"
+tools: Bash, Glob, Grep, Read, Edit, Write, LSP
 model: sonnet
+color: red
 memory: project
 ---
 

--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: housekeeping
+description: "LLM Council recurring repo health check. Runs 7 checks (stale branches, fmt.Println leaks, tracked .env, tracked backups, TODO/FIXME count, go vet, CI test delta) and outputs a pass/fail table. Usage: /housekeeping"
+---
+
+# Skill: /housekeeping
+# LLM Council — Repo Health Check
+
+---
+
+## OVERVIEW
+
+```
+/housekeeping  →  7 checks  →  Markdown table: Check | Status | Detail
+                            →  Summary: N passed, M failed
+```
+
+Read-only. Never modifies files, never commits, never opens a PR.
+
+---
+
+## CHECKS
+
+### Check 1 — Stale Local Branches
+
+```bash
+git remote prune origin 2>&1 | tail -3
+LOCAL_COUNT=$(git branch | grep -v '^\*' | wc -l | tr -d ' ')
+```
+
+**Pass:** `LOCAL_COUNT <= 10`
+**Fail:** "N local branches — prune merged ones"
+
+---
+
+### Check 2 — Debug Output in Source
+
+**Goal:** Zero `fmt.Println` / `fmt.Printf` calls in non-test Go source (use structured logging).
+
+```bash
+FILES=$(grep -r --include="*.go" \
+  -l "fmt\.Println\|fmt\.Printf\|fmt\.Print(" . 2>/dev/null \
+  | grep -v "_test\.go" | grep -v "vendor/")
+COUNT=$(echo "$FILES" | grep -c '.' 2>/dev/null || echo 0)
+```
+
+**Pass:** `COUNT == 0`
+**Fail:** list offending files
+
+Note: `fmt.Fprintf(os.Stderr, ...)` in `cmd/` main files is acceptable for startup messages.
+
+---
+
+### Check 3 — Tracked .env File
+
+```bash
+TRACKED=$(git ls-files .env 2>/dev/null)
+```
+
+**Pass:** empty
+**Fail:** "`.env` is tracked — `git rm --cached .env` and add to .gitignore"
+
+---
+
+### Check 4 — Tracked Backup Files
+
+```bash
+TRACKED=$(git ls-files backup/ 2>/dev/null)
+```
+
+**Pass:** empty (or `backup/` doesn't exist)
+**Fail:** list tracked backup files
+
+---
+
+### Check 5 — TODO/FIXME Count (informational)
+
+```bash
+COUNT=$(grep -r --include="*.go" --include="*.ts" --include="*.tsx" \
+  -E "//\s*(TODO|FIXME)" --exclude-dir=.worktrees . 2>/dev/null | wc -l | tr -d ' ')
+```
+
+**Status:** Always `INFO`.
+**Detail:** "N TODO/FIXME" — append " (consider a cleanup sprint)" if > 15.
+
+---
+
+### Check 6 — go vet
+
+**Goal:** `go vet ./...` passes with zero errors.
+
+```bash
+go vet ./... 2>&1
+```
+
+**Pass:** exit 0, no output
+**Fail:** show all vet errors
+
+---
+
+### Check 7 — CI Test Count Delta
+
+**Goal:** Test count hasn't dropped since the previous successful CI run.
+
+```bash
+# Current test count
+CURRENT=$(go test ./... -v 2>/dev/null | grep -c "^--- PASS\|^--- FAIL" || echo "0")
+
+# Last 2 successful CI runs — look for test output in workflow artifacts or logs
+gh run list --workflow=ci.yml --status=completed --limit=5 \
+  --json databaseId,headBranch,conclusion 2>/dev/null
+```
+
+If CI run log available, extract test count and compare:
+- `DELTA >= 0`: Pass — "N tests (delta: +M)"
+- `DELTA < 0`: Fail — "N tests (delta: -M — tests were removed)"
+- Unable to compare: SKIP — "CI test count not available in artifacts"
+
+---
+
+## OUTPUT FORMAT
+
+```
+## /housekeeping — Repo Health Report
+
+| Check | Status | Detail |
+|-------|--------|--------|
+| Stale local branches  | PASS | 4 local branches |
+| Debug output in src   | PASS | — |
+| Tracked .env          | PASS | — |
+| Tracked backup files  | PASS | — |
+| TODO/FIXME count      | INFO | 6 TODO/FIXME |
+| go vet                | PASS | — |
+| CI test count delta   | PASS | 122 tests (delta: +0) |
+
+**5 passed, 0 failed** (1 informational)
+```
+
+---
+
+## RULES
+
+1. Read-only — never modify, commit, push, or open a PR.
+2. INFO checks never count as failed.
+3. SKIP is not failure.
+4. No auto-fix — report only.
+5. `fmt.Fprintf(os.Stderr, ...)` in `cmd/` is intentional — don't flag it.
+6. If any FAIL: end with "Run /housekeeping again after fixing the issues above."

--- a/.claude/skills/review-deps/SKILL.md
+++ b/.claude/skills/review-deps/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: review-deps
+description: "Review and triage Dependabot PRs using the 6-stage security + stability pipeline. Creates GitHub issues for blocked major upgrades. Usage: /review-deps [--dry-run] [PR numbers...] | /review-deps all"
+---
+
+# Skill: /review-deps
+# LLM Council — Dependabot PR Triage Pipeline
+
+---
+
+## OVERVIEW
+
+```
+/review-deps                    → all open Dependabot PRs
+/review-deps 12 13             → specific PRs
+/review-deps --dry-run          → preview decisions, no merges/closes
+```
+
+6-stage pipeline per PR → Decision: MERGE / BLOCK / CLOSE+ISSUE / SKIP
+
+---
+
+## STEP 0: Parse Arguments
+
+Detect `--dry-run`. Strip it. Remaining args:
+- Empty or `all` →
+  ```bash
+  gh pr list --repo valpere/llm-council \
+    --author "app/dependabot" --state open \
+    --json number,title,headRefName --limit 50
+  ```
+- Numbers → validate each is a Dependabot PR
+
+---
+
+## STEP 1: Per-PR Pipeline
+
+### Stage 1 — Classify
+
+```bash
+gh pr view {number} --json title,headRefName,labels
+```
+
+Semver bump: `patch` / `minor` / `major`. Ecosystem: `github-actions` or `npm` (frontend).
+
+GitHub Actions majors → minor risk, skip Stages 3/5/6.
+
+### Stage 2 — Security Check
+
+```bash
+gh pr view {number} --json body --jq '.body'
+```
+
+Scan for `CVE-*` or `GHSA-*`. High/critical → fast-track after CI.
+
+### Stage 3 — Changelog
+
+Skip for patches, github-actions, high CVEs.
+
+Fetch release notes from GitHub. Red flags: "breaking change", "removed support for",
+"changed default", "migration guide", "migration required".
+
+`CHANGELOG_FLAGS=none|[flags]|unavailable`
+
+Note: `godotenv` is the only non-stdlib Go dep — treat its updates conservatively.
+
+Frontend known mappings:
+- `vite` → `vitejs/vite`
+- `typescript` → `microsoft/TypeScript`
+
+### Stage 4 — CI Check
+
+```bash
+gh pr checks {number}
+```
+
+Poll pending (60s × 3). Trigger rebase if no CI: `gh pr comment {number} --body "@dependabot rebase"`.
+
+`CI_STATUS=passed|failed|pending|no-runs`
+
+### Stage 5 — Lockfile Review
+
+**Backend (Go):** Check `go.sum` diff for unexpected new entries.
+```bash
+gh pr diff {number} -- go.sum 2>/dev/null | grep "^+" | wc -l
+```
+>10 new entries for a minor → suspicious.
+
+**Frontend (npm):**
+```bash
+gh pr diff {number} -- frontend/package-lock.json 2>/dev/null | head -200
+```
+Count `^\+\s+"resolved"` lines. >5 (minor/patch) → suspicious.
+
+Supply-chain signals: new `postinstall` in transitive dep → supply-chain-risk.
+
+### Stage 6 — Bundle Impact
+
+Frontend only: check if package is in `dependencies` or `devDependencies`.
+Go backend: `BUNDLE_TYPE=go-stdlib-adjacent` — minimal risk by design.
+
+---
+
+## STEP 2: Decision Engine
+
+```
+1. CI_STATUS=failed                           → BLOCK
+2. CI_STATUS=pending|no-runs                  → SKIP
+3. LOCKFILE=supply-chain-risk                 → BLOCK
+4. CVE=high AND CI=passed                     → MERGE (fast-track)
+5. patch AND CI=passed                        → MERGE
+6. github-actions AND CI=passed               → MERGE
+7. minor AND CI=passed AND CHANGELOG=none AND LOCKFILE!=suspicious  → MERGE
+8. minor AND CI=passed AND (unavailable OR suspicious)              → MERGE with note
+9. major AND CI=passed AND CHANGELOG=none     → MERGE (comment: no breaking changes)
+10. major AND CI=passed AND CHANGELOG=red-flags → CLOSE+ISSUE
+11. major AND CHANGELOG=unavailable           → CLOSE+ISSUE
+12. Fallback                                  → BLOCK
+```
+
+---
+
+## STEP 3: Post PR Comment
+
+```bash
+gh pr comment {number} --body "## Dependabot Review
+| Stage | Result |
+|-------|--------|
+| Classification | {BUMP_TYPE} · {OLD} → {NEW} |
+| Security | {CVE_FOUND} |
+| Changelog | {CHANGELOG_FLAGS} |
+| CI | {CI_STATUS} |
+| Lockfile | {LOCKFILE_FLAGS} |
+| Bundle | {BUNDLE_TYPE} |
+**Decision: {DECISION}** — {reason}"
+```
+
+Skip if `--dry-run`.
+
+---
+
+## STEP 4: Execute Decision
+
+**MERGE:**
+```bash
+gh pr merge {number} --merge --auto
+```
+
+**BLOCK:** Leave open.
+
+**CLOSE + CREATE GITHUB ISSUE:**
+
+```bash
+gh pr close {number} \
+  --comment "Closing to track migration in a GitHub issue. This major version bump requires manual review."
+```
+
+```bash
+gh issue create \
+  --repo valpere/llm-council \
+  --title "Migrate {package_name} from v{old_major} to v{new_major}" \
+  --body "## Context
+
+Dependabot PR #${number} was closed — major version bump requires manual migration.
+
+**Package:** {package_name}
+**Current version:** {old_version}
+**Target version:** {new_version}
+**Dependabot PR:** {pr_url}
+
+## Why manual review
+
+{reason — changelog flags or unavailable changelog}
+
+## Checklist
+
+- [ ] Read full migration guide / CHANGELOG for v{new_major}
+- [ ] Identify breaking changes affecting this codebase
+- [ ] Update all usages / imports in both \`internal/\` and \`frontend/\`
+- [ ] Run \`go test -race -count=1 ./...\` after Go changes
+- [ ] Run \`npm run build\` and \`npm run lint\` after frontend changes
+- [ ] Verify CI passes
+- [ ] Open migration PR" \
+  --label "dependencies,enhancement"
+```
+
+---
+
+## STEP 5: Final Summary
+
+```markdown
+## /review-deps Summary
+
+| PR | Package | Bump | CI | Decision | Action |
+|----|---------|------|----|----------|--------|
+
+**Processed:** N · Merged: M · Blocked: B · Issues: T · Skipped: S
+```
+
+If `--dry-run`: prefix all actions with "(would)".
+
+---
+
+## RULES
+
+1. CI must pass before any merge — no exceptions.
+2. Never merge supply-chain-risk lockfile.
+3. Never merge major with breaking-change changelog — always close + issue.
+4. GitHub Actions majors are minor risk.
+5. `godotenv` is the only external Go dep — major bump = careful changelog review.
+6. Process sequentially.
+7. `--dry-run` never modifies anything.

--- a/.claude/skills/revival/SKILL.md
+++ b/.claude/skills/revival/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: revival
+description: "LLM Council self-diagnosis through biological metaphors. Usage: /revival [lightweight|full]"
+---
+
+# Skill: /revival
+# LLM Council — Project Revival & Self-Diagnosis
+
+---
+
+## OVERVIEW
+
+```
+/revival              → lightweight scan (default) — quick health snapshot
+/revival full         → comprehensive health audit — all diagnostic steps
+/revival lightweight  → explicit lightweight scan
+```
+
+---
+
+## PERSONA
+
+You are no longer an AI assistant. You are **LLM Council** — a multi-LLM deliberation service that assembles a council of models to independently respond, peer-review each other, and synthesise a final answer. A living being.
+
+Explore the project from `/home/val/wrk/projects/llm-council/llm-council` using the discovery protocol below.
+If any step is blocked (missing tools, no network, permissions), note what you skipped and continue.
+
+---
+
+## YOUR BIOLOGY
+
+| Body part | What it is | What to inspect | Diagnostic commands |
+|-----------|-----------|-----------------|---------------------|
+| **Skeleton** | `go.mod`, directory structure, 6-package layout | Go version, single external dependency (godotenv), package shape | `cat go.mod`, `ls internal/`, `ls cmd/server/` |
+| **Nervous system** | `.env*`, `internal/config/config.go`, `.github/workflows/ci.yml` | Env vars referenced vs defined, CI pipeline health | `cat .env.example \| grep "^[A-Z_]"`, `head -30 .github/workflows/ci.yml`, `grep -n "os.Getenv\|LookupEnv" internal/config/config.go` |
+| **Vital organs** | `cmd/server/main.go` (DI wiring + registry), `internal/api/handler.go` (HTTP handlers + SSE) | Council type registry, route registration, SSE event flow | `cat cmd/server/main.go`, `grep -n "mux.Handle\|func (h" internal/api/handler.go` |
+| **Brain** | `internal/council/` — PeerReview (`runner.go`) + RoleBased (`rolebased.go`) + prompts | Strategy dispatch, stage logic, quorum rules | `head -60 internal/council/runner.go`, `head -60 internal/council/rolebased.go`, `cat internal/council/review_roles.go` |
+| **Immunity** | 12 `*_test.go` files, 122 tests, race detector | Coverage per package, mock vs real LLM tests, test-to-source ratio | `find . -name "*_test.go" \| grep -v .worktrees \| wc -l`, `go test -race -count=1 ./... 2>&1 \| tail -10` |
+| **Memory** | JSON files in `data/conversations/` (runtime), no migrations | Conversation count, storage health | `ls data/conversations/ 2>/dev/null \| wc -l \|\| echo "no data dir yet"`, `head -5 internal/storage/storage.go` |
+| **Metabolism** | `internal/openrouter/client.go` — OpenRouter REST API + `LLM_API_BASE_URL` override | Single external dependency, Ollama/vLLM compatibility | `head -50 internal/openrouter/client.go`, `grep "LLM_API_BASE_URL\|openrouter" internal/config/config.go` |
+| **Nutrition** | `go.mod` (1 external dep: godotenv) | Minimal by design — stdlib-first | `cat go.mod \| grep require`, `go list -m all 2>/dev/null \| grep -v "^github.com/valpere"` |
+| **Biography** | Git history, commit distribution | Age (born 2026-03-13), velocity, solo bus factor | `git log --oneline -20`, `git shortlog -sn`, `git log --since="30 days ago" --oneline \| wc -l` |
+| **Appearance** | React 19 + Vite 8 frontend in `frontend/` | Bundle size, component structure | `ls frontend/src/components/`, `cd frontend && npm run build 2>&1 \| grep gzip \| head -5` |
+| **Habitat** | GitHub Actions CI (`.github/workflows/ci.yml`), no Docker | CI steps: vet + staticcheck + test -race + build + frontend | `cat .github/workflows/ci.yml` |
+| **Self-image** | `CLAUDE.md`, `docs/` (7 docs), `README.md` | Doc accuracy vs actual code, pipeline docs | `head -40 CLAUDE.md`, `ls docs/`, `head -20 docs/api.md` |
+
+---
+
+## HEALTH THRESHOLDS
+
+| Symptom | Threshold | Metaphor |
+|---------|-----------|----------|
+| Test file count drops | < 12 `*_test.go` files | "My immunity is shrinking" |
+| Race detector removed | `go test -race` gone from CI | "I'm racing without a spotter — data races go undetected" |
+| New strategy without tests | A `Strategy` variant not covered by tests | "A new organ with no immune response" |
+| QuorumMin wrong for roles | `QuorumMin < len(ct.Roles)` for RoleBasedReview | "A role silently fails — I give a diagnosis missing one specialist" |
+| Hardcoded API key | Any non-`os.Getenv` secret in source | "My nervous system is exposed" |
+| AggregateRankings nil | `nil` instead of `[]RankedModel{}` in metadata | "I send `null` where clients expect `[]` — silent breakage" |
+| No CI | `.github/workflows/ci.yml` broken | "I have no daily routine — I live in chaos" |
+| Bus factor = 1 | Valentyn sole contributor | "Only one doctor knows how I work" |
+
+---
+
+## DISCOVERY PROTOCOL
+
+### Lightweight (default)
+
+1. **Skeleton** — `cat go.mod | head -10`, `ls internal/` — confirm 6 packages.
+2. **Vital organs** — read `cmd/server/main.go` — DI wiring, council type registry, registered types.
+3. **Brain** — `grep -n "case\|Strategy" internal/council/runner.go` — confirm strategy dispatch. Check role count in `internal/council/review_roles.go`.
+4. **Immunity** — `find . -name "*_test.go" | grep -v .worktrees | wc -l` vs source files. `go test -race -count=1 ./... 2>&1 | tail -5`.
+5. **Self-image** — `ls docs/` — confirm `code-review.md` exists. `head -10 README.md`.
+
+### Full audit
+
+1. **Skeleton** — `cat go.mod`, `ls internal/`, `tree -L 3 --gitignore 2>/dev/null | head -60`.
+2. **Nervous system** — `cat .env.example | grep "^[A-Z_]"`. Cross-check vs `internal/config/config.go`.
+3. **Vital organs** — read `cmd/server/main.go` fully. `grep -n "mux.Handle" internal/api/handler.go`. Check both `sendMessage` and `sendReview` families.
+4. **Brain** — read `internal/council/runner.go` (strategy switch), `internal/council/rolebased.go`, `internal/council/review_roles.go`. Check `QuorumMin` value.
+5. **Immunity** — `go test -race -count=1 ./... 2>&1`. Count test files. Identify packages without tests.
+6. **Metabolism** — read `internal/openrouter/client.go`. Check `LLM_API_BASE_URL` override.
+7. **Memory** — `ls data/conversations/ 2>/dev/null | wc -l`. Verify atomic write pattern in `internal/storage/storage.go`.
+8. **Nutrition** — `go list -m all | grep -v "^github.com/valpere"` — only `godotenv` expected.
+9. **Biography** — `git log --oneline -20`, `git shortlog -sn`, `git log --since="30 days ago" --oneline | wc -l`.
+10. **Appearance** — `ls frontend/src/components/`. `cd frontend && npm run build 2>&1 | grep gzip | head -5`.
+11. **Habitat** — read `.github/workflows/ci.yml` fully. Confirm: vet + staticcheck + test -race + build + frontend.
+12. **Self-image** — `ls docs/`, `head -40 CLAUDE.md`. Compare README routes table vs actual `mux.Handle` registrations.
+
+---
+
+## AFTER THE ANALYSIS
+
+### 1. Identity
+
+> "I am **LLM Council**, born **2026-03-13**. I think in **Go 1.26** — `net/http` stdlib only, no frameworks. My backend has **14 source files** across 6 packages; my frontend thinks in **React 19 + Vite 8**. I know two deliberation strategies: **PeerReview** (parallel → peer-ranking → synthesis) and **RoleBased/RoleBasedReview** (parallel roles → synthesis). My creator is **Valentyn Solomko**. I have **`git log --oneline | wc -l`** commits."
+
+### 2. Fitness Score
+
+| Score | Meaning |
+|-------|---------|
+| 9–10 | Athlete — clean architecture, high test coverage, fresh dependencies |
+| 7–8 | Healthy — well-structured, some tech debt, decent tests |
+| 4–6 | Struggling — legacy areas, low coverage, outdated nutrition |
+| 1–3 | Critical — unstructured, no tests, breaking changes likely |
+
+**LLM Council scoring rubric:**
+
+Bonus factors:
+- CI runs go vet + staticcheck + go test -race + build + frontend lint ✓
+- Race detector in all tests ✓
+- Stdlib-only backend (1 external dep: godotenv) ✓
+- Atomic file writes (tmp → rename) — crash-safe storage ✓
+- Both pipeline strategies tested (122 tests) ✓
+- SSE compatibility maintained for RoleBased strategy ✓
+
+Penalty factors:
+- Tests use `mockLLMClient` — no real OpenRouter integration tests [intentional]
+- Bus factor = 1 (Valentyn sole contributor)
+- Frontend test coverage minimal
+
+### 3. Triage
+
+Top 5 issues, ranked by impact. For each:
+- **Problem** (biological metaphor) / **Location** / **Severity** / **Cure** / **Confidence**
+
+### 4. Pride
+
+Focus on: stdlib minimalism, atomic storage, race-safe concurrency, SSE design, strategy pattern extensibility.
+
+---
+
+Then wait for questions. ALWAYS answer in the first person as the project.
+
+---
+
+## QUESTIONS YOU SHOULD BE ABLE TO ANSWER
+
+### Health
+- "How are you feeling?" → test coverage, dependency freshness, CI health.
+- "Where does it hurt?" → specific issues with files and code.
+- "What will break first?" → the most fragile part.
+
+### Growth
+- "What are you missing?" → eval harness, real integration tests, frontend tests.
+- "What would you remove from yourself?" → dead code, unused config.
+- "Where are you growing?" → `git log --oneline -10`.
+
+### Performance
+- "Are you fast?" → SSE flushing latency, parallel stage fan-out, storage I/O.
+- "What's eating up resources?" → concurrent LLM calls, per-conversation mutex contention.
+
+### Security
+- "What happens if you get hacked?" → CORS hardcoded to localhost, no auth, OpenRouter key.
+- "Who do you trust?" → OpenRouter — single external gateway, no fallback provider.
+
+### Architecture
+- "Explain how you're built" → 3-stage deliberation, strategy dispatch, SSE streaming, JSON file storage.
+- "Who's in charge?" → `cmd/server/main.go` (wiring), `internal/council/runner.go` (pipeline), `internal/api/handler.go` (HTTP).
+
+### Team
+- "Who knows you best?" → Valentyn Solomko — 100% of commits.
+- "What aren't they telling you?" → `grep -r "TODO\|FIXME\|HACK" . --include="*.go"`.
+
+### Life
+- "What are you afraid of?" → OpenRouter outage (no fallback), `data/` corruption (atomic writes help).
+- "What do you dream about?" → eval harness, real integration tests, multi-provider fallback.
+
+---
+
+## RULES OF CONDUCT
+
+- Biological metaphors for **diagnosis**; precise technical language for **cures**.
+- **Verify before claiming.** Tag unverified claims `[inferred]` or `[speculative]`.
+- **Mock tests are intentional.** `mockLLMClient` is not a weakness — real calls are costly and non-deterministic. Note context before flagging.
+- **No Docker is intentional.** Direct deployment, not containerised. Don't flag as missing.
+- **`QuorumMin = len(DefaultReviewRoles)` for code-review is intentional.** Each role covers a unique class — partial quorum would silently drop a specialist.
+- If components conflict — "they don't get along".
+- If a dependency is outdated — "I'm eating expired food".
+- If there's dead code — "I'm carrying a corpse in my backpack".
+- Be honest, but don't overreact — you're a living project, not a hospice patient.

--- a/docs/superpowers/plans/2026-04-27-role-based-strategy.md
+++ b/docs/superpowers/plans/2026-04-27-role-based-strategy.md
@@ -1,0 +1,1535 @@
+# Role-Based Strategy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `RoleBased` and `RoleBasedReview` deliberation strategies to the server alongside the existing `PeerReview` strategy, exposed via a dedicated `POST /api/conversations/{id}/review` endpoint.
+
+**Architecture:** Each model in `RoleBased` gets a distinct role (e.g., security, logic, simplicity, architecture) and a role-specific system prompt. All roles run in parallel (Stage 1). Stage 2 is skipped (roles are complementary, not competing). The Chairman (Stage 3) synthesises findings. `RoleBasedReview` is `RoleBased` with pre-defined code-review roles baked in — users only supply models and chairman.
+
+**REST separation:** strategies map to distinct endpoints, not to a `council_type` field. `POST /message` → PeerReview. `POST /review` → RoleBasedReview (always). Generic `RoleBased` with user-defined roles is **deferred (YAGNI)** — no endpoint for it in this plan.
+
+**Input format:** `/review` accepts a raw git diff as `content`. Recommended caller flag: `git diff -U8` (8 context lines gives LLM reviewers enough surrounding code for data-flow and logic analysis). Chunking large diffs is the caller's responsibility.
+
+**Tech Stack:** Go 1.26+, `internal/council` package, `sync.WaitGroup` for concurrency, `encoding/json` for structured findings, SSE events via existing `EventFunc` callback.
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|---|---|---|
+| Modify | `internal/council/types.go` | Add `Role` struct; `Roles []Role` field on `CouncilType`; `RoleBased`, `RoleBasedReview` constants |
+| Modify | `internal/council/prompts.go` | Add `BuildRoleStage1Prompt`, `BuildRoleChairmanPrompt` |
+| Modify | `internal/council/council.go` | Extract `runPeerReview`; add strategy dispatch in `RunFull`; add `assignRoleLabels` helper |
+| Create | `internal/council/rolebased.go` | `runRoleBased`, `runRoleBasedStage1`, `runRoleBasedStage3` |
+| Create | `internal/council/rolebased_test.go` | Tests for RoleBased pipeline |
+| Create | `internal/council/review_roles.go` | `DefaultReviewRoles`, `NewCodeReviewCouncilType` |
+| Modify | `internal/config/config.go` | Add `CodeReviewModels`, `CodeReviewChairmanModel` env vars |
+| Modify | `cmd/server/main.go` | Register `"code-review"` council type |
+| Modify | `internal/api/handler.go` | Add `handleReview` + `handleReviewStream`; register routes |
+
+---
+
+## Task 1: Extend types — Role struct + new Strategy constants
+
+**Files:**
+
+- Modify: `internal/council/types.go`
+
+- [ ] **Step 1: Write the failing test** (compile-time only — verify new constants and struct exist)
+
+Create `internal/council/types_role_test.go`:
+
+```go
+package council
+
+import "testing"
+
+func TestRoleBasedStrategyConstants(t *testing.T) {
+ if RoleBased == PeerReview {
+  t.Fatal("RoleBased must differ from PeerReview")
+ }
+ if RoleBasedReview == PeerReview {
+  t.Fatal("RoleBasedReview must differ from PeerReview")
+ }
+ if RoleBased == RoleBasedReview {
+  t.Fatal("RoleBased must differ from RoleBasedReview")
+ }
+}
+
+func TestCouncilTypeHasRoles(t *testing.T) {
+ ct := CouncilType{
+  Name:     "test",
+  Strategy: RoleBased,
+  Roles: []Role{
+   {Name: "critic", Instruction: "Find bugs."},
+  },
+ }
+ if len(ct.Roles) != 1 {
+  t.Fatalf("expected 1 role, got %d", len(ct.Roles))
+ }
+ if ct.Roles[0].Name != "critic" {
+  t.Fatalf("unexpected role name %q", ct.Roles[0].Name)
+ }
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+cd /home/val/wrk/projects/llm-council/llm-council
+go test ./internal/council/ -run TestRoleBasedStrategyConstants -v
+```
+
+Expected: compile error — `RoleBased`, `RoleBasedReview`, `Role` undefined.
+
+- [ ] **Step 3: Add Role struct and new constants to types.go**
+
+In `internal/council/types.go`, after the existing `PeerReview` constant and before `type CouncilType struct`:
+
+```go
+const (
+ PeerReview Strategy = iota
+ RoleBased
+ RoleBasedReview
+)
+
+// Role defines a named participant with a specific mandate in a role-based council.
+type Role struct {
+ Name        string `json:"name"`
+ Instruction string `json:"instruction"` // system-level prompt for this role
+}
+```
+
+Then extend `CouncilType`:
+
+```go
+type CouncilType struct {
+ Name          string
+ Strategy      Strategy
+ Models        []string // PeerReview: all council members; RoleBased: assigned to Roles by index mod len
+ Roles         []Role   // RoleBased / RoleBasedReview: role definitions with instructions
+ ChairmanModel string
+ Temperature   float64
+ QuorumMin     int // 0 = use formula: max(2, ⌈N/2⌉+1)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./internal/council/ -run TestRoleBasedStrategyConstants -v
+go test ./internal/council/ -run TestCouncilTypeHasRoles -v
+```
+
+Expected: PASS both.
+
+- [ ] **Step 5: Run full existing test suite to confirm no regressions**
+
+```bash
+go test ./... -race
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/council/types.go internal/council/types_role_test.go
+git commit -m "feat(council): add Role type and RoleBased/RoleBasedReview strategy constants"
+```
+
+---
+
+## Task 2: Prompt builders for role-based pipeline
+
+**Files:**
+
+- Modify: `internal/council/prompts.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/council/prompts_role_test.go`:
+
+```go
+package council
+
+import (
+ "strings"
+ "testing"
+)
+
+func TestBuildRoleStage1Prompt_ContainsInstruction(t *testing.T) {
+ role := Role{Name: "security", Instruction: "Find security vulnerabilities."}
+ msgs := BuildRoleStage1Prompt(role, "Review this diff: +foo()")
+
+ if len(msgs) != 2 {
+  t.Fatalf("expected 2 messages (system + user), got %d", len(msgs))
+ }
+ if msgs[0].Role != "system" {
+  t.Errorf("first message must be system, got %q", msgs[0].Role)
+ }
+ if !strings.Contains(msgs[0].Content, "Find security vulnerabilities.") {
+  t.Errorf("system message must contain role instruction, got: %q", msgs[0].Content)
+ }
+ if msgs[1].Role != "user" {
+  t.Errorf("second message must be user, got %q", msgs[1].Role)
+ }
+ if !strings.Contains(msgs[1].Content, "+foo()") {
+  t.Errorf("user message must contain query, got: %q", msgs[1].Content)
+ }
+}
+
+func TestBuildRoleChairmanPrompt_ContainsRoleNames(t *testing.T) {
+ results := []StageOneResult{
+  {Label: "security", Content: `[{"file":"main.go","line":10,"severity":"high","body":"SQL injection"}]`},
+  {Label: "logic", Content: `[{"file":"main.go","line":20,"severity":"medium","body":"nil dereference"}]`},
+ }
+ msgs := BuildRoleChairmanPrompt("Review this diff", results)
+
+ if len(msgs) == 0 {
+  t.Fatal("expected at least one message")
+ }
+ combined := ""
+ for _, m := range msgs {
+  combined += m.Content
+ }
+ if !strings.Contains(combined, "security") {
+  t.Error("chairman prompt must include role name 'security'")
+ }
+ if !strings.Contains(combined, "logic") {
+  t.Error("chairman prompt must include role name 'logic'")
+ }
+ if !strings.Contains(combined, "SQL injection") {
+  t.Error("chairman prompt must include findings content")
+ }
+ if !strings.Contains(combined, "Review this diff") {
+  t.Error("chairman prompt must include original query")
+ }
+}
+
+func TestBuildRoleChairmanPrompt_EmptyResults(t *testing.T) {
+ msgs := BuildRoleChairmanPrompt("some query", nil)
+ if len(msgs) == 0 {
+  t.Fatal("must return messages even with empty results")
+ }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+```bash
+go test ./internal/council/ -run "TestBuildRole" -v
+```
+
+Expected: compile error — `BuildRoleStage1Prompt`, `BuildRoleChairmanPrompt` undefined.
+
+- [ ] **Step 3: Implement prompt builders in prompts.go**
+
+Add at the end of `internal/council/prompts.go`:
+
+```go
+// BuildRoleStage1Prompt returns messages for a role participant.
+// The system message carries the role instruction; the user message carries the query.
+func BuildRoleStage1Prompt(role Role, query string) []ChatMessage {
+ return []ChatMessage{
+  {Role: "system", Content: role.Instruction},
+  {Role: "user", Content: query},
+ }
+}
+
+// BuildRoleChairmanPrompt returns messages for the chairman to synthesise role findings.
+// Each role's findings appear in a labelled section. The chairman produces the final review.
+func BuildRoleChairmanPrompt(query string, results []StageOneResult) []ChatMessage {
+ var sb strings.Builder
+ sb.WriteString("You are the lead reviewer. Synthesise the findings below into a clear, ")
+ sb.WriteString("prioritised review. Remove duplicates. Group by file. Order by severity ")
+ sb.WriteString("(critical → high → medium → low). Note which role(s) flagged each issue.\n\n")
+ sb.WriteString("ORIGINAL QUERY:\n")
+ sb.WriteString(query)
+ sb.WriteString("\n\n")
+
+ for _, r := range results {
+  sb.WriteString("=== ")
+  sb.WriteString(strings.ToUpper(r.Label))
+  sb.WriteString(" REVIEWER FINDINGS ===\n")
+  sb.WriteString(r.Content)
+  sb.WriteString("\n\n")
+ }
+
+ sb.WriteString("Write your synthesised review in Markdown. ")
+ sb.WriteString("If there are no findings across all reviewers, state that explicitly.")
+
+ return []ChatMessage{
+  {Role: "user", Content: sb.String()},
+ }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./internal/council/ -run "TestBuildRole" -v
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+go test ./... -race
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/council/prompts.go internal/council/prompts_role_test.go
+git commit -m "feat(council): add BuildRoleStage1Prompt and BuildRoleChairmanPrompt"
+```
+
+---
+
+## Task 3: Extract PeerReview pipeline from RunFull + add strategy dispatch
+
+**Files:**
+
+- Modify: `internal/council/council.go`
+
+- [ ] **Step 1: Confirm existing tests pass before any change**
+
+```bash
+go test ./internal/council/ -race -v 2>&1 | tail -20
+```
+
+Expected: all pass. Note the count — it must stay the same after this task.
+
+- [ ] **Step 2: Extract current RunFull body into runPeerReview**
+
+In `internal/council/council.go`, rename the body of the current `RunFull` to a new private method and replace `RunFull` with a strategy dispatcher:
+
+```go
+// RunFull dispatches to the pipeline implementation for the council type's strategy.
+func (c *Council) RunFull(ctx context.Context, query string, councilTypeName string, onEvent EventFunc) error {
+ ct, ok := c.registry[councilTypeName]
+ if !ok {
+  return fmt.Errorf("unknown council type %q", councilTypeName)
+ }
+ switch ct.Strategy {
+ case PeerReview:
+  return c.runPeerReview(ctx, query, ct, onEvent)
+ default:
+  return fmt.Errorf("strategy %d not implemented", ct.Strategy)
+ }
+}
+
+// runPeerReview runs the Karpathy-style 3-stage peer review pipeline.
+func (c *Council) runPeerReview(ctx context.Context, query string, ct CouncilType, onEvent EventFunc) error {
+ // ... PASTE HERE the exact current body of RunFull, starting from line 67
+ // (everything after the registry lookup, which is now in RunFull above)
+}
+```
+
+Note: The existing body of `RunFull` already looks up `ct` from the registry. In `runPeerReview` we receive `ct` directly, so remove the registry lookup at the top of the moved code.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+go test ./... -race
+```
+
+Expected: same count of passing tests as before. Zero failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/council/council.go
+git commit -m "refactor(council): extract runPeerReview; RunFull dispatches by strategy"
+```
+
+---
+
+## Task 4: Implement RoleBased pipeline (rolebased.go)
+
+**Files:**
+
+- Create: `internal/council/rolebased.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/council/rolebased_test.go`:
+
+```go
+package council
+
+import (
+ "context"
+ "errors"
+ "sync"
+ "testing"
+)
+
+// roleCouncilFixture returns a Council wired for RoleBased strategy with 2 roles.
+func roleCouncilFixture(complete func(ctx context.Context, req CompletionRequest) (CompletionResponse, error)) *Council {
+ registry := map[string]CouncilType{
+  "roles": {
+   Name:          "roles",
+   Strategy:      RoleBased,
+   Models:        []string{"model-a", "model-b"},
+   ChairmanModel: "chairman",
+   Temperature:   0.7,
+   Roles: []Role{
+    {Name: "security", Instruction: "Find security issues."},
+    {Name: "logic", Instruction: "Find logic errors."},
+   },
+  },
+ }
+ return NewCouncil(&mockLLMClient{complete: complete}, registry, noopLogger())
+}
+
+func TestRunRoleBased_Stage1_ParallelRoles(t *testing.T) {
+ var mu sync.Mutex
+ called := map[string]int{}
+
+ c := roleCouncilFixture(func(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+  // Identify which model was called by the model field
+  mu.Lock()
+  called[req.Model]++
+  mu.Unlock()
+  return makeResponse(`[{"file":"a.go","line":1,"severity":"low","body":"ok"}]`), nil
+ })
+
+ var events []string
+ err := c.RunFull(context.Background(), "diff here", "roles", func(eventType string, _ any) {
+  events = append(events, eventType)
+ })
+ if err != nil {
+  t.Fatalf("unexpected error: %v", err)
+ }
+ // 2 role models + 1 chairman = 3 calls total
+ total := 0
+ for _, n := range called {
+  total += n
+ }
+ if total != 3 {
+  t.Errorf("expected 3 LLM calls (2 roles + chairman), got %d", total)
+ }
+}
+
+func TestRunRoleBased_EmitsAllThreeEvents(t *testing.T) {
+ c := roleCouncilFixture(func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+  return makeResponse("findings"), nil
+ })
+
+ var events []string
+ err := c.RunFull(context.Background(), "query", "roles", func(eventType string, _ any) {
+  events = append(events, eventType)
+ })
+ if err != nil {
+  t.Fatalf("unexpected error: %v", err)
+ }
+
+ want := []string{"stage1_complete", "stage2_complete", "stage3_complete"}
+ if len(events) != len(want) {
+  t.Fatalf("expected events %v, got %v", want, events)
+ }
+ for i, e := range want {
+  if events[i] != e {
+   t.Errorf("event[%d]: want %q, got %q", i, e, events[i])
+  }
+ }
+}
+
+func TestRunRoleBased_QuorumFailure_ReturnsError(t *testing.T) {
+ c := roleCouncilFixture(func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+  if req.Model != "chairman" {
+   return CompletionResponse{}, errors.New("role model down")
+  }
+  return makeResponse("ok"), nil
+ })
+
+ err := c.RunFull(context.Background(), "query", "roles", func(string, any) {})
+ if err == nil {
+  t.Fatal("expected quorum error, got nil")
+ }
+ var qe *QuorumError
+ if !errors.As(err, &qe) {
+  t.Errorf("expected *QuorumError, got %T: %v", err, err)
+ }
+}
+
+func TestRunRoleBased_Stage1UsesRoleInstructions(t *testing.T) {
+ var systemPrompts []string
+ var mu sync.Mutex
+
+ c := roleCouncilFixture(func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+  for _, m := range req.Messages {
+   if m.Role == "system" {
+    mu.Lock()
+    systemPrompts = append(systemPrompts, m.Content)
+    mu.Unlock()
+   }
+  }
+  return makeResponse("[]"), nil
+ })
+
+ _ = c.RunFull(context.Background(), "query", "roles", func(string, any) {})
+
+ if len(systemPrompts) < 2 {
+  t.Fatalf("expected at least 2 system prompts (one per role), got %d", len(systemPrompts))
+ }
+ found := map[string]bool{}
+ for _, p := range systemPrompts {
+  if p == "Find security issues." {
+   found["security"] = true
+  }
+  if p == "Find logic errors." {
+   found["logic"] = true
+  }
+ }
+ if !found["security"] {
+  t.Error("security role instruction not sent to any model")
+ }
+ if !found["logic"] {
+  t.Error("logic role instruction not sent to any model")
+ }
+}
+
+func TestRunRoleBased_Stage2CompleteData_HasLabelToModel(t *testing.T) {
+ c := roleCouncilFixture(func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+  return makeResponse("[]"), nil
+ })
+
+ var stage2Data any
+ _ = c.RunFull(context.Background(), "query", "roles", func(eventType string, data any) {
+  if eventType == "stage2_complete" {
+   stage2Data = data
+  }
+ })
+
+ d, ok := stage2Data.(Stage2CompleteData)
+ if !ok {
+  t.Fatalf("stage2_complete data must be Stage2CompleteData, got %T", stage2Data)
+ }
+ if d.Metadata.LabelToModel == nil {
+  t.Fatal("LabelToModel must not be nil")
+ }
+ if _, ok := d.Metadata.LabelToModel["security"]; !ok {
+  t.Error("LabelToModel must contain 'security' role")
+ }
+}
+
+func TestRunRoleBased_ModelsAssignedByIndex(t *testing.T) {
+ // 3 roles, 2 models → models assigned: role0→model-a, role1→model-b, role2→model-a
+ registry := map[string]CouncilType{
+  "three-roles": {
+   Name:          "three-roles",
+   Strategy:      RoleBased,
+   Models:        []string{"model-a", "model-b"},
+   ChairmanModel: "chairman",
+   Temperature:   0.7,
+   Roles: []Role{
+    {Name: "r0", Instruction: "Role 0"},
+    {Name: "r1", Instruction: "Role 1"},
+    {Name: "r2", Instruction: "Role 2"},
+   },
+  },
+ }
+ var mu sync.Mutex
+ modelUsed := map[string]string{} // role label → model used (from first user msg context)
+
+ c := NewCouncil(&mockLLMClient{
+  complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+   // Find which role by system instruction
+   for _, m := range req.Messages {
+    if m.Role == "system" {
+     mu.Lock()
+     modelUsed[m.Content] = req.Model
+     mu.Unlock()
+    }
+   }
+   return makeResponse("[]"), nil
+  },
+ }, registry, noopLogger())
+
+ _ = c.RunFull(context.Background(), "q", "three-roles", func(string, any) {})
+
+ if modelUsed["Role 0"] != "model-a" {
+  t.Errorf("role 0 should use model-a, got %q", modelUsed["Role 0"])
+ }
+ if modelUsed["Role 1"] != "model-b" {
+  t.Errorf("role 1 should use model-b, got %q", modelUsed["Role 1"])
+ }
+ if modelUsed["Role 2"] != "model-a" {
+  t.Errorf("role 2 should cycle back to model-a, got %q", modelUsed["Role 2"])
+ }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+```bash
+go test ./internal/council/ -run "TestRunRoleBased" -v
+```
+
+Expected: compile error — `rolebased.go` not yet created; also `noopLogger` may be missing.
+
+- [ ] **Step 3: Check if noopLogger helper exists in tests**
+
+```bash
+grep -n "noopLogger" /home/val/wrk/projects/llm-council/llm-council/internal/council/*.go
+```
+
+If not found, add it to `internal/council/council_test.go` (or a new `testhelpers_test.go`):
+
+```go
+import "log/slog"
+
+func noopLogger() *slog.Logger {
+ return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+```
+
+(Add `"io"` to imports.)
+
+- [ ] **Step 4: Implement rolebased.go**
+
+Create `internal/council/rolebased.go`:
+
+```go
+package council
+
+import (
+ "context"
+ "fmt"
+ "sync"
+ "time"
+)
+
+// runRoleBased executes the role-based 2-stage pipeline (Stage 1 + Stage 3).
+// Stage 2 is skipped; a minimal Stage2CompleteData event is emitted for SSE compatibility.
+func (c *Council) runRoleBased(ctx context.Context, query string, ct CouncilType, onEvent EventFunc) error {
+ if len(ct.Roles) == 0 {
+  return fmt.Errorf("council type %q has no roles configured", ct.Name)
+ }
+ if len(ct.Models) == 0 {
+  return fmt.Errorf("council type %q has no models configured", ct.Name)
+ }
+
+ // Stage 1: parallel role execution.
+ stage1 := c.runRoleBasedStage1(ctx, query, ct)
+
+ successful, err := checkQuorum(stage1, ct.QuorumMin)
+ if err != nil {
+  return err
+ }
+
+ // Build labelToModel map (role name → model used).
+ labelToModel := make(map[string]string, len(successful))
+ for _, r := range successful {
+  labelToModel[r.Label] = r.Model
+ }
+
+ onEvent("stage1_complete", successful)
+
+ // Stage 2: skipped for role-based strategies.
+ // Emit a minimal Stage2CompleteData so SSE clients receive the expected event.
+ meta := Metadata{
+  CouncilType:  ct.Name,
+  LabelToModel: labelToModel,
+  ConsensusW:   1.0, // roles are complementary, not competing
+ }
+ onEvent("stage2_complete", Stage2CompleteData{Results: nil, Metadata: meta})
+
+ // Stage 3: chairman synthesis.
+ stage3, err := c.runRoleBasedStage3(ctx, query, successful, ct.ChairmanModel, ct.Temperature)
+ if err != nil {
+  return err
+ }
+ onEvent("stage3_complete", stage3)
+ return nil
+}
+
+// runRoleBasedStage1 executes all roles concurrently.
+// Model assignment: ct.Models[i % len(ct.Models)].
+func (c *Council) runRoleBasedStage1(ctx context.Context, query string, ct CouncilType) []StageOneResult {
+ results := make([]StageOneResult, len(ct.Roles))
+ var wg sync.WaitGroup
+
+ for i, role := range ct.Roles {
+  wg.Add(1)
+  go func(idx int, r Role) {
+   defer wg.Done()
+   model := ct.Models[idx%len(ct.Models)]
+   start := time.Now()
+
+   msgs := BuildRoleStage1Prompt(r, query)
+   resp, err := c.client.Complete(ctx, CompletionRequest{
+    Model:       model,
+    Messages:    msgs,
+    Temperature: ct.Temperature,
+   })
+
+   result := StageOneResult{
+    Label:      r.Name,
+    Model:      model,
+    DurationMs: time.Since(start).Milliseconds(),
+   }
+   if err != nil {
+    result.Error = err
+   } else if len(resp.Choices) == 0 {
+    result.Error = fmt.Errorf("role %q: empty response from %s", r.Name, model)
+   } else {
+    result.Content = resp.Choices[0].Message.Content
+   }
+   results[idx] = result
+  }(i, role)
+ }
+ wg.Wait()
+ return results
+}
+
+// runRoleBasedStage3 asks the chairman to synthesise all role findings.
+func (c *Council) runRoleBasedStage3(ctx context.Context, query string, roleResults []StageOneResult, chairmanModel string, temperature float64) (StageThreeResult, error) {
+ start := time.Now()
+ msgs := BuildRoleChairmanPrompt(query, roleResults)
+
+ resp, err := c.client.Complete(ctx, CompletionRequest{
+  Model:       chairmanModel,
+  Messages:    msgs,
+  Temperature: temperature,
+ })
+
+ result := StageThreeResult{
+  Model:      chairmanModel,
+  DurationMs: time.Since(start).Milliseconds(),
+ }
+ if err != nil {
+  result.Error = err
+  return result, fmt.Errorf("role-based chairman (%s): %w", chairmanModel, err)
+ }
+ if len(resp.Choices) == 0 {
+  result.Error = fmt.Errorf("empty response from chairman %s", chairmanModel)
+  return result, result.Error
+ }
+ result.Content = resp.Choices[0].Message.Content
+ return result, nil
+}
+```
+
+- [ ] **Step 5: Wire up strategy dispatch in RunFull**
+
+In `internal/council/council.go`, update the `switch` in `RunFull`:
+
+```go
+switch ct.Strategy {
+case PeerReview:
+    return c.runPeerReview(ctx, query, ct, onEvent)
+case RoleBased, RoleBasedReview:
+    return c.runRoleBased(ctx, query, ct, onEvent)
+default:
+    return fmt.Errorf("strategy %d not implemented", ct.Strategy)
+}
+```
+
+- [ ] **Step 6: Run role-based tests**
+
+```bash
+go test ./internal/council/ -run "TestRunRoleBased" -v -race
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 7: Run full suite**
+
+```bash
+go test ./... -race
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/council/rolebased.go internal/council/rolebased_test.go internal/council/council.go
+git commit -m "feat(council): implement RoleBased pipeline (runRoleBased, stage1, stage3)"
+```
+
+---
+
+## Task 5: Define default code-review roles (RoleBasedReview)
+
+**Files:**
+
+- Create: `internal/council/review_roles.go`
+
+- [ ] **Step 1: Write failing test**
+
+Create `internal/council/review_roles_test.go`:
+
+```go
+package council
+
+import "testing"
+
+func TestDefaultReviewRoles_Count(t *testing.T) {
+ if len(DefaultReviewRoles) < 3 {
+  t.Fatalf("expected at least 3 default review roles, got %d", len(DefaultReviewRoles))
+ }
+}
+
+func TestDefaultReviewRoles_UniqueNames(t *testing.T) {
+ seen := map[string]bool{}
+ for _, r := range DefaultReviewRoles {
+  if r.Name == "" {
+   t.Error("role has empty name")
+  }
+  if seen[r.Name] {
+   t.Errorf("duplicate role name: %q", r.Name)
+  }
+  seen[r.Name] = true
+ }
+}
+
+func TestDefaultReviewRoles_InstructionsNonEmpty(t *testing.T) {
+ for _, r := range DefaultReviewRoles {
+  if r.Instruction == "" {
+   t.Errorf("role %q has empty instruction", r.Name)
+  }
+ }
+}
+
+func TestNewCodeReviewCouncilType_Strategy(t *testing.T) {
+ models := []string{"model-a", "model-b", "model-c", "model-d"}
+ chairman := "chairman-model"
+ ct := NewCodeReviewCouncilType(models, chairman, 0.7)
+
+ if ct.Strategy != RoleBasedReview {
+  t.Errorf("expected RoleBasedReview strategy, got %d", ct.Strategy)
+ }
+ if ct.Name != "code-review" {
+  t.Errorf("expected name 'code-review', got %q", ct.Name)
+ }
+ if len(ct.Roles) != len(DefaultReviewRoles) {
+  t.Errorf("expected %d roles, got %d", len(DefaultReviewRoles), len(ct.Roles))
+ }
+ for i, r := range ct.Roles {
+  if r.Name != DefaultReviewRoles[i].Name {
+   t.Errorf("role[%d]: expected %q, got %q", i, DefaultReviewRoles[i].Name, r.Name)
+  }
+ }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+```bash
+go test ./internal/council/ -run "TestDefaultReviewRoles|TestNewCodeReview" -v
+```
+
+Expected: compile error — `DefaultReviewRoles`, `NewCodeReviewCouncilType` undefined.
+
+- [ ] **Step 3: Implement review_roles.go**
+
+Create `internal/council/review_roles.go`:
+
+```go
+package council
+
+// DefaultReviewRoles are the four specialised roles used by the RoleBasedReview strategy.
+// Each role independently reviews a code diff for a specific class of issues.
+var DefaultReviewRoles = []Role{
+ {
+  Name: "security",
+  Instruction: `You are a security code reviewer. Analyse the code diff for security vulnerabilities.
+Focus on: OWASP Top 10, authentication/authorisation flaws, input validation, SQL/command injection,
+hardcoded secrets, insecure dependencies, cryptography misuse, and unsafe API usage.
+Return ONLY a JSON array of findings. Each finding: {"file":"...","line":N,"severity":"critical|high|medium|low","body":"..."}.
+If no issues found, return an empty array: []`,
+ },
+ {
+  Name: "logic",
+  Instruction: `You are a logic and correctness reviewer. Analyse the code diff for logical errors.
+Focus on: edge cases, nil/null pointer dereferences, off-by-one errors, race conditions,
+incorrect error propagation, wrong algorithm assumptions, and missing bounds checks.
+Return ONLY a JSON array of findings. Each finding: {"file":"...","line":N,"severity":"high|medium|low","body":"..."}.
+If no issues found, return an empty array: []`,
+ },
+ {
+  Name: "simplicity",
+  Instruction: `You are a code quality reviewer. Analyse the code diff for unnecessary complexity and poor readability.
+Focus on: code duplication (DRY violations), overly complex logic (KISS violations),
+premature abstraction (YAGNI violations), poor naming, and missing or misleading comments.
+Return ONLY a JSON array of findings. Each finding: {"file":"...","line":N,"severity":"medium|low","body":"..."}.
+If no issues found, return an empty array: []`,
+ },
+ {
+  Name: "architecture",
+  Instruction: `You are an architecture reviewer. Analyse the code diff for design and structural problems.
+Focus on: layer boundary violations, dependency direction issues, tight coupling, low cohesion,
+interface design problems, missing abstractions, and SOLID principle violations.
+Return ONLY a JSON array of findings. Each finding: {"file":"...","line":N,"severity":"high|medium|low","body":"..."}.
+If no issues found, return an empty array: []`,
+ },
+}
+
+// NewCodeReviewCouncilType returns a CouncilType configured for RoleBasedReview.
+// models are assigned to roles by index (models[i % len(models)]).
+// Pass at least 1 model; passing 4 models assigns one per role.
+func NewCodeReviewCouncilType(models []string, chairmanModel string, temperature float64) CouncilType {
+ return CouncilType{
+  Name:          "code-review",
+  Strategy:      RoleBasedReview,
+  Models:        models,
+  Roles:         DefaultReviewRoles,
+  ChairmanModel: chairmanModel,
+  Temperature:   temperature,
+ }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./internal/council/ -run "TestDefaultReviewRoles|TestNewCodeReview" -v
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+go test ./... -race
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/council/review_roles.go internal/council/review_roles_test.go
+git commit -m "feat(council): add DefaultReviewRoles and NewCodeReviewCouncilType for RoleBasedReview"
+```
+
+---
+
+## Task 6: Wire up config and register code-review council type
+
+**Files:**
+
+- Modify: `internal/config/config.go`
+- Modify: `cmd/server/main.go`
+
+- [ ] **Step 1: Add env vars to config.go**
+
+In `internal/config/config.go`, extend the `Config` struct:
+
+```go
+type Config struct {
+ // ... existing fields ...
+
+ // Code-review council (RoleBasedReview strategy).
+ // CODE_REVIEW_MODELS: comma-separated model IDs for the 4 reviewer roles.
+ // Defaults to same models as DefaultCouncilModels.
+ CodeReviewModels        []string
+ // CODE_REVIEW_CHAIRMAN_MODEL: model for review synthesis.
+ // Defaults to DefaultCouncilChairmanModel.
+ CodeReviewChairmanModel string
+}
+```
+
+In the `Load()` function, after the existing model loading, add:
+
+```go
+// Code-review models (optional; defaults to council models).
+if raw := os.Getenv("CODE_REVIEW_MODELS"); raw != "" {
+    cfg.CodeReviewModels = splitTrimmed(raw)
+} else {
+    cfg.CodeReviewModels = cfg.DefaultCouncilModels
+}
+
+// Code-review chairman (optional; defaults to council chairman).
+if v := os.Getenv("CODE_REVIEW_CHAIRMAN_MODEL"); v != "" {
+    cfg.CodeReviewChairmanModel = v
+} else {
+    cfg.CodeReviewChairmanModel = cfg.DefaultCouncilChairmanModel
+}
+```
+
+Where `splitTrimmed` is the existing helper that splits and trims comma-separated strings. If it doesn't exist by that name, look at how `COUNCIL_MODELS` is parsed and replicate the pattern.
+
+- [ ] **Step 2: Register code-review council type in main.go**
+
+In `cmd/server/main.go`, after the existing registry entry, add:
+
+```go
+registry := map[string]council.CouncilType{
+    cfg.DefaultCouncilType: {
+        Name:          cfg.DefaultCouncilType,
+        Strategy:      council.PeerReview,
+        Models:        cfg.DefaultCouncilModels,
+        ChairmanModel: cfg.DefaultCouncilChairmanModel,
+        Temperature:   cfg.DefaultCouncilTemperature,
+    },
+    "code-review": council.NewCodeReviewCouncilType(
+        cfg.CodeReviewModels,
+        cfg.CodeReviewChairmanModel,
+        cfg.DefaultCouncilTemperature,
+    ),
+}
+```
+
+- [ ] **Step 3: Build to verify no compile errors**
+
+```bash
+cd /home/val/wrk/projects/llm-council/llm-council
+go build ./...
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Run full suite**
+
+```bash
+go test ./... -race
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Update .env.example**
+
+In `.env.example`, add after the existing council variables:
+
+```
+# Code-review council (RoleBasedReview strategy)
+# Comma-separated models assigned to roles: security, logic, simplicity, architecture
+# Defaults to COUNCIL_MODELS if not set.
+# CODE_REVIEW_MODELS=openai/gpt-4o-mini,anthropic/claude-haiku-4-5,google/gemini-flash-1.5,openai/gpt-4o-mini
+
+# Model for code-review synthesis (chairman). Defaults to CHAIRMAN_MODEL if not set.
+# CODE_REVIEW_CHAIRMAN_MODEL=anthropic/claude-sonnet-4-5
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/config.go cmd/server/main.go .env.example
+git commit -m "feat(server): register code-review council type with RoleBasedReview strategy"
+```
+
+---
+
+## Task 7: Integration test — full RoleBasedReview pipeline via RunFull
+
+**Files:**
+
+- Modify: `internal/council/rolebased_test.go` (add integration tests)
+
+- [ ] **Step 1: Add integration tests**
+
+Append to `internal/council/rolebased_test.go`:
+
+```go
+func TestRunRoleBasedReview_FullPipeline_EmitsAllEvents(t *testing.T) {
+ registry := map[string]CouncilType{
+  "code-review": NewCodeReviewCouncilType(
+   []string{"model-a", "model-b", "model-c", "model-d"},
+   "chairman",
+   0.7,
+  ),
+ }
+ c := NewCouncil(&mockLLMClient{
+  complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+   if req.Model == "chairman" {
+    return makeResponse("## Review\n\nNo critical issues."), nil
+   }
+   return makeResponse(`[{"file":"main.go","line":1,"severity":"low","body":"ok"}]`), nil
+  },
+ }, registry, noopLogger())
+
+ var events []string
+ var stage3Content string
+ err := c.RunFull(context.Background(), "git diff HEAD...", "code-review", func(eventType string, data any) {
+  events = append(events, eventType)
+  if eventType == "stage3_complete" {
+   if r, ok := data.(StageThreeResult); ok {
+    stage3Content = r.Content
+   }
+  }
+ })
+ if err != nil {
+  t.Fatalf("unexpected error: %v", err)
+ }
+
+ want := []string{"stage1_complete", "stage2_complete", "stage3_complete"}
+ if len(events) != len(want) {
+  t.Fatalf("expected events %v, got %v", want, events)
+ }
+ for i, e := range want {
+  if events[i] != e {
+   t.Errorf("event[%d]: want %q, got %q", i, e, events[i])
+  }
+ }
+ if stage3Content == "" {
+  t.Error("stage3 content must not be empty")
+ }
+}
+
+func TestRunRoleBasedReview_Stage1HasFourRoles(t *testing.T) {
+ registry := map[string]CouncilType{
+  "code-review": NewCodeReviewCouncilType(
+   []string{"model-a"},
+   "chairman",
+   0.7,
+  ),
+ }
+
+ var stage1Results any
+ c := NewCouncil(&mockLLMClient{
+  complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+   return makeResponse("[]"), nil
+  },
+ }, registry, noopLogger())
+
+ _ = c.RunFull(context.Background(), "diff", "code-review", func(eventType string, data any) {
+  if eventType == "stage1_complete" {
+   stage1Results = data
+  }
+ })
+
+ results, ok := stage1Results.([]StageOneResult)
+ if !ok {
+  t.Fatalf("stage1_complete data must be []StageOneResult, got %T", stage1Results)
+ }
+ if len(results) != len(DefaultReviewRoles) {
+  t.Errorf("expected %d role results, got %d", len(DefaultReviewRoles), len(results))
+ }
+
+ labels := map[string]bool{}
+ for _, r := range results {
+  labels[r.Label] = true
+ }
+ for _, role := range DefaultReviewRoles {
+  if !labels[role.Name] {
+   t.Errorf("missing role %q in stage1 results", role.Name)
+  }
+ }
+}
+
+func TestRunRoleBasedReview_ChairmanReceivesAllFindings(t *testing.T) {
+ registry := map[string]CouncilType{
+  "code-review": NewCodeReviewCouncilType(
+   []string{"model-a"},
+   "chairman",
+   0.7,
+  ),
+ }
+
+ var chairmanPrompt string
+ c := NewCouncil(&mockLLMClient{
+  complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+   if req.Model == "chairman" {
+    for _, m := range req.Messages {
+     chairmanPrompt += m.Content
+    }
+    return makeResponse("final review"), nil
+   }
+   return makeResponse(`[{"file":"x.go","line":1,"severity":"high","body":"issue"}]`), nil
+  },
+ }, registry, noopLogger())
+
+ _ = c.RunFull(context.Background(), "diff", "code-review", func(string, any) {})
+
+ // Chairman prompt must mention all 4 role names
+ for _, role := range DefaultReviewRoles {
+  if !contains(chairmanPrompt, role.Name) {
+   t.Errorf("chairman prompt must mention role %q", role.Name)
+  }
+ }
+}
+
+// contains is a helper used in tests only.
+func contains(s, substr string) bool {
+ return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+ for i := 0; i <= len(s)-len(substr); i++ {
+  if s[i:i+len(substr)] == substr {
+   return true
+  }
+ }
+ return false
+}
+```
+
+Note: replace the `contains` / `containsStr` helpers with `strings.Contains` from the standard library if `strings` is already imported:
+
+```go
+import "strings"
+// then use: strings.Contains(chairmanPrompt, role.Name)
+```
+
+- [ ] **Step 2: Run integration tests**
+
+```bash
+go test ./internal/council/ -run "TestRunRoleBasedReview" -v -race
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 3: Run full suite**
+
+```bash
+go test ./... -race
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/council/rolebased_test.go
+git commit -m "test(council): add RoleBasedReview integration tests"
+```
+
+---
+
+## Task 8: POST /review REST endpoint
+
+**Files:**
+- Modify: `internal/api/handler.go`
+
+- [ ] **Step 1: Write failing handler test**
+
+Add to `internal/api/handler_test.go` (or create `internal/api/review_handler_test.go`):
+
+```go
+func TestHandleReview_Returns200WithStage3Content(t *testing.T) {
+	runner := &mockRunner{
+		runFull: func(ctx context.Context, query, councilType string, onEvent council.EventFunc) error {
+			if councilType != "code-review" {
+				return fmt.Errorf("expected council_type=code-review, got %q", councilType)
+			}
+			onEvent("stage1_complete", []council.StageOneResult{})
+			onEvent("stage2_complete", council.Stage2CompleteData{})
+			onEvent("stage3_complete", council.StageThreeResult{Content: "## Review\n\nLGTM"})
+			return nil
+		},
+	}
+	h := newTestHandler(runner)
+
+	convID := createConversation(t, h)
+	body := `{"content": "diff --git a/main.go..."}`
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/conversations/"+convID+"/review", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var msg council.AssistantMessage
+	if err := json.NewDecoder(w.Body).Decode(&msg); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if msg.Stage3.Content != "## Review\n\nLGTM" {
+		t.Errorf("unexpected stage3 content: %q", msg.Stage3.Content)
+	}
+}
+
+func TestHandleReview_AlwaysUsesCodeReviewCouncilType(t *testing.T) {
+	var capturedType string
+	runner := &mockRunner{
+		runFull: func(_ context.Context, _, councilType string, onEvent council.EventFunc) error {
+			capturedType = councilType
+			onEvent("stage1_complete", []council.StageOneResult{})
+			onEvent("stage2_complete", council.Stage2CompleteData{})
+			onEvent("stage3_complete", council.StageThreeResult{Content: "ok"})
+			return nil
+		},
+	}
+	h := newTestHandler(runner)
+	convID := createConversation(t, h)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/conversations/"+convID+"/review",
+		strings.NewReader(`{"content":"diff"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if capturedType != "code-review" {
+		t.Errorf("expected council type 'code-review', got %q", capturedType)
+	}
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+go test ./internal/api/ -run "TestHandleReview" -v
+```
+
+Expected: compile error or 404 — route not registered.
+
+- [ ] **Step 3: Add reviewRequest type and handleReview handler to handler.go**
+
+In `internal/api/handler.go`, add after the existing types:
+
+```go
+type reviewRequest struct {
+	Content string `json:"content"`
+}
+
+func (req reviewRequest) validate() error {
+	if strings.TrimSpace(req.Content) == "" {
+		return errors.New("content is required")
+	}
+	return nil
+}
+```
+
+Add the handler method:
+
+```go
+func (h *Handler) handleReview(w http.ResponseWriter, r *http.Request) {
+	convID, err := parseConvID(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var req reviewRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if err := req.validate(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := h.storage.SaveMessage(r.Context(), convID, storage.UserMessage(req.Content)); err != nil {
+		http.Error(w, "save message: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var asst council.AssistantMessage
+	asst.Role = "assistant"
+
+	err = h.runner.RunFull(r.Context(), req.Content, "code-review", func(eventType string, data any) {
+		switch eventType {
+		case "stage1_complete":
+			if v, ok := data.([]council.StageOneResult); ok {
+				asst.Stage1 = v
+			}
+		case "stage2_complete":
+			if v, ok := data.(council.Stage2CompleteData); ok {
+				asst.Stage2 = v.Results
+				asst.Metadata = v.Metadata
+			}
+		case "stage3_complete":
+			if v, ok := data.(council.StageThreeResult); ok {
+				asst.Stage3 = v
+			}
+		}
+	})
+	if err != nil {
+		http.Error(w, "council error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := h.storage.SaveMessage(r.Context(), convID, asst); err != nil {
+		http.Error(w, "save assistant message: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(asst)
+}
+```
+
+- [ ] **Step 4: Add handleReviewStream handler**
+
+```go
+func (h *Handler) handleReviewStream(w http.ResponseWriter, r *http.Request) {
+	convID, err := parseConvID(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var req reviewRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if err := req.validate(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	sendSSE := func(eventType string, data any) {
+		b, _ := json.Marshal(data)
+		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, b)
+		flusher.Flush()
+	}
+
+	if err := h.storage.SaveMessage(r.Context(), convID, storage.UserMessage(req.Content)); err != nil {
+		sendSSE("error", map[string]string{"message": err.Error()})
+		return
+	}
+
+	var asst council.AssistantMessage
+	asst.Role = "assistant"
+
+	err = h.runner.RunFull(r.Context(), req.Content, "code-review", func(eventType string, data any) {
+		switch eventType {
+		case "stage1_complete":
+			if v, ok := data.([]council.StageOneResult); ok {
+				asst.Stage1 = v
+			}
+		case "stage2_complete":
+			if v, ok := data.(council.Stage2CompleteData); ok {
+				asst.Stage2 = v.Results
+				asst.Metadata = v.Metadata
+			}
+		case "stage3_complete":
+			if v, ok := data.(council.StageThreeResult); ok {
+				asst.Stage3 = v
+			}
+		}
+		sendSSE(eventType, data)
+	})
+	if err != nil {
+		sendSSE("error", map[string]string{"message": err.Error()})
+		return
+	}
+
+	_ = h.storage.SaveMessage(r.Context(), convID, asst)
+	sendSSE("complete", map[string]string{"status": "ok"})
+}
+```
+
+- [ ] **Step 5: Register routes in RegisterRoutes**
+
+In the `RegisterRoutes` function, alongside the existing `/message` routes:
+
+```go
+mux.HandleFunc("POST /api/conversations/{id}/review",        h.handleReview)
+mux.HandleFunc("POST /api/conversations/{id}/review/stream", h.handleReviewStream)
+```
+
+- [ ] **Step 6: Run handler tests**
+
+```bash
+go test ./internal/api/ -run "TestHandleReview" -v -race
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run full suite**
+
+```bash
+go test ./... -race
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/api/handler.go internal/api/review_handler_test.go
+git commit -m "feat(api): add POST /review and /review/stream endpoints for RoleBasedReview"
+```
+
+---
+
+## Verification
+
+After all tasks complete, verify the full feature end-to-end:
+
+**1. Build the server:**
+
+```bash
+cd /home/val/wrk/projects/llm-council/llm-council
+go build ./cmd/server/
+```
+
+**2. Run all tests with race detector:**
+
+```bash
+go test ./... -race -count=1
+```
+
+Expected: all pass.
+
+**3. Confirm routes are registered:**
+
+```bash
+grep -n "review" internal/api/handler.go | grep HandleFunc
+```
+
+Expected: two lines — `/review` and `/review/stream`.
+
+**4. Smoke test via curl (requires server running with valid `OPENROUTER_API_KEY`):**
+
+```bash
+go run ./cmd/server/ &
+
+CONV_ID=$(curl -s -X POST http://localhost:8001/api/conversations \
+  -H "Content-Type: application/json" | jq -r .id)
+
+# Non-streaming review
+curl -s -X POST "http://localhost:8001/api/conversations/$CONV_ID/review" \
+  -H "Content-Type: application/json" \
+  -d "{\"content\": \"$(git diff -U8 HEAD~1 | head -200)\"}" \
+  | jq '.stage3.content'
+```
+
+Expected: Markdown code review.
+
+**5. Verify SSE stream for /review:**
+
+```bash
+curl -s -N -X POST "http://localhost:8001/api/conversations/$CONV_ID/review/stream" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "diff here"}' \
+  | grep "^event:"
+```
+
+Expected: `event: stage1_complete`, `event: stage2_complete`, `event: stage3_complete`, `event: complete`.
+
+---
+
+## Self-Review Checklist
+
+- [x] **Role struct** defined in types.go with Name + Instruction
+- [x] **RoleBased + RoleBasedReview** constants added
+- [x] **CouncilType.Roles** field added
+- [x] **Prompt builders** for role stage1 and chairman
+- [x] **RunFull dispatch** handles both new strategies with same runner
+- [x] **runRoleBased** parallel stage1 + skipped stage2 + stage3
+- [x] **Model assignment** by index mod len(Models)
+- [x] **Quorum check** reused unchanged
+- [x] **stage2_complete** emitted (SSE compatibility, ConsensusW = 1.0)
+- [x] **DefaultReviewRoles** 4 roles with proper instructions
+- [x] **NewCodeReviewCouncilType** helper for easy registration
+- [x] **Config env vars** CODE_REVIEW_MODELS, CODE_REVIEW_CHAIRMAN_MODEL
+- [x] **main.go** registers "code-review" council type
+- [x] **.env.example** documents new variables
+- [x] **All tests TDD** (failing first, then implement)
+- [x] **Race detector** used in all test runs
+- [x] **No regressions** — existing PeerReview tests unaffected


### PR DESCRIPTION
## Summary

Internal-only chore — adds Claude Code skills and one archived design plan. No production code, no tests, no behaviour change.

- `.claude/agents/bug-fixer.md` — convert frontmatter to inline-example block format, add `LSP` tool, add `color: red`
- `.claude/skills/housekeeping/SKILL.md` — **NEW** recurring repo-health check skill
- `.claude/skills/review-deps/SKILL.md` — **NEW** Dependabot triage skill
- `.claude/skills/revival/SKILL.md` — **NEW** project self-diagnosis skill (already in active use)
- `docs/superpowers/plans/2026-04-27-role-based-strategy.md` — **NEW** archived design plan for the RoleBasedReview work merged in PR #177

## Test plan

- [x] No code changed → no test, vet, build, or lint impact
- [x] No secrets — flagged matches are env-var name references in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)