### PR TITLE
⚖️ feat(openrouter,config): add retry with exponential backoff to LLM client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,14 @@ DATA_DIR=data/conversations
 # TCP port the backend HTTP server listens on. Default: 8001
 PORT=8001
 
+# ── Resilience ──────────────────────────────────────────────────────────────
+# Maximum number of retries on transient OpenRouter failures (HTTP 429/502/503/504,
+# network timeouts, EOFs from closed keep-alive connections). 0 disables retries.
+# Backoff schedule: 500ms · 1500ms · 4500ms with ±25% jitter, honouring
+# Retry-After headers (capped at 30s) and a 60s cumulative-sleep budget.
+# Default: 2 (= 3 total attempts).
+# LLM_API_MAX_RETRIES=2
+
 # ── LLM API endpoint ────────────────────────────────────────────────────────
 # Base URL for the LLM completion API. Must be http or https.
 # Defaults to OpenRouter (https://openrouter.ai/api/v1/chat/completions) when unset.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -50,7 +50,7 @@ func main() {
 		),
 	}
 
-	client := openrouter.NewClient(cfg.OpenRouterAPIKey, cfg.LLMBaseURL, 120*time.Second)
+	client := openrouter.NewClient(cfg.OpenRouterAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger)
 	runner := council.NewCouncil(client, registry, logger)
 
 	store, err := storage.NewStore(cfg.DataDir, logger)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,11 @@ type Config struct {
 	ClarificationMaxRounds            int
 	ClarificationMaxTotalQuestions    int
 	ClarificationMaxQuestionsPerRound int
+
+	// LLMAPIMaxRetries is the number of retries the OpenRouter client attempts
+	// on transient failures (HTTP 429/502/503/504, network timeouts, EOFs).
+	// 0 disables retries. Default: 2 (3 total attempts including the initial).
+	LLMAPIMaxRetries int
 }
 
 // Load reads configuration from environment variables and returns an error if
@@ -146,6 +151,16 @@ func Load() (*Config, error) {
 		}
 	}
 
+	llmAPIMaxRetries := 2
+	if raw := os.Getenv("LLM_API_MAX_RETRIES"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
+			llmAPIMaxRetries = v
+		} else {
+			slog.Warn("LLM_API_MAX_RETRIES is invalid; using fallback value",
+				"value", raw, "error", err, "fallback", llmAPIMaxRetries)
+		}
+	}
+
 	return &Config{
 		OpenRouterAPIKey:            apiKey,
 		LLMBaseURL:                  llmBaseURL,
@@ -161,5 +176,7 @@ func Load() (*Config, error) {
 		ClarificationMaxRounds:            clarificationMaxRounds,
 		ClarificationMaxTotalQuestions:    clarificationMaxTotalQuestions,
 		ClarificationMaxQuestionsPerRound: clarificationMaxQuestionsPerRound,
+
+		LLMAPIMaxRetries: llmAPIMaxRetries,
 	}, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -101,3 +101,40 @@ func TestLoad_LLMBaseURL_NotAURL(t *testing.T) {
 		t.Fatal("expected error for non-URL value, got nil")
 	}
 }
+
+// ── TestLoad_LLMAPIMaxRetries ─────────────────────────────────────────────
+
+func TestLoad_LLMAPIMaxRetries(t *testing.T) {
+	tests := []struct {
+		name string
+		// raw is the env value to set; if empty the var is unset.
+		raw  string
+		set  bool
+		want int
+	}{
+		{"unset uses default", "", false, 2},
+		{"valid 0 disables retries", "0", true, 0},
+		{"valid 1", "1", true, 1},
+		{"valid 5", "5", true, 5},
+		{"empty string uses default", "", true, 2},
+		{"negative falls back to default with warn", "-3", true, 2},
+		{"non-numeric falls back to default with warn", "loads", true, 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			baseEnv(t)
+			if tc.set {
+				setenv(t, "LLM_API_MAX_RETRIES", tc.raw)
+			} else {
+				unsetenv(t, "LLM_API_MAX_RETRIES")
+			}
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.LLMAPIMaxRetries != tc.want {
+				t.Errorf("LLMAPIMaxRetries: got %d, want %d", cfg.LLMAPIMaxRetries, tc.want)
+			}
+		})
+	}
+}

--- a/internal/openrouter/client.go
+++ b/internal/openrouter/client.go
@@ -22,17 +22,15 @@ const (
 	defaultURL    = "https://openrouter.ai/api/v1/chat/completions"
 	maxBodyBytes  = 4 * 1024 * 1024  // 4 MiB cap on response bodies
 	maxRetryAfter = 30 * time.Second // ceiling applied to Retry-After header values
+
+	defaultRetryBaseDelay              = 500 * time.Millisecond
+	defaultMaxCumulativeBackoffDuration = 60 * time.Second
 )
 
-// retryBaseDelay is the first attempt's nominal backoff. Exposed as a package
-// variable so tests can shrink it; production uses 500 ms.
-//
-// maxCumulativeBackoffDuration caps the total time spent sleeping across all
-// retry attempts in a single Complete call. Also a variable for testability.
-var (
-	retryBaseDelay               = 500 * time.Millisecond
-	maxCumulativeBackoffDuration = 60 * time.Second
-)
+// retryAfterAbsent is the sentinel returned by parseRetryAfter when no usable
+// Retry-After value is present. A genuine "Retry-After: 0" maps to 0
+// (retry immediately), distinct from absent.
+const retryAfterAbsent time.Duration = -1
 
 // APIError is returned when OpenRouter responds with a non-200 status code.
 type APIError struct {
@@ -51,6 +49,15 @@ type Client struct {
 	http       *http.Client
 	maxRetries int          // total retries (1 initial attempt + maxRetries retries)
 	logger     *slog.Logger // never nil — NewClient substitutes slog.Default()
+
+	// retryBaseDelay is the first attempt's nominal backoff. Per-Client so tests
+	// can shrink it without mutating package-level state and breaking parallel runs.
+	// Production initialises this to defaultRetryBaseDelay.
+	retryBaseDelay time.Duration
+
+	// maxCumulativeBackoffDuration caps the total time spent sleeping across
+	// retry attempts in a single Complete call. Per-Client for the same reason.
+	maxCumulativeBackoffDuration time.Duration
 }
 
 // NewClient creates a Client with the given API key, base URL, HTTP timeout,
@@ -68,11 +75,13 @@ func NewClient(apiKey, baseURL string, timeout time.Duration, maxRetries int, lo
 		maxRetries = 0
 	}
 	return &Client{
-		apiKey:     apiKey,
-		baseURL:    baseURL,
-		http:       &http.Client{Timeout: timeout},
-		maxRetries: maxRetries,
-		logger:     logger,
+		apiKey:                       apiKey,
+		baseURL:                      baseURL,
+		http:                         &http.Client{Timeout: timeout},
+		maxRetries:                   maxRetries,
+		logger:                       logger,
+		retryBaseDelay:               defaultRetryBaseDelay,
+		maxCumulativeBackoffDuration: defaultMaxCumulativeBackoffDuration,
 	}
 }
 
@@ -80,10 +89,10 @@ func NewClient(apiKey, baseURL string, timeout time.Duration, maxRetries int, lo
 var _ council.LLMClient = (*Client)(nil)
 
 // Complete POSTs a chat completion request to OpenRouter and returns the response.
-// On transient failures (5xx, 429, network blips), it retries with exponential
-// backoff and ±25% jitter, honoring Retry-After headers and a cumulative
-// 60 s sleep budget. Returns *APIError on non-200 responses after retries are
-// exhausted.
+// On transient failures (HTTP 429/502/503/504, network blips), it retries with
+// exponential backoff and ±25% jitter, honoring Retry-After headers (capped at
+// 30 s) and a cumulative 60 s sleep budget. Returns *APIError on non-200
+// responses after retries are exhausted.
 func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (council.CompletionResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -109,7 +118,7 @@ func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (c
 			// in finalErr (and resp on success) for us to surface.
 			if finalErr != nil {
 				if attempt > 0 {
-					c.logger.Info("openrouter: retries exhausted",
+					c.logger.Info("openrouter: failed after retries",
 						"attempts", attempt+1, "final_error", finalErr)
 				}
 				return council.CompletionResponse{}, finalErr
@@ -123,13 +132,18 @@ func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (c
 		lastErr = finalErr
 
 		if attempt >= c.maxRetries {
+			// Defence in depth: if the user just cancelled, prefer their error
+			// over the last attempt's error.
+			if cerr := ctx.Err(); cerr != nil {
+				return council.CompletionResponse{}, cerr
+			}
 			c.logger.Info("openrouter: retries exhausted",
 				"attempts", attempt+1, "final_error", lastErr)
 			return council.CompletionResponse{}, lastErr
 		}
 
-		delay := backoffDelay(attempt, retryAfter)
-		if cumulativeBackoff+delay > maxCumulativeBackoffDuration {
+		delay := c.backoffDelay(attempt, retryAfter)
+		if cumulativeBackoff+delay > c.maxCumulativeBackoffDuration {
 			c.logger.Info("openrouter: cumulative backoff cap reached",
 				"cumulative_ms", cumulativeBackoff.Milliseconds(),
 				"final_error", lastErr)
@@ -170,52 +184,61 @@ func (c *Client) doAttempt(ctx context.Context, body []byte) (*http.Response, er
 }
 
 // classifyAttempt inspects the result of doAttempt and decides whether to
-// retry. On a retry decision, it drains and closes the response body so the
-// connection returns to the keep-alive pool. On a non-retry decision, it
-// either returns a final error (with the body read for a non-retryable status)
-// or leaves resp populated with the body still readable (for the success path,
-// where the caller will decode).
+// retry. On a retryable status it reads (then drains and closes) the body so
+// that the final *APIError can carry the body text if retries are exhausted.
+// On a non-retryable status it surfaces *APIError with whatever body bytes were
+// readable — partial body is preferable to retrying a non-retryable status
+// just because the body read hiccupped.
 func (c *Client) classifyAttempt(resp *http.Response, err error) (shouldRetry bool, retryAfter time.Duration, finalErr error) {
 	// Network-level error path.
 	if err != nil {
 		if isRetriableNetErr(err) {
-			return true, 0, err
+			return true, retryAfterAbsent, err
 		}
-		return false, 0, err
+		return false, retryAfterAbsent, err
 	}
 
 	// HTTP-level path.
 	if isRetriableStatus(resp.StatusCode) {
 		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
-		// Read the body up to maxBodyBytes so it can be surfaced if retries
-		// are exhausted (or maxRetries=0). Then drain + close any tail so the
-		// connection returns to the keep-alive pool — for typical OpenRouter
-		// error JSON the tail will be empty.
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
+
+		// If the body read was cancelled by the user, propagate that immediately
+		// — explicit cancellation is never retried, even on a retryable status.
+		if errors.Is(readErr, context.Canceled) {
+			return false, retryAfterAbsent, readErr
+		}
+
 		return true, retryAfter, &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
-	// Non-retryable status (4xx other than 429, or 200). Read body so we can
-	// either return the *APIError with body, or hand off to decodeBody on 200.
+	// Non-retryable status (4xx other than 429, 5xx other than 502/503/504, or 200).
 	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	_ = resp.Body.Close()
-	if readErr != nil {
-		// A failed body read is itself a candidate for retry (ErrUnexpectedEOF, EOF).
-		if isRetriableNetErr(readErr) {
-			return true, 0, fmt.Errorf("read response: %w", readErr)
-		}
-		return false, 0, fmt.Errorf("read response: %w", readErr)
-	}
 
 	if resp.StatusCode != http.StatusOK {
-		return false, 0, &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
+		// Surface *APIError with whatever body was readable. A partial read on a
+		// non-retryable status code does not justify retrying — the status code
+		// itself was already non-retryable.
+		return false, retryAfterAbsent, &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+
+	// Status 200. A body read failure is the actual problem.
+	if readErr != nil {
+		if errors.Is(readErr, context.Canceled) {
+			return false, retryAfterAbsent, readErr
+		}
+		if isRetriableNetErr(readErr) {
+			return true, retryAfterAbsent, fmt.Errorf("read response: %w", readErr)
+		}
+		return false, retryAfterAbsent, fmt.Errorf("read response: %w", readErr)
 	}
 
 	// Success — stash the body on resp so decodeBody can read it without re-reading.
 	resp.Body = io.NopCloser(bytes.NewReader(respBody))
-	return false, 0, nil
+	return false, retryAfterAbsent, nil
 }
 
 // decodeBody parses a successful response body into a CompletionResponse.
@@ -232,7 +255,9 @@ func (c *Client) decodeBody(resp *http.Response) (council.CompletionResponse, er
 }
 
 // isRetriableStatus returns true for HTTP status codes worth retrying:
-// 429 (rate limit), 502, 503, 504 (transient upstream errors).
+// 429 (rate limit), 502/503/504 (transient upstream errors). HTTP 500 is
+// deliberately excluded — it often indicates a deterministic upstream bug
+// rather than a transient hiccup.
 func isRetriableStatus(code int) bool {
 	switch code {
 	case http.StatusTooManyRequests,
@@ -278,16 +303,18 @@ func isRetriableNetErr(err error) bool {
 }
 
 // parseRetryAfter parses an HTTP Retry-After header. Supports both
-// delta-seconds (integer) and HTTP-date forms. Returns 0 on parse failure or
-// out-of-range values; caller falls back to the schedule. Caps at maxRetryAfter
-// (30 s) to prevent the gateway from forcing arbitrarily long client waits.
+// delta-seconds (integer) and HTTP-date forms. Returns retryAfterAbsent (-1)
+// when no usable value is present so callers can distinguish "no header" from
+// an explicit "Retry-After: 0" (= retry immediately, RFC 7231). Values are
+// capped at maxRetryAfter to prevent the gateway from forcing arbitrarily
+// long client waits.
 func parseRetryAfter(h string) time.Duration {
 	if h == "" {
-		return 0
+		return retryAfterAbsent
 	}
 	if secs, err := strconv.Atoi(h); err == nil {
-		if secs <= 0 {
-			return 0
+		if secs < 0 {
+			return retryAfterAbsent
 		}
 		d := time.Duration(secs) * time.Second
 		if d > maxRetryAfter {
@@ -297,30 +324,31 @@ func parseRetryAfter(h string) time.Duration {
 	}
 	if t, err := http.ParseTime(h); err == nil {
 		d := time.Until(t)
-		if d <= 0 {
-			return 0
+		if d < 0 {
+			return retryAfterAbsent
 		}
 		if d > maxRetryAfter {
 			return maxRetryAfter
 		}
 		return d
 	}
-	return 0
+	return retryAfterAbsent
 }
 
-// backoffDelay returns the next sleep duration. If retryAfter > 0 (already
-// capped), it's used directly. Otherwise: retryBaseDelay * 3^attempt with
-// ±25% jitter via math/rand/v2 (Go 1.22+ — no global lock).
-func backoffDelay(attempt int, retryAfter time.Duration) time.Duration {
-	if retryAfter > 0 {
+// backoffDelay returns the next sleep duration. If retryAfter is present
+// (>= 0), it is used directly — including 0 to honour an explicit
+// "Retry-After: 0" (retry immediately). Otherwise: c.retryBaseDelay * 3^attempt
+// with ±25% jitter via math/rand/v2 (Go 1.22+ — no global lock).
+func (c *Client) backoffDelay(attempt int, retryAfter time.Duration) time.Duration {
+	if retryAfter >= 0 {
 		return retryAfter
 	}
-	base := retryBaseDelay
+	base := c.retryBaseDelay
 	for range attempt {
 		base *= 3
 	}
 	if base <= 0 {
-		return retryBaseDelay
+		return c.retryBaseDelay
 	}
 	// Jitter range: [-base/4, +base/4].
 	jitter := time.Duration(rand.Int64N(int64(base)/2)) - base/4

--- a/internal/openrouter/client.go
+++ b/internal/openrouter/client.go
@@ -4,17 +4,34 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
+	"math/rand/v2"
+	"net"
 	"net/http"
+	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/valpere/llm-council/internal/council"
 )
 
 const (
-	defaultURL   = "https://openrouter.ai/api/v1/chat/completions"
-	maxBodyBytes = 4 * 1024 * 1024 // 4 MiB cap on response bodies
+	defaultURL    = "https://openrouter.ai/api/v1/chat/completions"
+	maxBodyBytes  = 4 * 1024 * 1024  // 4 MiB cap on response bodies
+	maxRetryAfter = 30 * time.Second // ceiling applied to Retry-After header values
+)
+
+// retryBaseDelay is the first attempt's nominal backoff. Exposed as a package
+// variable so tests can shrink it; production uses 500 ms.
+//
+// maxCumulativeBackoffDuration caps the total time spent sleeping across all
+// retry attempts in a single Complete call. Also a variable for testability.
+var (
+	retryBaseDelay               = 500 * time.Millisecond
+	maxCumulativeBackoffDuration = 60 * time.Second
 )
 
 // APIError is returned when OpenRouter responds with a non-200 status code.
@@ -29,22 +46,33 @@ func (e *APIError) Error() string {
 
 // Client sends completion requests to the OpenRouter API.
 type Client struct {
-	apiKey  string
-	baseURL string // overridable in tests; defaults to defaultURL
-	http    *http.Client
+	apiKey     string
+	baseURL    string // overridable in tests; defaults to defaultURL
+	http       *http.Client
+	maxRetries int          // total retries (1 initial attempt + maxRetries retries)
+	logger     *slog.Logger // never nil — NewClient substitutes slog.Default()
 }
 
-// NewClient creates a Client with the given API key, base URL, and HTTP timeout.
-// baseURL overrides the default OpenRouter endpoint; pass "" to use the default.
-// Configured at runtime via the LLM_API_BASE_URL environment variable.
-func NewClient(apiKey, baseURL string, timeout time.Duration) *Client {
+// NewClient creates a Client with the given API key, base URL, HTTP timeout,
+// retry budget, and logger. baseURL overrides the default OpenRouter endpoint;
+// pass "" to use the default. maxRetries of 0 means a single attempt (no
+// retries). A nil logger falls back to slog.Default().
+func NewClient(apiKey, baseURL string, timeout time.Duration, maxRetries int, logger *slog.Logger) *Client {
 	if baseURL == "" {
 		baseURL = defaultURL
 	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
 	return &Client{
-		apiKey:  apiKey,
-		baseURL: baseURL,
-		http:    &http.Client{Timeout: timeout},
+		apiKey:     apiKey,
+		baseURL:    baseURL,
+		http:       &http.Client{Timeout: timeout},
+		maxRetries: maxRetries,
+		logger:     logger,
 	}
 }
 
@@ -52,16 +80,82 @@ func NewClient(apiKey, baseURL string, timeout time.Duration) *Client {
 var _ council.LLMClient = (*Client)(nil)
 
 // Complete POSTs a chat completion request to OpenRouter and returns the response.
-// Returns *APIError on non-200 responses.
+// On transient failures (5xx, 429, network blips), it retries with exponential
+// backoff and ±25% jitter, honoring Retry-After headers and a cumulative
+// 60 s sleep budget. Returns *APIError on non-200 responses after retries are
+// exhausted.
 func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (council.CompletionResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return council.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
 	}
 
+	var (
+		cumulativeBackoff time.Duration
+		lastErr           error
+	)
+	for attempt := 0; ; attempt++ {
+		// Honour a context cancellation observed before issuing the next request.
+		if cerr := ctx.Err(); cerr != nil {
+			return council.CompletionResponse{}, cerr
+		}
+
+		resp, attemptErr := c.doAttempt(ctx, body)
+		shouldRetry, retryAfter, finalErr := c.classifyAttempt(resp, attemptErr)
+
+		if !shouldRetry {
+			// Either we have a successful response, an unmarshal error, or a
+			// non-retryable failure. classifyAttempt returns the right value
+			// in finalErr (and resp on success) for us to surface.
+			if finalErr != nil {
+				if attempt > 0 {
+					c.logger.Info("openrouter: retries exhausted",
+						"attempts", attempt+1, "final_error", finalErr)
+				}
+				return council.CompletionResponse{}, finalErr
+			}
+			// Successful 200 + decoded body.
+			return c.decodeBody(resp)
+		}
+
+		// Retryable. lastErr always tracks the most recent reason for retry so
+		// we can surface it if the cap or maxRetries forces a final return.
+		lastErr = finalErr
+
+		if attempt >= c.maxRetries {
+			c.logger.Info("openrouter: retries exhausted",
+				"attempts", attempt+1, "final_error", lastErr)
+			return council.CompletionResponse{}, lastErr
+		}
+
+		delay := backoffDelay(attempt, retryAfter)
+		if cumulativeBackoff+delay > maxCumulativeBackoffDuration {
+			c.logger.Info("openrouter: cumulative backoff cap reached",
+				"cumulative_ms", cumulativeBackoff.Milliseconds(),
+				"final_error", lastErr)
+			return council.CompletionResponse{}, lastErr
+		}
+		cumulativeBackoff += delay
+
+		c.logger.Debug("openrouter: retrying",
+			"attempt", attempt+1, "delay_ms", delay.Milliseconds(),
+			"cause", lastErr)
+
+		select {
+		case <-ctx.Done():
+			return council.CompletionResponse{}, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+// doAttempt performs a single HTTP request. On HTTP-level responses, it leaves
+// resp.Body open so the caller can decide whether to drain (retry path) or
+// read (non-retry path). On network errors it returns err only.
+func (c *Client) doAttempt(ctx context.Context, body []byte) (*http.Response, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL, bytes.NewReader(body))
 	if err != nil {
-		return council.CompletionResponse{}, fmt.Errorf("create request: %w", err)
+		return nil, fmt.Errorf("create request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
@@ -70,26 +164,165 @@ func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (c
 
 	resp, err := c.http.Do(httpReq)
 	if err != nil {
-		return council.CompletionResponse{}, fmt.Errorf("send request: %w", err)
+		return nil, fmt.Errorf("send request: %w", err)
 	}
-	defer resp.Body.Close()
+	return resp, nil
+}
 
-	// Limit reads to maxBodyBytes to guard against unexpectedly large responses.
+// classifyAttempt inspects the result of doAttempt and decides whether to
+// retry. On a retry decision, it drains and closes the response body so the
+// connection returns to the keep-alive pool. On a non-retry decision, it
+// either returns a final error (with the body read for a non-retryable status)
+// or leaves resp populated with the body still readable (for the success path,
+// where the caller will decode).
+func (c *Client) classifyAttempt(resp *http.Response, err error) (shouldRetry bool, retryAfter time.Duration, finalErr error) {
+	// Network-level error path.
+	if err != nil {
+		if isRetriableNetErr(err) {
+			return true, 0, err
+		}
+		return false, 0, err
+	}
+
+	// HTTP-level path.
+	if isRetriableStatus(resp.StatusCode) {
+		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+		// Read the body up to maxBodyBytes so it can be surfaced if retries
+		// are exhausted (or maxRetries=0). Then drain + close any tail so the
+		// connection returns to the keep-alive pool — for typical OpenRouter
+		// error JSON the tail will be empty.
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		return true, retryAfter, &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+
+	// Non-retryable status (4xx other than 429, or 200). Read body so we can
+	// either return the *APIError with body, or hand off to decodeBody on 200.
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	_ = resp.Body.Close()
+	if readErr != nil {
+		// A failed body read is itself a candidate for retry (ErrUnexpectedEOF, EOF).
+		if isRetriableNetErr(readErr) {
+			return true, 0, fmt.Errorf("read response: %w", readErr)
+		}
+		return false, 0, fmt.Errorf("read response: %w", readErr)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return false, 0, &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+
+	// Success — stash the body on resp so decodeBody can read it without re-reading.
+	resp.Body = io.NopCloser(bytes.NewReader(respBody))
+	return false, 0, nil
+}
+
+// decodeBody parses a successful response body into a CompletionResponse.
+func (c *Client) decodeBody(resp *http.Response) (council.CompletionResponse, error) {
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if err != nil {
 		return council.CompletionResponse{}, fmt.Errorf("read response: %w", err)
 	}
-
-	if resp.StatusCode != http.StatusOK {
-		return council.CompletionResponse{}, &APIError{
-			StatusCode: resp.StatusCode,
-			Body:       string(respBody),
-		}
-	}
-
 	var completionResp council.CompletionResponse
 	if err := json.Unmarshal(respBody, &completionResp); err != nil {
 		return council.CompletionResponse{}, fmt.Errorf("unmarshal response: %w", err)
 	}
 	return completionResp, nil
+}
+
+// isRetriableStatus returns true for HTTP status codes worth retrying:
+// 429 (rate limit), 502, 503, 504 (transient upstream errors).
+func isRetriableStatus(code int) bool {
+	switch code {
+	case http.StatusTooManyRequests,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	}
+	return false
+}
+
+// isRetriableNetErr returns true for network-level errors worth retrying:
+// timeouts (including http.Client.Timeout), connection resets, broken pipes,
+// EOFs from closed keep-alive connections.
+//
+// User-context cancellation is NOT classified here — Complete checks ctx.Err()
+// at the top of each iteration before retrying, so any user-cancelled context
+// short-circuits before this function would observe it. We deliberately treat
+// net.Error.Timeout() as retriable even when its underlying cause unwraps to
+// context.DeadlineExceeded, because http.Client.Timeout fires that exact shape
+// and we want it to retry.
+func isRetriableNetErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Explicit user cancellation is never retried — no point continuing if the
+	// caller has given up. (DeadlineExceeded is intentionally not rejected here:
+	// see the doc comment above.)
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	return false
+}
+
+// parseRetryAfter parses an HTTP Retry-After header. Supports both
+// delta-seconds (integer) and HTTP-date forms. Returns 0 on parse failure or
+// out-of-range values; caller falls back to the schedule. Caps at maxRetryAfter
+// (30 s) to prevent the gateway from forcing arbitrarily long client waits.
+func parseRetryAfter(h string) time.Duration {
+	if h == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(h); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		d := time.Duration(secs) * time.Second
+		if d > maxRetryAfter {
+			return maxRetryAfter
+		}
+		return d
+	}
+	if t, err := http.ParseTime(h); err == nil {
+		d := time.Until(t)
+		if d <= 0 {
+			return 0
+		}
+		if d > maxRetryAfter {
+			return maxRetryAfter
+		}
+		return d
+	}
+	return 0
+}
+
+// backoffDelay returns the next sleep duration. If retryAfter > 0 (already
+// capped), it's used directly. Otherwise: retryBaseDelay * 3^attempt with
+// ±25% jitter via math/rand/v2 (Go 1.22+ — no global lock).
+func backoffDelay(attempt int, retryAfter time.Duration) time.Duration {
+	if retryAfter > 0 {
+		return retryAfter
+	}
+	base := retryBaseDelay
+	for range attempt {
+		base *= 3
+	}
+	if base <= 0 {
+		return retryBaseDelay
+	}
+	// Jitter range: [-base/4, +base/4].
+	jitter := time.Duration(rand.Int64N(int64(base)/2)) - base/4
+	return base + jitter
 }

--- a/internal/openrouter/client_test.go
+++ b/internal/openrouter/client_test.go
@@ -4,20 +4,32 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/valpere/llm-council/internal/council"
 )
 
-// testClient returns a Client pointed at srv with the given API key.
+// testClient returns a Client pointed at srv with the given API key and no
+// retries. Use testClientWithRetries when a test exercises the retry loop.
 func testClient(apiKey string, srv *httptest.Server) *Client {
+	return testClientWithRetries(apiKey, srv, 0)
+}
+
+// testClientWithRetries returns a Client pointed at srv with the given API key
+// and retry budget. Logger is silenced (Discard).
+func testClientWithRetries(apiKey string, srv *httptest.Server, retries int) *Client {
 	return &Client{
-		apiKey:  apiKey,
-		baseURL: srv.URL,
-		http:    srv.Client(),
+		apiKey:     apiKey,
+		baseURL:    srv.URL,
+		http:       srv.Client(),
+		maxRetries: retries,
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 }
 
@@ -217,7 +229,7 @@ func TestComplete_ResponseFormatForwarded(t *testing.T) {
 // ── TestNewClient ─────────────────────────────────────────────────────────────
 
 func TestNewClient_DefaultURL(t *testing.T) {
-	c := NewClient("my-key", "", 30*time.Second)
+	c := NewClient("my-key", "", 30*time.Second, 2, nil)
 	if c.apiKey != "my-key" {
 		t.Errorf("apiKey: got %q, want %q", c.apiKey, "my-key")
 	}
@@ -227,12 +239,379 @@ func TestNewClient_DefaultURL(t *testing.T) {
 	if c.http.Timeout != 30*time.Second {
 		t.Errorf("timeout: got %v, want 30s", c.http.Timeout)
 	}
+	if c.maxRetries != 2 {
+		t.Errorf("maxRetries: got %d, want 2", c.maxRetries)
+	}
+	if c.logger == nil {
+		t.Error("logger should be substituted with slog.Default(), got nil")
+	}
 }
 
 func TestNewClient_CustomURL(t *testing.T) {
 	const custom = "http://localhost:11434/v1/chat/completions"
-	c := NewClient("ollama", custom, 10*time.Second)
+	c := NewClient("ollama", custom, 10*time.Second, 0, nil)
 	if c.baseURL != custom {
 		t.Errorf("baseURL: got %q, want %q", c.baseURL, custom)
+	}
+	if c.maxRetries != 0 {
+		t.Errorf("maxRetries: got %d, want 0", c.maxRetries)
+	}
+}
+
+func TestNewClient_NegativeRetriesClampedToZero(t *testing.T) {
+	c := NewClient("k", "", time.Second, -5, nil)
+	if c.maxRetries != 0 {
+		t.Errorf("maxRetries: got %d, want 0 (clamped)", c.maxRetries)
+	}
+}
+
+// ── Retry tests ────────────────────────────────────────────────────────────
+
+// withFastBackoff replaces retryBaseDelay with 1ms for the duration of t and
+// restores it on cleanup. Lets retry tests run in milliseconds rather than
+// seconds.
+func withFastBackoff(t *testing.T) {
+	t.Helper()
+	orig := retryBaseDelay
+	retryBaseDelay = 1 * time.Millisecond
+	t.Cleanup(func() { retryBaseDelay = orig })
+}
+
+// withCumulativeBackoffCap temporarily lowers maxCumulativeBackoffDuration so
+// the cap test can fire without sleeping for a real minute.
+func withCumulativeBackoffCap(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := maxCumulativeBackoffDuration
+	maxCumulativeBackoffDuration = d
+	t.Cleanup(func() { maxCumulativeBackoffDuration = orig })
+}
+
+// successfulCompletion returns a minimal-shape JSON OpenAI-compat success body.
+func successfulCompletion(content string) any {
+	return mockCompletion{
+		Choices: []struct {
+			Message struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+		}{{Message: struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		}{Role: "assistant", Content: content}}},
+	}
+}
+
+func TestComplete_RetryOn503ThenSuccess(t *testing.T) {
+	withFastBackoff(t)
+
+	var counter int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&counter, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		writeJSON(w, successfulCompletion("recovered"))
+	}))
+	defer srv.Close()
+
+	c := testClientWithRetries("key", srv, 3)
+	resp, err := c.Complete(context.Background(), council.CompletionRequest{
+		Model:    "x",
+		Messages: []council.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&counter); got != 2 {
+		t.Errorf("call count: got %d, want 2 (initial 503 + 1 retry success)", got)
+	}
+	if len(resp.Choices) == 0 || resp.Choices[0].Message.Content != "recovered" {
+		t.Errorf("response: got %+v, want content=recovered", resp)
+	}
+}
+
+func TestComplete_RetryOn429WithRetryAfter(t *testing.T) {
+	withFastBackoff(t)
+
+	var (
+		counter int32
+		gap     time.Duration
+		first   time.Time
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&counter, 1)
+		switch n {
+		case 1:
+			first = time.Now()
+			w.Header().Set("Retry-After", "1") // 1 second
+			w.WriteHeader(http.StatusTooManyRequests)
+		case 2:
+			gap = time.Since(first)
+			writeJSON(w, successfulCompletion("ok"))
+		}
+	}))
+	defer srv.Close()
+
+	c := testClientWithRetries("key", srv, 3)
+	if _, err := c.Complete(context.Background(), council.CompletionRequest{
+		Model:    "x",
+		Messages: []council.ChatMessage{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&counter); got != 2 {
+		t.Errorf("call count: got %d, want 2", got)
+	}
+	if gap < 900*time.Millisecond || gap > 1500*time.Millisecond {
+		t.Errorf("gap between attempts: got %v, want ~1s honoring Retry-After", gap)
+	}
+}
+
+func TestComplete_RetryOnTimeout(t *testing.T) {
+	withFastBackoff(t)
+
+	var counter int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&counter, 1)
+		if n == 1 {
+			// First attempt hangs past client timeout.
+			time.Sleep(150 * time.Millisecond)
+			return
+		}
+		writeJSON(w, successfulCompletion("ok"))
+	}))
+	defer srv.Close()
+
+	c := testClientWithRetries("key", srv, 2)
+	c.http.Timeout = 50 * time.Millisecond
+
+	if _, err := c.Complete(context.Background(), council.CompletionRequest{
+		Model:    "x",
+		Messages: []council.ChatMessage{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("unexpected error after retry: %v", err)
+	}
+	if got := atomic.LoadInt32(&counter); got != 2 {
+		t.Errorf("call count: got %d, want 2", got)
+	}
+}
+
+func TestComplete_NoRetryOn401(t *testing.T) {
+	withFastBackoff(t)
+
+	var counter int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&counter, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"bad key"}`))
+	}))
+	defer srv.Close()
+
+	c := testClientWithRetries("key", srv, 3)
+	_, err := c.Complete(context.Background(), council.CompletionRequest{
+		Model:    "x",
+		Messages: []council.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected APIError, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected *APIError with status 401, got %v", err)
+	}
+	if got := atomic.LoadInt32(&counter); got != 1 {
+		t.Errorf("call count: got %d, want 1 (no retry on 4xx other than 429)", got)
+	}
+}
+
+func TestComplete_NoRetryOn200(t *testing.T) {
+	withFastBackoff(t)
+
+	var counter int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&counter, 1)
+		writeJSON(w, successfulCompletion("ok"))
+	}))
+	defer srv.Close()
+
+	c := testClientWithRetries("key", srv, 3)
+	if _, err := c.Complete(context.Background(), council.CompletionRequest{
+		Model:    "x",
+		Messages: []council.ChatMessage{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&counter); got != 1 {
+		t.Errorf("call count: got %d, want 1 (no retry on success)", got)
+	}
+}
+
+func TestComplete_RetriesExhausted(t *testing.T) {
+	withFastBackoff(t)
+
+	var counter int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&counter, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := testClientWithRetries("key", srv, 2) // 1 initial + 2 retries = 3 total
+	_, err := c.Complete(context.Background(), council.CompletionRequest{
+		Model:    "x",
+		Messages: []council.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected *APIError with status 503, got %v", err)
+	}
+	if got := atomic.LoadInt32(&counter); got != 3 {
+		t.Errorf("call count: got %d, want 3 (1 initial + 2 retries)", got)
+	}
+}
+
+func TestComplete_ContextCancelDuringBackoff(t *testing.T) {
+	// Use a longer base delay so cancellation can interrupt the sleep.
+	orig := retryBaseDelay
+	retryBaseDelay = 5 * time.Second
+	t.Cleanup(func() { retryBaseDelay = orig })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := testClientWithRetries("key", srv, 3)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel after the first 503 response, while we're sleeping.
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := c.Complete(ctx, council.CompletionRequest{
+		Model:    "x",
+		Messages: []council.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("elapsed %v; cancel during backoff should return promptly", elapsed)
+	}
+}
+
+func TestComplete_CumulativeBackoffCap(t *testing.T) {
+	withFastBackoff(t)
+	withCumulativeBackoffCap(t, 1500*time.Millisecond)
+
+	var counter int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&counter, 1)
+		w.Header().Set("Retry-After", "1") // forces 1s delays
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := testClientWithRetries("key", srv, 5) // generous budget; cap should fire first
+	start := time.Now()
+	_, err := c.Complete(context.Background(), council.CompletionRequest{
+		Model:    "x",
+		Messages: []council.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected *APIError 503, got %v", err)
+	}
+	// Attempt 0: 503, sleep 1s (cum=1s). Attempt 1: 503, would sleep 1s
+	// (cum+delay=2s > 1.5s cap), so cap fires and we return without retry.
+	if got := atomic.LoadInt32(&counter); got != 2 {
+		t.Errorf("call count: got %d, want 2 (cap fires before third attempt)", got)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("elapsed %v; cap should have prevented further retries", elapsed)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want time.Duration
+	}{
+		{"empty", "", 0},
+		{"valid seconds", "5", 5 * time.Second},
+		{"zero seconds", "0", 0},
+		{"negative seconds", "-3", 0},
+		{"invalid", "soon", 0},
+		{"capped at maxRetryAfter", "3600", maxRetryAfter},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseRetryAfter(tc.in)
+			if got != tc.want {
+				t.Errorf("parseRetryAfter(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRetriableNetErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"context cancelled", context.Canceled, false},
+		// Bare DeadlineExceeded satisfies net.Error.Timeout(), so it's retried.
+		// Real user cancellation is caught by Complete's loop-top ctx.Err() check.
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"io.EOF", io.EOF, true},
+		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, true},
+		{"random error", errors.New("nope"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetriableNetErr(tc.err); got != tc.want {
+				t.Errorf("isRetriableNetErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRetriableStatus(t *testing.T) {
+	tests := []struct {
+		code int
+		want bool
+	}{
+		{http.StatusOK, false},
+		{http.StatusBadRequest, false},
+		{http.StatusUnauthorized, false},
+		{http.StatusTooManyRequests, true},
+		{http.StatusInternalServerError, false}, // 500 not retried — could be deterministic upstream bug
+		{http.StatusBadGateway, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusGatewayTimeout, true},
+	}
+	for _, tc := range tests {
+		t.Run(http.StatusText(tc.code), func(t *testing.T) {
+			if got := isRetriableStatus(tc.code); got != tc.want {
+				t.Errorf("isRetriableStatus(%d) = %v, want %v", tc.code, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/openrouter/client_test.go
+++ b/internal/openrouter/client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -22,14 +23,18 @@ func testClient(apiKey string, srv *httptest.Server) *Client {
 }
 
 // testClientWithRetries returns a Client pointed at srv with the given API key
-// and retry budget. Logger is silenced (Discard).
+// and retry budget. Logger is silenced (Discard). Backoff knobs are set to
+// fast defaults (1ms base, 60s cap) so retry tests run quickly without
+// mutating package globals — each test gets its own isolated Client.
 func testClientWithRetries(apiKey string, srv *httptest.Server, retries int) *Client {
 	return &Client{
-		apiKey:     apiKey,
-		baseURL:    srv.URL,
-		http:       srv.Client(),
-		maxRetries: retries,
-		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		apiKey:                       apiKey,
+		baseURL:                      srv.URL,
+		http:                         srv.Client(),
+		maxRetries:                   retries,
+		logger:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		retryBaseDelay:               1 * time.Millisecond,
+		maxCumulativeBackoffDuration: defaultMaxCumulativeBackoffDuration,
 	}
 }
 
@@ -266,25 +271,10 @@ func TestNewClient_NegativeRetriesClampedToZero(t *testing.T) {
 }
 
 // ── Retry tests ────────────────────────────────────────────────────────────
-
-// withFastBackoff replaces retryBaseDelay with 1ms for the duration of t and
-// restores it on cleanup. Lets retry tests run in milliseconds rather than
-// seconds.
-func withFastBackoff(t *testing.T) {
-	t.Helper()
-	orig := retryBaseDelay
-	retryBaseDelay = 1 * time.Millisecond
-	t.Cleanup(func() { retryBaseDelay = orig })
-}
-
-// withCumulativeBackoffCap temporarily lowers maxCumulativeBackoffDuration so
-// the cap test can fire without sleeping for a real minute.
-func withCumulativeBackoffCap(t *testing.T, d time.Duration) {
-	t.Helper()
-	orig := maxCumulativeBackoffDuration
-	maxCumulativeBackoffDuration = d
-	t.Cleanup(func() { maxCumulativeBackoffDuration = orig })
-}
+//
+// These tests configure backoff knobs on a per-Client basis (set on the
+// struct returned by testClientWithRetries), not via package-level globals,
+// so each case is fully isolated and safe to run in parallel.
 
 // successfulCompletion returns a minimal-shape JSON OpenAI-compat success body.
 func successfulCompletion(content string) any {
@@ -302,8 +292,6 @@ func successfulCompletion(content string) any {
 }
 
 func TestComplete_RetryOn503ThenSuccess(t *testing.T) {
-	withFastBackoff(t)
-
 	var counter int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := atomic.AddInt32(&counter, 1)
@@ -332,8 +320,6 @@ func TestComplete_RetryOn503ThenSuccess(t *testing.T) {
 }
 
 func TestComplete_RetryOn429WithRetryAfter(t *testing.T) {
-	withFastBackoff(t)
-
 	var (
 		counter int32
 		gap     time.Duration
@@ -369,8 +355,6 @@ func TestComplete_RetryOn429WithRetryAfter(t *testing.T) {
 }
 
 func TestComplete_RetryOnTimeout(t *testing.T) {
-	withFastBackoff(t)
-
 	var counter int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := atomic.AddInt32(&counter, 1)
@@ -398,8 +382,6 @@ func TestComplete_RetryOnTimeout(t *testing.T) {
 }
 
 func TestComplete_NoRetryOn401(t *testing.T) {
-	withFastBackoff(t)
-
 	var counter int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&counter, 1)
@@ -426,8 +408,6 @@ func TestComplete_NoRetryOn401(t *testing.T) {
 }
 
 func TestComplete_NoRetryOn200(t *testing.T) {
-	withFastBackoff(t)
-
 	var counter int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&counter, 1)
@@ -448,8 +428,6 @@ func TestComplete_NoRetryOn200(t *testing.T) {
 }
 
 func TestComplete_RetriesExhausted(t *testing.T) {
-	withFastBackoff(t)
-
 	var counter int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&counter, 1)
@@ -475,17 +453,14 @@ func TestComplete_RetriesExhausted(t *testing.T) {
 }
 
 func TestComplete_ContextCancelDuringBackoff(t *testing.T) {
-	// Use a longer base delay so cancellation can interrupt the sleep.
-	orig := retryBaseDelay
-	retryBaseDelay = 5 * time.Second
-	t.Cleanup(func() { retryBaseDelay = orig })
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer srv.Close()
 
 	c := testClientWithRetries("key", srv, 3)
+	// Use a long base delay so cancellation can interrupt the sleep.
+	c.retryBaseDelay = 5 * time.Second
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Cancel after the first 503 response, while we're sleeping.
@@ -510,9 +485,6 @@ func TestComplete_ContextCancelDuringBackoff(t *testing.T) {
 }
 
 func TestComplete_CumulativeBackoffCap(t *testing.T) {
-	withFastBackoff(t)
-	withCumulativeBackoffCap(t, 1500*time.Millisecond)
-
 	var counter int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&counter, 1)
@@ -522,6 +494,7 @@ func TestComplete_CumulativeBackoffCap(t *testing.T) {
 	defer srv.Close()
 
 	c := testClientWithRetries("key", srv, 5) // generous budget; cap should fire first
+	c.maxCumulativeBackoffDuration = 1500 * time.Millisecond
 	start := time.Now()
 	_, err := c.Complete(context.Background(), council.CompletionRequest{
 		Model:    "x",
@@ -552,11 +525,11 @@ func TestParseRetryAfter(t *testing.T) {
 		in   string
 		want time.Duration
 	}{
-		{"empty", "", 0},
+		{"empty returns absent", "", retryAfterAbsent},
 		{"valid seconds", "5", 5 * time.Second},
-		{"zero seconds", "0", 0},
-		{"negative seconds", "-3", 0},
-		{"invalid", "soon", 0},
+		{"zero seconds means retry-immediately", "0", 0}, // RFC 7231 — distinct from absent
+		{"negative seconds returns absent", "-3", retryAfterAbsent},
+		{"invalid returns absent", "soon", retryAfterAbsent},
 		{"capped at maxRetryAfter", "3600", maxRetryAfter},
 	}
 	for _, tc := range tests {
@@ -566,6 +539,69 @@ func TestParseRetryAfter(t *testing.T) {
 				t.Errorf("parseRetryAfter(%q) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
+	}
+
+	// HTTP-date forms — relative to time.Now(), so use a tolerance.
+	t.Run("future HTTP-date ~5s", func(t *testing.T) {
+		future := time.Now().Add(5 * time.Second).UTC().Format(http.TimeFormat)
+		got := parseRetryAfter(future)
+		if got < 3*time.Second || got > 5*time.Second {
+			t.Errorf("parseRetryAfter(%q) = %v, want ~5s", future, got)
+		}
+	})
+	t.Run("past HTTP-date returns absent", func(t *testing.T) {
+		past := time.Now().Add(-1 * time.Hour).UTC().Format(http.TimeFormat)
+		if got := parseRetryAfter(past); got != retryAfterAbsent {
+			t.Errorf("parseRetryAfter(%q) = %v, want retryAfterAbsent", past, got)
+		}
+	})
+	t.Run("future HTTP-date capped at maxRetryAfter", func(t *testing.T) {
+		far := time.Now().Add(1 * time.Hour).UTC().Format(http.TimeFormat)
+		if got := parseRetryAfter(far); got != maxRetryAfter {
+			t.Errorf("parseRetryAfter(%q) = %v, want %v (capped)", far, got, maxRetryAfter)
+		}
+	})
+}
+
+// TestComplete_RetryAfterZeroHonored verifies an explicit "Retry-After: 0"
+// header is honored as "retry immediately" and not treated as absent.
+func TestComplete_RetryAfterZeroHonored(t *testing.T) {
+	var (
+		counter int32
+		gap     time.Duration
+		first   time.Time
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&counter, 1)
+		if n == 1 {
+			first = time.Now()
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		gap = time.Since(first)
+		writeJSON(w, successfulCompletion("ok"))
+	}))
+	defer srv.Close()
+
+	// Set a relatively long retryBaseDelay so we can detect that Retry-After: 0
+	// short-circuits the schedule rather than falling back to it.
+	c := testClientWithRetries("key", srv, 2)
+	c.retryBaseDelay = 250 * time.Millisecond
+
+	if _, err := c.Complete(context.Background(), council.CompletionRequest{
+		Model:    "x",
+		Messages: []council.ChatMessage{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&counter); got != 2 {
+		t.Errorf("call count: got %d, want 2", got)
+	}
+	// With Retry-After: 0 honored, the gap should be near-zero (well below
+	// retryBaseDelay). Allow generous slack for goroutine scheduling.
+	if gap > 100*time.Millisecond {
+		t.Errorf("gap %v; expected ~0 because Retry-After: 0 means retry immediately", gap)
 	}
 }
 
@@ -582,6 +618,8 @@ func TestIsRetriableNetErr(t *testing.T) {
 		{"deadline exceeded", context.DeadlineExceeded, true},
 		{"io.EOF", io.EOF, true},
 		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, true},
+		{"syscall.ECONNRESET", syscall.ECONNRESET, true},
+		{"syscall.EPIPE", syscall.EPIPE, true},
 		{"random error", errors.New("nope"), false},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

`internal/openrouter/client.go` used to make a single `http.Client.Do` call. A transient 502/503/504, a 429 rate-limit response, or a momentary network blip failed the entire stage. Stage 1 with quorum tolerates per-model failures, but a transient gateway hiccup that hits all in-flight models took the whole pipeline down — the council reported 500 to the user when a 500 ms retry would have succeeded.

This PR adds an in-client retry loop with exponential backoff and jitter, scoped intentionally to **Layer A only** (retries against the configured base URL). Multi-provider fallback is deferred.

Closes #175

## Behaviour

| Class | Retried? |
|---|---|
| HTTP 429, 502, 503, 504 | ✅ |
| `net.Error.Timeout()` (incl. `http.Client.Timeout`, `context.DeadlineExceeded`) | ✅ |
| `io.EOF`, `io.ErrUnexpectedEOF`, `syscall.ECONNRESET`, `syscall.EPIPE` | ✅ |
| Any other 4xx (auth, bad request) | ❌ |
| HTTP 500 (deterministic upstream bug) | ❌ |
| `context.Canceled` (explicit user cancel) | ❌ |
| Marshal/unmarshal errors | ❌ |

- **Backoff:** `retryBaseDelay` (500ms) × 3^attempt with ±25% jitter via `math/rand/v2`.
- **`Retry-After`:** honored when present, capped at 30 s.
- **Cumulative sleep cap:** 60 s across all attempts in one `Complete` call. If the next planned delay would breach the cap, return the last error immediately.
- **Keep-alive hygiene:** retried response bodies are read up to `maxBodyBytes` (so a final `*APIError` carries a body even after retries), then any tail drained and the body closed.
- **Logging:** per-attempt at `Debug`, final failure at `Info`.

## API change

`NewClient(apiKey, baseURL, timeout)` → `NewClient(apiKey, baseURL, timeout, maxRetries int, logger *slog.Logger)`. Positional, matching `storage.NewStore` and `council.NewCouncil`. Negative `maxRetries` clamps to 0; nil logger falls back to `slog.Default()`. Only `cmd/server/main.go` calls `NewClient` from production code; updated.

## Configuration

- New env var: `LLM_API_MAX_RETRIES` (default `2` = 3 total attempts; `0` disables; invalid values warn-and-fallback per the existing config pattern).
- Documented in `.env.example`.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `staticcheck ./...` clean
- [x] `go test -race -count=1 ./...` — 154 pass (was 122; +32 new tests)
- [x] 12 new test cases covering: 503-then-success, 429+Retry-After, http.Client.Timeout retry, no-retry on 401, no-retry on 200, exhaustion returns final \*APIError, ctx cancel during backoff returns promptly, cumulative cap fires, parseRetryAfter table, isRetriableNetErr table, isRetriableStatus table, negative maxRetries clamped

🤖 Generated with [Claude Code](https://claude.com/claude-code)