### PR TITLE
🏗️ feat(eval,council): add evaluation harness measuring council vs single-model quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ bin/
 
 data/
 
+# Eval harness — golden inputs ARE checked in (internal/eval/testdata/).
+# Result envelopes from running cmd/eval are local artefacts and are NOT.
+eval-results*.json
+
 # Self-learning pattern store (global gitignore has _* — explicitly opt in, then exclude raw logs)
 !_patterns/
 !_patterns/**

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -1,0 +1,171 @@
+// Command eval runs the LLM Council evaluation harness — a manual,
+// pre-merge regression detector that compares the council pipeline against
+// a single-model baseline using an LLM-as-judge.
+//
+// Usage:
+//
+//	go run ./cmd/eval \
+//	    -input internal/eval/testdata/golden.json \
+//	    -out eval-results.json \
+//	    -baseline-model openai/gpt-4o-mini \
+//	    -council-type default
+//
+// Costs real money (~$1–2 per pass with the balanced model preset). Run
+// before any prompt-template, strategy, or default-models change.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/joho/godotenv"
+
+	"github.com/valpere/llm-council/internal/config"
+	"github.com/valpere/llm-council/internal/council"
+	"github.com/valpere/llm-council/internal/eval"
+	"github.com/valpere/llm-council/internal/openrouter"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "eval:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		inputPath     = flag.String("input", "internal/eval/testdata/golden.json", "path to golden case JSON file")
+		outPath       = flag.String("out", "eval-results.json", "path to write the results JSON envelope")
+		baselineModel = flag.String("baseline-model", "", "single-model baseline (required)")
+		judgeModel    = flag.String("judge-model", "", "judge model — defaults to chairman; MUST differ from baseline")
+		councilType   = flag.String("council-type", "default", "council type registered in the server registry")
+		seed          = flag.Int64("seed", 0, "RNG seed for A/B order (0 = time-based, captured into output meta)")
+	)
+	flag.Parse()
+
+	if *baselineModel == "" {
+		return fmt.Errorf("-baseline-model is required")
+	}
+
+	// Load .env so OPENROUTER_API_KEY etc. resolve in dev. Production
+	// environments without a .env file are expected.
+	_ = godotenv.Load()
+
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	slog.SetDefault(logger)
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	// Default judge to chairman if -judge-model was not provided.
+	jModel := *judgeModel
+	if jModel == "" {
+		jModel = cfg.DefaultCouncilChairmanModel
+	}
+	if jModel == *baselineModel {
+		return fmt.Errorf("judge model %q must differ from baseline model to avoid self-preference bias; pass -judge-model explicitly", jModel)
+	}
+
+	// Read input file twice's worth of work in one pass: parse + hash. The
+	// hash is echoed into the output meta so a flipped result can be replayed
+	// against the exact same prompt set.
+	data, err := os.ReadFile(*inputPath)
+	if err != nil {
+		return fmt.Errorf("read input: %w", err)
+	}
+	suite, err := eval.LoadSuite(data)
+	if err != nil {
+		return err
+	}
+	if len(suite.Cases) == 0 {
+		return fmt.Errorf("input %q contains zero cases", *inputPath)
+	}
+
+	chosenSeed := *seed
+	if chosenSeed == 0 {
+		chosenSeed = time.Now().UnixNano()
+	}
+
+	// Build the council pipeline using the same wiring shape as cmd/server.
+	registry := map[string]council.CouncilType{
+		cfg.DefaultCouncilType: {
+			Name:          cfg.DefaultCouncilType,
+			Strategy:      council.PeerReview,
+			Models:        cfg.DefaultCouncilModels,
+			ChairmanModel: cfg.DefaultCouncilChairmanModel,
+			Temperature:   cfg.DefaultCouncilTemperature,
+		},
+		"code-review": council.NewCodeReviewCouncilType(
+			cfg.CodeReviewModels,
+			cfg.CodeReviewChairmanModel,
+			cfg.DefaultCouncilTemperature,
+		),
+	}
+	if _, ok := registry[*councilType]; !ok {
+		return fmt.Errorf("unknown council type %q (known: %v)", *councilType, knownTypes(registry))
+	}
+
+	client := openrouter.NewClient(cfg.OpenRouterAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger)
+	runner := council.NewCouncil(client, registry, logger)
+
+	// Honour SIGINT / SIGTERM mid-run — the harness is sequential, so
+	// cancelling between cases is enough; no goroutine cleanup is needed.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	results, err := eval.Run(ctx, eval.Options{
+		Suite:         suite,
+		Runner:        runner,
+		Client:        client,
+		BaselineModel: *baselineModel,
+		JudgeModel:    jModel,
+		CouncilType:   *councilType,
+		Temperature:   cfg.DefaultCouncilTemperature,
+		Seed:          chosenSeed,
+		Logger:        logger,
+	})
+	if err != nil {
+		return fmt.Errorf("run suite: %w", err)
+	}
+
+	meta := eval.Meta{
+		Seed:          chosenSeed,
+		InputSHA256:   eval.SuiteSHA256(data),
+		BaselineModel: *baselineModel,
+		JudgeModel:    jModel,
+		CouncilType:   *councilType,
+	}
+
+	out, err := os.Create(*outPath)
+	if err != nil {
+		return fmt.Errorf("create output: %w", err)
+	}
+	defer out.Close()
+	if err := eval.WriteOutput(out, meta, results); err != nil {
+		return err
+	}
+
+	summary := eval.Aggregate(results)
+	fmt.Println(summary.Format(len(results)))
+	fmt.Fprintf(os.Stderr, "wrote %s (seed=%d, sha256=%s)\n", *outPath, chosenSeed, meta.InputSHA256)
+	return nil
+}
+
+// knownTypes returns the keys of registry sorted lexicographically — used
+// only for diagnostic error messages.
+func knownTypes(registry map[string]council.CouncilType) []string {
+	keys := make([]string, 0, len(registry))
+	for k := range registry {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"sort"
 	"syscall"
 	"time"
 
@@ -161,11 +162,13 @@ func run() error {
 }
 
 // knownTypes returns the keys of registry sorted lexicographically — used
-// only for diagnostic error messages.
+// only for diagnostic error messages, but determinism matters here so a
+// failing CI run always blames the same line of "expected: [a b c]" output.
 func knownTypes(registry map[string]council.CouncilType) []string {
 	keys := make([]string, 0, len(registry))
 	for k := range registry {
 		keys = append(keys, k)
 	}
+	sort.Strings(keys)
 	return keys
 }

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -205,6 +205,105 @@ go test -race -count=1000 -v ./internal/council/ -run TestW_
 
 ---
 
+## 7. Evaluation Harness
+
+The four layers above answer the question "does my code do what I claim?".
+None of them answer the question "is my council producing better answers
+than a single model would?". The evaluation harness in `internal/eval/`
+plus the `cmd/eval` binary fill that gap.
+
+### What it does
+
+For each prompt in a fixed golden set, the harness runs:
+
+1. **Council pipeline** — `Runner.RunFull` against the configured council
+   type, capturing the chairman's final answer and the Stage 2 consensus W.
+2. **Single-model baseline** — `LLMClient.Complete` against one of the
+   council's models, given just the user prompt.
+3. **Pairwise judge** — a third model (distinct from the baseline) is shown
+   "Answer A" and "Answer B" in randomised order and asked which is better,
+   returning a JSON `{verdict, explanation}`.
+
+Verdicts are remapped from A/B back to council/baseline after parsing, and
+aggregated into a single line on stdout:
+
+```
+council won X/N · tied Y/N · baseline won Z/N · errors W/N
+```
+
+A `{meta, results}` JSON envelope is also written to disk, with the seed
+and input file SHA-256 echoed into `meta` so a flipped result can be
+replayed.
+
+### How to run
+
+```bash
+go run ./cmd/eval \
+    -input internal/eval/testdata/golden.json \
+    -out eval-results.json \
+    -baseline-model openai/gpt-4o-mini \
+    -council-type default
+```
+
+Optional flags:
+
+- `-judge-model <id>` — override the judge (defaults to the configured
+  chairman model). MUST differ from `-baseline-model`; the binary refuses
+  to start if they match, to avoid self-preference bias.
+- `-seed <int64>` — pin the A/B-order RNG so a flipped result is replayable.
+  Default is time-based, captured into output meta either way.
+
+### When to run
+
+Run **before** any change that could shift output quality:
+
+- Editing a stage prompt template (`internal/council/prompts.go`).
+- Changing default models or council strategy defaults.
+- Refactoring the deliberation pipeline.
+
+Compare the new run's summary line against the previous run's. A drop of
+more than ~20% in council wins on the same golden set is a regression
+signal worth blocking the change for.
+
+### When NOT to run
+
+The harness is **not** wired into CI. A single pass costs roughly $1–2 with
+the balanced model preset (≈132 LLM calls: 12 cases × 9 council calls per
+case + 12 baseline + 12 judge). CI runs it on every PR would cost dollars
+per merge — not worth it at this maturity. Run manually before
+quality-affecting merges.
+
+### Caveats
+
+- **Judge bias.** LLM-as-judge has well-known positional, verbosity, and
+  self-preference biases. Mitigations applied: A/B order is randomised
+  per case; the judge model must differ from the baseline; the system
+  prompt explicitly says "length is not a quality signal — prefer the
+  more correct and concise answer." Residual verbosity bias is
+  acknowledged: council answers tend to be longer by design.
+- **n = 12.** This harness is built to detect *large* regressions
+  (>20%). Detecting small drifts requires a much larger case set,
+  multi-judge majority voting, and statistical significance tests — all
+  explicitly out of scope.
+- **No golden-output assertion.** We never assert "the council says X for
+  case Y". The judge is the only signal.
+
+### Files
+
+| File | Role |
+|------|------|
+| `internal/eval/eval.go` | `Suite`, `Case`, `Result`, `Run` orchestrator |
+| `internal/eval/judge.go` | Pairwise LLM-as-judge using `council.LLMClient` |
+| `internal/eval/runner.go` | Per-case council + baseline drivers |
+| `internal/eval/report.go` | Aggregation + JSON envelope serialisation |
+| `internal/eval/testdata/golden.json` | 12 hand-crafted prompts |
+| `cmd/eval/main.go` | CLI binary |
+
+`eval-results*.json` is in `.gitignore` — local result files are not
+committed. Golden inputs ARE.
+
+---
+
 ## Related Documents
 
 - `docs/council-research-synthesis.md §8` — Go implementation patterns and interface design

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -14,9 +14,12 @@ import (
 
 var errNoChoices = errors.New("council: completion response contained no choices")
 
-// stripCodeFence removes markdown code fences that some models wrap around JSON.
+// StripCodeFence removes markdown code fences that some models wrap around JSON.
 // Handles ```json\n...\n``` and ```\n...\n``` patterns.
-func stripCodeFence(s string) string {
+//
+// Exported for use by the eval package, which talks to the same family of
+// fence-happy models when running its judge.
+func StripCodeFence(s string) string {
 	s = strings.TrimSpace(s)
 	for _, prefix := range []string{"```json", "```"} {
 		if strings.HasPrefix(s, prefix) {
@@ -215,7 +218,7 @@ func (c *Council) runStage2(ctx context.Context, query string, stage1 []StageOne
 			var parsed struct {
 				Rankings []string `json:"rankings"`
 			}
-			if err := json.Unmarshal([]byte(stripCodeFence(resp.Choices[0].Message.Content)), &parsed); err != nil {
+			if err := json.Unmarshal([]byte(StripCodeFence(resp.Choices[0].Message.Content)), &parsed); err != nil {
 				if c.logger != nil {
 					c.logger.Warn("stage2: parse failure", slog.String("reviewer", s1.Label), slog.Any("error", err))
 				}
@@ -361,7 +364,7 @@ func (c *Council) runStage0Generators(ctx context.Context, prompt []ChatMessage,
 					Text string `json:"text"`
 				} `json:"questions"`
 			}
-			if err := json.Unmarshal([]byte(stripCodeFence(resp.Choices[0].Message.Content)), &parsed); err != nil {
+			if err := json.Unmarshal([]byte(StripCodeFence(resp.Choices[0].Message.Content)), &parsed); err != nil {
 				if c.logger != nil {
 					c.logger.Warn("stage0: generator parse failure", "model", model, "error", err)
 				}
@@ -398,7 +401,7 @@ func (c *Council) runStage0Chairman(ctx context.Context, query string, candidate
 		return nil, true, fmt.Errorf("stage0 chairman: %w", err)
 	}
 
-	content := stripCodeFence(resp.Choices[0].Message.Content)
+	content := StripCodeFence(resp.Choices[0].Message.Content)
 	var parsed struct {
 		Questions []ClarificationQuestion `json:"questions"`
 		Enough    bool                    `json:"enough"`

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -1,0 +1,237 @@
+// Package eval implements a manually-invoked evaluation harness that compares
+// the output of the LLM Council pipeline against a single-model baseline.
+//
+// The harness runs each prompt through both pipelines, asks a third model
+// (acting as judge) to pick the better answer in a blinded pairwise
+// comparison, and emits a JSON envelope of per-case results plus a summary
+// counter.
+//
+// Scope: smallest possible regression detector for prompt/strategy changes.
+// Not a research-grade evaluation framework. Costs real money — never wired
+// into CI; trigger manually before any prompt-template, strategy, or
+// default-models change.
+package eval
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+
+	"github.com/valpere/llm-council/internal/council"
+)
+
+// Case is a single evaluation prompt loaded from the golden input file.
+type Case struct {
+	ID       string `json:"id"`
+	Prompt   string `json:"prompt"`
+	Category string `json:"category"`
+}
+
+// Suite is the set of cases the harness will run.
+type Suite struct {
+	Cases []Case `json:"-"`
+}
+
+// Verdict is the four-state judge outcome surfaced in Result.JudgeVerdict.
+type Verdict string
+
+const (
+	VerdictCouncil  Verdict = "council"
+	VerdictBaseline Verdict = "baseline"
+	VerdictTie      Verdict = "tie"
+	VerdictError    Verdict = "error"
+)
+
+// Result is the per-case record written to the output JSON.
+type Result struct {
+	ID                 string  `json:"id"`
+	Prompt             string  `json:"prompt"`
+	CouncilAnswer      string  `json:"council_answer"`
+	BaselineAnswer     string  `json:"baseline_answer"`
+	CouncilModel       string  `json:"council_model"`
+	BaselineModel      string  `json:"baseline_model"`
+	JudgeVerdict       Verdict `json:"judge_verdict"`
+	JudgeExplanation   string  `json:"judge_explanation"`
+	CouncilConsensusW  float64 `json:"council_consensus_w"`
+	CouncilDurationMs  int64   `json:"council_duration_ms"`
+	BaselineDurationMs int64   `json:"baseline_duration_ms"`
+	Error              string  `json:"error,omitempty"`
+}
+
+// Meta is the run-level header echoed into the output JSON envelope. The
+// seed and input_sha256 fields make a flipped result replayable.
+type Meta struct {
+	Seed          int64  `json:"seed"`
+	InputSHA256   string `json:"input_sha256"`
+	BaselineModel string `json:"baseline_model"`
+	JudgeModel    string `json:"judge_model"`
+	CouncilType   string `json:"council_type"`
+}
+
+// Output is the envelope serialised to disk.
+type Output struct {
+	Meta    Meta     `json:"meta"`
+	Results []Result `json:"results"`
+}
+
+// Options bundles the dependencies and parameters for a single Run.
+type Options struct {
+	Suite         Suite
+	Runner        council.Runner
+	Client        council.LLMClient
+	BaselineModel string
+	JudgeModel    string
+	CouncilType   string
+	Temperature   float64
+	Seed          int64
+	Logger        *slog.Logger
+}
+
+// Run executes the suite sequentially against the configured pipelines.
+// Per-case errors (council failure, baseline failure, judge parse failure)
+// are recorded as VerdictError and do not abort the run; only a configuration
+// error (missing dependency) returns a top-level error.
+func Run(ctx context.Context, opts Options) ([]Result, error) {
+	if opts.Runner == nil {
+		return nil, errors.New("eval: Options.Runner is required")
+	}
+	if opts.Client == nil {
+		return nil, errors.New("eval: Options.Client is required")
+	}
+	if opts.BaselineModel == "" {
+		return nil, errors.New("eval: Options.BaselineModel is required")
+	}
+	if opts.JudgeModel == "" {
+		return nil, errors.New("eval: Options.JudgeModel is required")
+	}
+	if opts.JudgeModel == opts.BaselineModel {
+		return nil, fmt.Errorf("eval: judge model %q must differ from baseline model to avoid self-preference bias", opts.JudgeModel)
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// rand/v2 PCG, seeded deterministically. The same seed + same input file
+	// produces the same A/B-order assignments, which is what the meta header
+	// promises.
+	rng := rand.New(rand.NewPCG(uint64(opts.Seed), 0))
+	judge := &Judge{Client: opts.Client, Model: opts.JudgeModel, Temperature: opts.Temperature}
+
+	results := make([]Result, 0, len(opts.Suite.Cases))
+	for _, c := range opts.Suite.Cases {
+		if err := ctx.Err(); err != nil {
+			return results, err
+		}
+		results = append(results, runCase(ctx, c, opts, judge, rng, logger))
+	}
+	return results, nil
+}
+
+// runCase executes a single case end-to-end (council, baseline, judge) and
+// returns the populated Result. It never returns an error — every failure
+// path is captured in Result.Error / Result.JudgeVerdict so the orchestrator
+// loop can continue to the next case.
+func runCase(
+	ctx context.Context,
+	c Case,
+	opts Options,
+	judge *Judge,
+	rng *rand.Rand,
+	logger *slog.Logger,
+) Result {
+	r := Result{
+		ID:            c.ID,
+		Prompt:        c.Prompt,
+		CouncilModel:  opts.CouncilType + ":synthesis",
+		BaselineModel: opts.BaselineModel,
+	}
+
+	// Run both pipelines. If either errors, we record it and skip the judge —
+	// there's nothing meaningful to compare.
+	cAnswer, cConsensusW, cDur, cErr := runCouncil(ctx, opts.Runner, c.Prompt, opts.CouncilType)
+	r.CouncilAnswer = cAnswer
+	r.CouncilConsensusW = cConsensusW
+	r.CouncilDurationMs = cDur
+	if cErr != nil {
+		r.JudgeVerdict = VerdictError
+		r.Error = fmt.Sprintf("council error: %v", cErr)
+		logger.Warn("eval: council error", "id", c.ID, "error", cErr)
+		return r
+	}
+
+	bAnswer, bDur, bErr := runBaseline(ctx, opts.Client, c.Prompt, opts.BaselineModel, opts.Temperature)
+	r.BaselineAnswer = bAnswer
+	r.BaselineDurationMs = bDur
+	if bErr != nil {
+		r.JudgeVerdict = VerdictError
+		r.Error = fmt.Sprintf("baseline error: %v", bErr)
+		logger.Warn("eval: baseline error", "id", c.ID, "error", bErr)
+		return r
+	}
+
+	// Decide A/B order per case via the seeded RNG. councilFirst==true means
+	// Answer A is the council's answer; the judge's verdict is then remapped
+	// back to council/baseline before being written into Result.
+	councilFirst := rng.IntN(2) == 0
+	answerA, answerB := cAnswer, bAnswer
+	if !councilFirst {
+		answerA, answerB = bAnswer, cAnswer
+	}
+
+	rawVerdict, explanation, err := judge.Compare(ctx, c.Prompt, answerA, answerB)
+	r.JudgeExplanation = explanation
+	if err != nil {
+		r.JudgeVerdict = VerdictError
+		r.Error = fmt.Sprintf("judge error: %v", err)
+		logger.Warn("eval: judge error", "id", c.ID, "error", err)
+		return r
+	}
+
+	r.JudgeVerdict = remapVerdict(rawVerdict, councilFirst)
+	return r
+}
+
+// remapVerdict translates the judge's "A"/"B"/"tie" output back to the
+// pipeline-named verdict, accounting for the per-case order randomisation.
+func remapVerdict(raw string, councilFirst bool) Verdict {
+	switch raw {
+	case "tie":
+		return VerdictTie
+	case "A":
+		if councilFirst {
+			return VerdictCouncil
+		}
+		return VerdictBaseline
+	case "B":
+		if councilFirst {
+			return VerdictBaseline
+		}
+		return VerdictCouncil
+	default:
+		return VerdictError
+	}
+}
+
+// LoadSuite is a convenience helper for the cmd/eval CLI: it parses a JSON
+// array of cases. It lives here rather than in cmd/ so tests can use it.
+func LoadSuite(data []byte) (Suite, error) {
+	var cases []Case
+	if err := json.Unmarshal(data, &cases); err != nil {
+		return Suite{}, fmt.Errorf("parse cases: %w", err)
+	}
+	return Suite{Cases: cases}, nil
+}
+
+// SuiteSHA256 returns the lowercase hex SHA-256 of the raw input file bytes.
+// Echoing this into the output meta lets a flipped run be replayed against
+// the exact same input.
+func SuiteSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -397,7 +397,7 @@ func (r *runnerFailingOnCase) RunFull(ctx context.Context, prompt string, counci
 func findSeedWithCouncilFirst(t *testing.T, want bool) int64 {
 	t.Helper()
 	for s := int64(1); s < 1000; s++ {
-		if courseFirstForSeed(s) == want {
+		if councilFirstForSeed(s) == want {
 			return s
 		}
 	}
@@ -405,9 +405,9 @@ func findSeedWithCouncilFirst(t *testing.T, want bool) int64 {
 	return 0
 }
 
-// courseFirstForSeed mirrors the exact RNG construction used by Run so the
+// councilFirstForSeed mirrors the exact RNG construction used by Run so the
 // test's expectation matches production behaviour.
-func courseFirstForSeed(seed int64) bool {
+func councilFirstForSeed(seed int64) bool {
 	rng := rand.New(rand.NewPCG(uint64(seed), 0))
 	return rng.IntN(2) == 0
 }

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1,0 +1,413 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"testing"
+
+	"github.com/valpere/llm-council/internal/council"
+)
+
+// fakeLLMClient routes Complete() calls to the per-model `responses` map.
+// Tests pre-populate the map with the answer they want returned for a given
+// model, so the orchestrator's path through council baseline + baseline
+// fallback + judge can be exercised without any real LLM calls.
+type fakeLLMClient struct {
+	responses map[string]string
+	errs      map[string]error
+	calls     []council.CompletionRequest
+}
+
+func (f *fakeLLMClient) Complete(_ context.Context, req council.CompletionRequest) (council.CompletionResponse, error) {
+	f.calls = append(f.calls, req)
+	if err, ok := f.errs[req.Model]; ok {
+		return council.CompletionResponse{}, err
+	}
+	body, ok := f.responses[req.Model]
+	if !ok {
+		return council.CompletionResponse{}, fmt.Errorf("fakeLLMClient: no response for model %q", req.Model)
+	}
+	return council.CompletionResponse{
+		Choices: []struct {
+			Message council.ChatMessage `json:"message"`
+		}{{Message: council.ChatMessage{Role: "assistant", Content: body}}},
+	}, nil
+}
+
+// fakeRunner implements council.Runner. RunFull fires a fixed event sequence
+// (stage2_complete with metadata, then stage3_complete with the configured
+// answer) so the orchestrator's onEvent capture is exercised. errOnRun lets
+// individual cases inject a council failure.
+type fakeRunner struct {
+	answer     string
+	consensusW float64
+	errOnRun   error
+}
+
+func (r *fakeRunner) RunFull(_ context.Context, _ string, _ string, onEvent council.EventFunc) error {
+	if r.errOnRun != nil {
+		return r.errOnRun
+	}
+	if onEvent != nil {
+		onEvent("stage2_complete", council.Stage2CompleteData{
+			Metadata: council.Metadata{ConsensusW: r.consensusW},
+		})
+		onEvent("stage3_complete", council.StageThreeResult{Content: r.answer})
+	}
+	return nil
+}
+
+// judgeReply marshals a judge response payload into the JSON shape the
+// real Judge will parse.
+func judgeReply(verdict, explanation string) string {
+	b, _ := json.Marshal(judgeResponse{Verdict: verdict, Explanation: explanation})
+	return string(b)
+}
+
+// ── Run: success paths ─────────────────────────────────────────────────────
+
+func TestRun_CapturesCouncilAnswerAndConsensusW(t *testing.T) {
+	const (
+		baselineModel = "baseline-x"
+		judgeModelID  = "judge-y"
+	)
+	runner := &fakeRunner{answer: "council says foo", consensusW: 0.73}
+	client := &fakeLLMClient{
+		responses: map[string]string{
+			baselineModel: "baseline says bar",
+			judgeModelID:  judgeReply("A", "council answer is more focused"),
+		},
+	}
+
+	results, err := Run(context.Background(), Options{
+		Suite:         Suite{Cases: []Case{{ID: "c1", Prompt: "what is foo?", Category: "factual"}}},
+		Runner:        runner,
+		Client:        client,
+		BaselineModel: baselineModel,
+		JudgeModel:    judgeModelID,
+		CouncilType:   "default",
+		Temperature:   0.7,
+		Seed:          42, // deterministic
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	r := results[0]
+	if r.CouncilAnswer != "council says foo" {
+		t.Errorf("CouncilAnswer: got %q", r.CouncilAnswer)
+	}
+	if r.BaselineAnswer != "baseline says bar" {
+		t.Errorf("BaselineAnswer: got %q", r.BaselineAnswer)
+	}
+	if r.CouncilConsensusW != 0.73 {
+		t.Errorf("CouncilConsensusW: got %v, want 0.73", r.CouncilConsensusW)
+	}
+	// Verdict can be either VerdictCouncil or VerdictBaseline depending on the
+	// per-case A/B order, but it MUST be one of the pipeline names — never
+	// the raw "A" or "B" — and never VerdictError on this happy path.
+	if r.JudgeVerdict != VerdictCouncil && r.JudgeVerdict != VerdictBaseline {
+		t.Errorf("JudgeVerdict: got %q, want council or baseline", r.JudgeVerdict)
+	}
+	if r.Error != "" {
+		t.Errorf("Error should be empty, got %q", r.Error)
+	}
+}
+
+// ── Run: blinding + remap ──────────────────────────────────────────────────
+
+// Both cases below pin the seed so we can know whether councilFirst will be
+// true or false, and assert that the same raw verdict ("A") remaps to the
+// correct pipeline name in each ordering.
+func TestRun_RemapHonoursABOrder(t *testing.T) {
+	// Find one seed where councilFirst=true and one where councilFirst=false
+	// for case index 0. The PCG output for IntN(2) varies per seed so we
+	// just iterate small seeds until we have both.
+	const (
+		baselineModel = "baseline-x"
+		judgeModelID  = "judge-y"
+	)
+	tests := []struct {
+		name              string
+		councilFirstSeed  int64
+		judgeReturnsA     bool
+		wantVerdict       Verdict
+	}{
+		// Verdict "A" in a councilFirst run → council won.
+		{"council A wins when councilFirst", findSeedWithCouncilFirst(t, true), true, VerdictCouncil},
+		// Verdict "A" in a baselineFirst run → baseline won.
+		{"baseline A wins when baselineFirst", findSeedWithCouncilFirst(t, false), true, VerdictBaseline},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &fakeRunner{answer: "C", consensusW: 1}
+			client := &fakeLLMClient{responses: map[string]string{
+				baselineModel: "B",
+				judgeModelID:  judgeReply("A", "answer A is better"),
+			}}
+			results, err := Run(context.Background(), Options{
+				Suite:         Suite{Cases: []Case{{ID: "x", Prompt: "?", Category: "test"}}},
+				Runner:        runner,
+				Client:        client,
+				BaselineModel: baselineModel,
+				JudgeModel:    judgeModelID,
+				CouncilType:   "default",
+				Seed:          tc.councilFirstSeed,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if results[0].JudgeVerdict != tc.wantVerdict {
+				t.Errorf("verdict: got %q, want %q", results[0].JudgeVerdict, tc.wantVerdict)
+			}
+		})
+	}
+}
+
+func TestRun_TieRemapsToTie(t *testing.T) {
+	const (
+		baselineModel = "baseline-x"
+		judgeModelID  = "judge-y"
+	)
+	runner := &fakeRunner{answer: "C", consensusW: 1}
+	client := &fakeLLMClient{responses: map[string]string{
+		baselineModel: "B",
+		judgeModelID:  judgeReply("tie", "equally good"),
+	}}
+	results, err := Run(context.Background(), Options{
+		Suite:         Suite{Cases: []Case{{ID: "x", Prompt: "?", Category: "test"}}},
+		Runner:        runner,
+		Client:        client,
+		BaselineModel: baselineModel,
+		JudgeModel:    judgeModelID,
+		CouncilType:   "default",
+		Seed:          1,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results[0].JudgeVerdict != VerdictTie {
+		t.Errorf("verdict: got %q, want tie", results[0].JudgeVerdict)
+	}
+}
+
+// ── Run: error handling ────────────────────────────────────────────────────
+
+func TestRun_CouncilErrorRecordedAsVerdictError(t *testing.T) {
+	const (
+		baselineModel = "baseline-x"
+		judgeModelID  = "judge-y"
+	)
+	runner := &fakeRunner{errOnRun: errors.New("quorum not met")}
+	client := &fakeLLMClient{responses: map[string]string{
+		baselineModel: "B",
+		judgeModelID:  judgeReply("A", "x"),
+	}}
+
+	results, err := Run(context.Background(), Options{
+		Suite:         Suite{Cases: []Case{{ID: "x", Prompt: "?", Category: "test"}}},
+		Runner:        runner,
+		Client:        client,
+		BaselineModel: baselineModel,
+		JudgeModel:    judgeModelID,
+		CouncilType:   "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := results[0]
+	if r.JudgeVerdict != VerdictError {
+		t.Errorf("verdict: got %q, want error", r.JudgeVerdict)
+	}
+	if !strings.Contains(r.Error, "quorum not met") {
+		t.Errorf("Error: got %q, want it to contain 'quorum not met'", r.Error)
+	}
+	// Judge MUST NOT have been called when council errored.
+	for _, call := range client.calls {
+		if call.Model == judgeModelID {
+			t.Error("judge was called despite council error")
+		}
+	}
+}
+
+func TestRun_BaselineErrorRecordedAsVerdictError(t *testing.T) {
+	const (
+		baselineModel = "baseline-x"
+		judgeModelID  = "judge-y"
+	)
+	runner := &fakeRunner{answer: "C", consensusW: 1}
+	client := &fakeLLMClient{
+		responses: map[string]string{judgeModelID: judgeReply("A", "x")},
+		errs:      map[string]error{baselineModel: errors.New("rate limited")},
+	}
+
+	results, err := Run(context.Background(), Options{
+		Suite:         Suite{Cases: []Case{{ID: "x", Prompt: "?", Category: "test"}}},
+		Runner:        runner,
+		Client:        client,
+		BaselineModel: baselineModel,
+		JudgeModel:    judgeModelID,
+		CouncilType:   "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := results[0]
+	if r.JudgeVerdict != VerdictError {
+		t.Errorf("verdict: got %q, want error", r.JudgeVerdict)
+	}
+	if !strings.Contains(r.Error, "rate limited") {
+		t.Errorf("Error: got %q, want it to contain 'rate limited'", r.Error)
+	}
+}
+
+func TestRun_MixedOutcomesDoNotAbort(t *testing.T) {
+	// Three cases: two ordinary successes followed by a council failure.
+	// After the failure the orchestrator must still process all three rows.
+	const (
+		baselineModel = "baseline-x"
+		judgeModelID  = "judge-y"
+	)
+	runner := &fakeRunner{answer: "C", consensusW: 1}
+	client := &fakeLLMClient{responses: map[string]string{
+		baselineModel: "B",
+		judgeModelID:  judgeReply("tie", "x"),
+	}}
+	suite := Suite{Cases: []Case{
+		{ID: "ok-1", Prompt: "?", Category: "test"},
+		{ID: "ok-2", Prompt: "?", Category: "test"},
+		{ID: "fail-1", Prompt: "?", Category: "test"},
+	}}
+
+	// Swap to a failing runner just for the third case by wrapping.
+	failing := &runnerFailingOnCase{base: runner, failID: "fail-1"}
+
+	results, err := Run(context.Background(), Options{
+		Suite:         suite,
+		Runner:        failing,
+		Client:        client,
+		BaselineModel: baselineModel,
+		JudgeModel:    judgeModelID,
+		CouncilType:   "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("got %d results, want 3", len(results))
+	}
+	if results[0].JudgeVerdict != VerdictTie || results[1].JudgeVerdict != VerdictTie {
+		t.Errorf("first two verdicts: got %q,%q, want tie,tie", results[0].JudgeVerdict, results[1].JudgeVerdict)
+	}
+	if results[2].JudgeVerdict != VerdictError {
+		t.Errorf("third verdict: got %q, want error", results[2].JudgeVerdict)
+	}
+}
+
+// ── Run: validation ────────────────────────────────────────────────────────
+
+func TestRun_ValidatesRequiredFields(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+		want string
+	}{
+		{"missing runner", Options{Client: &fakeLLMClient{}, BaselineModel: "b", JudgeModel: "j"}, "Runner is required"},
+		{"missing client", Options{Runner: &fakeRunner{}, BaselineModel: "b", JudgeModel: "j"}, "Client is required"},
+		{"missing baseline", Options{Runner: &fakeRunner{}, Client: &fakeLLMClient{}, JudgeModel: "j"}, "BaselineModel is required"},
+		{"missing judge", Options{Runner: &fakeRunner{}, Client: &fakeLLMClient{}, BaselineModel: "b"}, "JudgeModel is required"},
+		{"judge equals baseline", Options{Runner: &fakeRunner{}, Client: &fakeLLMClient{}, BaselineModel: "x", JudgeModel: "x"}, "must differ"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Run(context.Background(), tc.opts)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err: got %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// ── Run: SuiteSHA256 ──────────────────────────────────────────────────────
+
+func TestSuiteSHA256_DeterministicAndDifferentForDifferentInputs(t *testing.T) {
+	a := SuiteSHA256([]byte(`[{"id":"x","prompt":"hi","category":"c"}]`))
+	b := SuiteSHA256([]byte(`[{"id":"x","prompt":"hi","category":"c"}]`))
+	c := SuiteSHA256([]byte(`[{"id":"y","prompt":"hi","category":"c"}]`))
+	if a != b {
+		t.Error("same input should produce same hash")
+	}
+	if a == c {
+		t.Error("different input should produce different hash")
+	}
+	if len(a) != 64 {
+		t.Errorf("hash length: got %d, want 64 (sha256 hex)", len(a))
+	}
+}
+
+// ── Run: LoadSuite ─────────────────────────────────────────────────────────
+
+func TestLoadSuite_ParsesCases(t *testing.T) {
+	suite, err := LoadSuite([]byte(`[{"id":"a","prompt":"P","category":"factual"}]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(suite.Cases) != 1 || suite.Cases[0].ID != "a" {
+		t.Errorf("got %+v, want one case with ID=a", suite.Cases)
+	}
+}
+
+func TestLoadSuite_RejectsBadJSON(t *testing.T) {
+	_, err := LoadSuite([]byte(`{not: valid`))
+	if err == nil {
+		t.Error("expected parse error")
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+// runnerFailingOnCase wraps a runner so that for one specific Case ID the
+// RunFull call returns an error, but for every other ID it delegates to the
+// base runner. We can't switch on case ID inside RunFull because the council
+// API doesn't pass it through, so we count calls instead.
+type runnerFailingOnCase struct {
+	base    *fakeRunner
+	failID  string
+	calls   int
+}
+
+func (r *runnerFailingOnCase) RunFull(ctx context.Context, prompt string, councilType string, onEvent council.EventFunc) error {
+	r.calls++
+	// Fail on the third call (matches "fail-1" in the test fixture).
+	if r.calls == 3 {
+		return errors.New("council quorum not met")
+	}
+	return r.base.RunFull(ctx, prompt, councilType, onEvent)
+}
+
+// findSeedWithCouncilFirst returns a small int64 seed whose first PCG IntN(2)
+// draw matches `want`. Used by remap tests so we can pin orderings without
+// exporting the RNG.
+func findSeedWithCouncilFirst(t *testing.T, want bool) int64 {
+	t.Helper()
+	for s := int64(1); s < 1000; s++ {
+		if courseFirstForSeed(s) == want {
+			return s
+		}
+	}
+	t.Fatalf("could not find seed with councilFirst=%v in [1, 1000)", want)
+	return 0
+}
+
+// courseFirstForSeed mirrors the exact RNG construction used by Run so the
+// test's expectation matches production behaviour.
+func courseFirstForSeed(seed int64) bool {
+	rng := rand.New(rand.NewPCG(uint64(seed), 0))
+	return rng.IntN(2) == 0
+}

--- a/internal/eval/judge.go
+++ b/internal/eval/judge.go
@@ -1,0 +1,98 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/valpere/llm-council/internal/council"
+)
+
+// Judge runs a pairwise comparison between two answers and returns one of
+// "A", "B", or "tie" together with a short explanation. The judge is a third
+// model — distinct from the baseline — selected by the caller. The system
+// prompt explicitly tells the model not to use length as a quality signal,
+// which mitigates the most common LLM-as-judge bias against the council
+// (whose 3-stage pipeline tends to produce longer answers).
+type Judge struct {
+	Client      council.LLMClient
+	Model       string
+	Temperature float64
+}
+
+// judgeSystemPrompt is the verbatim system message sent to the judge for
+// every comparison. Order randomisation happens at the orchestrator level —
+// the judge always sees "Answer A" then "Answer B" without knowing which is
+// which.
+const judgeSystemPrompt = `You are an impartial evaluator. Compare two candidate answers ` +
+	`to the same question. Length is not a quality signal — prefer the more correct ` +
+	`and concise answer. Return ONLY a JSON object with fields ` +
+	`{"verdict": "A" | "B" | "tie", "explanation": "..."}.`
+
+// judgeUserTemplate formats the question + two answers into a single user
+// message. Plain-text concatenation is sufficient: the judge does not need to
+// see structured data, only the raw text.
+const judgeUserTemplate = "Question:\n%s\n\nAnswer A:\n%s\n\nAnswer B:\n%s\n\nWhich is better?"
+
+// judgeResponse is the schema the judge is expected to return.
+type judgeResponse struct {
+	Verdict     string `json:"verdict"`
+	Explanation string `json:"explanation"`
+}
+
+// Compare asks the judge model to pick between answerA and answerB for the
+// given prompt. Returns the raw verdict ("A", "B", or "tie") and an
+// explanation. Returns an error only if the LLM call itself fails or the
+// response is unparseable; an unrecognised verdict string surfaces as an
+// error so the orchestrator records it as VerdictError rather than silently
+// remapping it to one of the pipelines.
+func (j *Judge) Compare(ctx context.Context, prompt, answerA, answerB string) (verdict, explanation string, err error) {
+	if j == nil || j.Client == nil {
+		return "", "", errors.New("eval: Judge.Client is required")
+	}
+	if j.Model == "" {
+		return "", "", errors.New("eval: Judge.Model is required")
+	}
+
+	req := council.CompletionRequest{
+		Model: j.Model,
+		Messages: []council.ChatMessage{
+			{Role: "system", Content: judgeSystemPrompt},
+			{Role: "user", Content: fmt.Sprintf(judgeUserTemplate, prompt, answerA, answerB)},
+		},
+		Temperature:    j.Temperature,
+		ResponseFormat: &council.ResponseFormat{Type: "json_object"},
+	}
+	resp, err := j.Client.Complete(ctx, req)
+	if err != nil {
+		return "", "", fmt.Errorf("judge llm call: %w", err)
+	}
+	if len(resp.Choices) == 0 {
+		return "", "", errors.New("judge llm response had no choices")
+	}
+
+	raw := council.StripCodeFence(resp.Choices[0].Message.Content)
+	var parsed judgeResponse
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return "", "", fmt.Errorf("judge response parse: %w (raw: %q)", err, truncate(raw, 200))
+	}
+
+	switch parsed.Verdict {
+	case "A", "B", "tie":
+		return parsed.Verdict, parsed.Explanation, nil
+	case "":
+		return "", "", fmt.Errorf("judge response missing verdict (raw: %q)", truncate(raw, 200))
+	default:
+		return "", "", fmt.Errorf("judge response has unknown verdict %q (raw: %q)", parsed.Verdict, truncate(raw, 200))
+	}
+}
+
+// truncate returns at most n bytes of s, used when embedding malformed
+// model output into error messages so a 4 MiB blob doesn't drown logs.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/eval/judge_test.go
+++ b/internal/eval/judge_test.go
@@ -1,0 +1,186 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/valpere/llm-council/internal/council"
+)
+
+func TestJudge_Compare_HappyPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantVerdict string
+	}{
+		{"verdict A", `{"verdict":"A","explanation":"clearer"}`, "A"},
+		{"verdict B", `{"verdict":"B","explanation":"more correct"}`, "B"},
+		{"verdict tie", `{"verdict":"tie","explanation":"equivalent"}`, "tie"},
+		{"strips ```json fence",
+			"```json\n{\"verdict\":\"A\",\"explanation\":\"e\"}\n```",
+			"A"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			j := &Judge{
+				Client: &fakeLLMClient{responses: map[string]string{"judge-y": tc.body}},
+				Model:  "judge-y",
+			}
+			verdict, exp, err := j.Compare(context.Background(), "Q?", "answerA", "answerB")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if verdict != tc.wantVerdict {
+				t.Errorf("verdict: got %q, want %q", verdict, tc.wantVerdict)
+			}
+			if exp == "" {
+				t.Errorf("explanation should not be empty")
+			}
+		})
+	}
+}
+
+func TestJudge_Compare_SystemPromptIncludesVerbosityMitigation(t *testing.T) {
+	client := &fakeLLMClient{responses: map[string]string{"judge-y": `{"verdict":"A","explanation":"e"}`}}
+	j := &Judge{Client: client, Model: "judge-y"}
+
+	if _, _, err := j.Compare(context.Background(), "Q?", "A", "B"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(client.calls) != 1 {
+		t.Fatalf("expected exactly 1 LLM call, got %d", len(client.calls))
+	}
+	msgs := client.calls[0].Messages
+	if len(msgs) < 2 || msgs[0].Role != "system" {
+		t.Fatalf("expected system message first, got %+v", msgs)
+	}
+	if !strings.Contains(msgs[0].Content, "Length is not a quality signal") {
+		t.Errorf("system prompt missing verbosity-bias mitigation: %q", msgs[0].Content)
+	}
+}
+
+func TestJudge_Compare_RequestsJSONResponseFormat(t *testing.T) {
+	client := &fakeLLMClient{responses: map[string]string{"judge-y": `{"verdict":"A","explanation":"e"}`}}
+	j := &Judge{Client: client, Model: "judge-y"}
+
+	_, _, _ = j.Compare(context.Background(), "Q?", "A", "B")
+	if len(client.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(client.calls))
+	}
+	rf := client.calls[0].ResponseFormat
+	if rf == nil || rf.Type != "json_object" {
+		t.Errorf("ResponseFormat: got %+v, want json_object", rf)
+	}
+}
+
+func TestJudge_Compare_MalformedJSONReturnsError(t *testing.T) {
+	j := &Judge{
+		Client: &fakeLLMClient{responses: map[string]string{"judge-y": "not json at all"}},
+		Model:  "judge-y",
+	}
+	_, _, err := j.Compare(context.Background(), "Q?", "A", "B")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "judge response parse") {
+		t.Errorf("error: %v, want it to mention parse failure", err)
+	}
+}
+
+func TestJudge_Compare_MissingVerdictFieldReturnsError(t *testing.T) {
+	j := &Judge{
+		Client: &fakeLLMClient{responses: map[string]string{"judge-y": `{"explanation":"e"}`}},
+		Model:  "judge-y",
+	}
+	_, _, err := j.Compare(context.Background(), "Q?", "A", "B")
+	if err == nil {
+		t.Fatal("expected error for missing verdict")
+	}
+	if !strings.Contains(err.Error(), "missing verdict") {
+		t.Errorf("error: %v, want it to mention missing verdict", err)
+	}
+}
+
+func TestJudge_Compare_UnknownVerdictReturnsError(t *testing.T) {
+	j := &Judge{
+		Client: &fakeLLMClient{responses: map[string]string{"judge-y": `{"verdict":"maybe","explanation":"e"}`}},
+		Model:  "judge-y",
+	}
+	_, _, err := j.Compare(context.Background(), "Q?", "A", "B")
+	if err == nil {
+		t.Fatal("expected error for unknown verdict")
+	}
+	if !strings.Contains(err.Error(), "unknown verdict") {
+		t.Errorf("error: %v, want it to mention unknown verdict", err)
+	}
+}
+
+func TestJudge_Compare_ClientErrorPropagates(t *testing.T) {
+	want := errors.New("rate limit")
+	j := &Judge{
+		Client: &fakeLLMClient{
+			responses: map[string]string{"judge-y": ""},
+			errs:      map[string]error{"judge-y": want},
+		},
+		Model: "judge-y",
+	}
+	_, _, err := j.Compare(context.Background(), "Q?", "A", "B")
+	if err == nil || !errors.Is(err, want) {
+		t.Errorf("err: %v, want chain to include %v", err, want)
+	}
+}
+
+func TestJudge_Compare_NilClientReturnsError(t *testing.T) {
+	j := &Judge{Model: "judge-y"}
+	_, _, err := j.Compare(context.Background(), "Q?", "A", "B")
+	if err == nil || !strings.Contains(err.Error(), "Client is required") {
+		t.Errorf("err: %v, want 'Client is required'", err)
+	}
+}
+
+func TestJudge_Compare_EmptyModelReturnsError(t *testing.T) {
+	j := &Judge{Client: &fakeLLMClient{}, Model: ""}
+	_, _, err := j.Compare(context.Background(), "Q?", "A", "B")
+	if err == nil || !strings.Contains(err.Error(), "Model is required") {
+		t.Errorf("err: %v, want 'Model is required'", err)
+	}
+}
+
+func TestJudge_Compare_NoChoicesReturnsError(t *testing.T) {
+	// fakeLLMClient with an empty body wouldn't trigger this — we need an
+	// LLMClient that returns a CompletionResponse with zero choices.
+	j := &Judge{Client: noChoicesClient{}, Model: "judge-y"}
+	_, _, err := j.Compare(context.Background(), "Q?", "A", "B")
+	if err == nil || !strings.Contains(err.Error(), "no choices") {
+		t.Errorf("err: %v, want 'no choices'", err)
+	}
+}
+
+// noChoicesClient is a one-off fake that returns a successful CompletionResponse
+// with an empty Choices slice. Real OpenRouter responses can technically be
+// shaped this way if the gateway returns 200 with truncated body — the judge
+// must not crash.
+type noChoicesClient struct{}
+
+func (noChoicesClient) Complete(_ context.Context, _ council.CompletionRequest) (council.CompletionResponse, error) {
+	return council.CompletionResponse{}, nil
+}
+
+// truncate is exercised indirectly by error cases above; this test pins its
+// own boundary behaviour because future error formatting changes might forget
+// the cap.
+func TestTruncate(t *testing.T) {
+	if got := truncate("short", 10); got != "short" {
+		t.Errorf("truncate('short', 10) = %q, want short", got)
+	}
+	got := truncate(strings.Repeat("a", 250), 200)
+	// 200 'a's + the U+2026 ellipsis (3 bytes in UTF-8) → 203 bytes total.
+	if len(got) != 203 {
+		t.Errorf("truncate len: got %d, want 203 (200 + 3-byte ellipsis)", len(got))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncate suffix: got %q, want trailing ellipsis", got[len(got)-3:])
+	}
+}

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -1,0 +1,62 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Summary aggregates per-case verdicts into the four-bucket counter that
+// shows up on stdout at the end of a run.
+type Summary struct {
+	CouncilWon  int
+	BaselineWon int
+	Ties        int
+	Errors      int
+}
+
+// Aggregate counts verdicts across results. Unknown verdicts (which should
+// only appear if a future Verdict constant is added without updating this
+// function) fall through to the Errors bucket.
+func Aggregate(results []Result) Summary {
+	var s Summary
+	for _, r := range results {
+		switch r.JudgeVerdict {
+		case VerdictCouncil:
+			s.CouncilWon++
+		case VerdictBaseline:
+			s.BaselineWon++
+		case VerdictTie:
+			s.Ties++
+		default:
+			s.Errors++
+		}
+	}
+	return s
+}
+
+// Format renders the summary as a single human-readable line for stdout.
+// `total` is passed in (rather than reconstructed from the buckets) so the
+// caller can use len(results) directly without arithmetic.
+func (s Summary) Format(total int) string {
+	return fmt.Sprintf(
+		"council won %d/%d · tied %d/%d · baseline won %d/%d · errors %d/%d",
+		s.CouncilWon, total,
+		s.Ties, total,
+		s.BaselineWon, total,
+		s.Errors, total,
+	)
+}
+
+// WriteOutput serialises the {meta, results} envelope as indented JSON.
+// Indentation matters: a human will read this file when investigating a
+// regression.
+func WriteOutput(w io.Writer, meta Meta, results []Result) error {
+	out := Output{Meta: meta, Results: results}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		return fmt.Errorf("encode output: %w", err)
+	}
+	return nil
+}

--- a/internal/eval/report_test.go
+++ b/internal/eval/report_test.go
@@ -1,0 +1,139 @@
+package eval
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAggregate_MixedVerdicts(t *testing.T) {
+	results := []Result{
+		{JudgeVerdict: VerdictCouncil},
+		{JudgeVerdict: VerdictCouncil},
+		{JudgeVerdict: VerdictCouncil},
+		{JudgeVerdict: VerdictCouncil},
+		{JudgeVerdict: VerdictCouncil},
+		{JudgeVerdict: VerdictBaseline},
+		{JudgeVerdict: VerdictBaseline},
+		{JudgeVerdict: VerdictTie},
+		{JudgeVerdict: VerdictTie},
+		{JudgeVerdict: VerdictTie},
+		{JudgeVerdict: VerdictError},
+		{JudgeVerdict: VerdictError},
+	}
+	got := Aggregate(results)
+	want := Summary{CouncilWon: 5, BaselineWon: 2, Ties: 3, Errors: 2}
+	if got != want {
+		t.Errorf("Aggregate: got %+v, want %+v", got, want)
+	}
+}
+
+func TestAggregate_EmptyInput(t *testing.T) {
+	got := Aggregate(nil)
+	want := Summary{}
+	if got != want {
+		t.Errorf("Aggregate(nil): got %+v, want zero", got)
+	}
+}
+
+func TestAggregate_UnknownVerdictCountsAsError(t *testing.T) {
+	results := []Result{{JudgeVerdict: Verdict("???")}}
+	got := Aggregate(results)
+	if got.Errors != 1 {
+		t.Errorf("unknown verdict should count as error, got Errors=%d", got.Errors)
+	}
+}
+
+func TestSummary_Format(t *testing.T) {
+	s := Summary{CouncilWon: 5, BaselineWon: 2, Ties: 3, Errors: 1}
+	got := s.Format(11)
+	want := "council won 5/11 · tied 3/11 · baseline won 2/11 · errors 1/11"
+	if got != want {
+		t.Errorf("Format: got %q, want %q", got, want)
+	}
+}
+
+func TestSummary_Format_ZeroTotal(t *testing.T) {
+	s := Summary{}
+	got := s.Format(0)
+	if !strings.Contains(got, "0/0") {
+		t.Errorf("Format(0) should still render counters, got %q", got)
+	}
+}
+
+func TestWriteOutput_RoundTripsThroughJSON(t *testing.T) {
+	meta := Meta{
+		Seed:          42,
+		InputSHA256:   "abcd",
+		BaselineModel: "openai/gpt-4o-mini",
+		JudgeModel:    "anthropic/claude-haiku-4-5",
+		CouncilType:   "default",
+	}
+	results := []Result{
+		{
+			ID:                 "case-1",
+			Prompt:             "What is foo?",
+			CouncilAnswer:      "council answer",
+			BaselineAnswer:     "baseline answer",
+			CouncilModel:       "default:synthesis",
+			BaselineModel:      "openai/gpt-4o-mini",
+			JudgeVerdict:       VerdictCouncil,
+			JudgeExplanation:   "more focused",
+			CouncilConsensusW:  0.73,
+			CouncilDurationMs:  14820,
+			BaselineDurationMs: 1200,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteOutput(&buf, meta, results); err != nil {
+		t.Fatalf("WriteOutput: %v", err)
+	}
+
+	// Must be parseable as Output.
+	var got Output
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, buf.String())
+	}
+	if got.Meta != meta {
+		t.Errorf("meta round-trip: got %+v, want %+v", got.Meta, meta)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results round-trip: got %d, want 1", len(got.Results))
+	}
+	if got.Results[0] != results[0] {
+		t.Errorf("result round-trip: got %+v, want %+v", got.Results[0], results[0])
+	}
+
+	// Pretty-printed body keeps it diff-able for humans investigating a
+	// regression. Pin one structural property: indented arrays.
+	if !strings.Contains(buf.String(), "  \"meta\": {") {
+		t.Errorf("output should be indented for readability, got: %s", buf.String())
+	}
+}
+
+func TestWriteOutput_OmitsErrorFieldWhenEmpty(t *testing.T) {
+	// Per the json:"error,omitempty" tag, a successful result must not write
+	// an empty "error" field — that would visually pollute every successful
+	// row in a results file.
+	results := []Result{{ID: "x", JudgeVerdict: VerdictCouncil}}
+	var buf bytes.Buffer
+	if err := WriteOutput(&buf, Meta{}, results); err != nil {
+		t.Fatalf("WriteOutput: %v", err)
+	}
+	if strings.Contains(buf.String(), `"error"`) {
+		t.Errorf("empty error field should be omitted, got: %s", buf.String())
+	}
+}
+
+func TestWriteOutput_IncludesErrorFieldWhenSet(t *testing.T) {
+	results := []Result{{ID: "x", JudgeVerdict: VerdictError, Error: "council failed"}}
+	var buf bytes.Buffer
+	if err := WriteOutput(&buf, Meta{}, results); err != nil {
+		t.Fatalf("WriteOutput: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"error": "council failed"`) {
+		t.Errorf("non-empty error field should appear, got: %s", buf.String())
+	}
+}

--- a/internal/eval/runner.go
+++ b/internal/eval/runner.go
@@ -1,0 +1,78 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/valpere/llm-council/internal/council"
+)
+
+// runCouncil drives the full council pipeline for a single prompt and pulls
+// out the chairman's final answer plus the consensus W computed in Stage 2.
+//
+// The Runner contract delivers stage results via onEvent — there is no
+// "return value" channel — so this helper closes over local variables that
+// the EventFunc populates as the events fire. After RunFull returns we have
+// either a captured answer (success) or a captured error.
+func runCouncil(
+	ctx context.Context,
+	runner council.Runner,
+	prompt, councilType string,
+) (answer string, consensusW float64, durationMs int64, err error) {
+	var (
+		stage3Captured bool
+	)
+	onEvent := func(eventType string, data any) {
+		switch eventType {
+		case "stage2_complete":
+			if d, ok := data.(council.Stage2CompleteData); ok {
+				consensusW = d.Metadata.ConsensusW
+			}
+		case "stage3_complete":
+			if d, ok := data.(council.StageThreeResult); ok {
+				answer = d.Content
+				stage3Captured = true
+			}
+		}
+	}
+
+	start := time.Now()
+	runErr := runner.RunFull(ctx, prompt, councilType, onEvent)
+	durationMs = time.Since(start).Milliseconds()
+
+	if runErr != nil {
+		return "", consensusW, durationMs, fmt.Errorf("council run: %w", runErr)
+	}
+	if !stage3Captured {
+		return "", consensusW, durationMs, errors.New("council run completed but no stage3_complete event was observed")
+	}
+	return answer, consensusW, durationMs, nil
+}
+
+// runBaseline calls the LLM gateway directly with a single user message —
+// this is the "what would a single model produce on its own" comparison
+// point. Temperature matches the council's so we're comparing apples to
+// apples for sampling behaviour.
+func runBaseline(
+	ctx context.Context,
+	client council.LLMClient,
+	prompt, model string,
+	temperature float64,
+) (answer string, durationMs int64, err error) {
+	start := time.Now()
+	resp, callErr := client.Complete(ctx, council.CompletionRequest{
+		Model:       model,
+		Messages:    []council.ChatMessage{{Role: "user", Content: prompt}},
+		Temperature: temperature,
+	})
+	durationMs = time.Since(start).Milliseconds()
+	if callErr != nil {
+		return "", durationMs, fmt.Errorf("baseline llm call: %w", callErr)
+	}
+	if len(resp.Choices) == 0 {
+		return "", durationMs, errors.New("baseline response had no choices")
+	}
+	return resp.Choices[0].Message.Content, durationMs, nil
+}

--- a/internal/eval/testdata/golden.json
+++ b/internal/eval/testdata/golden.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ambig-01",
+    "category": "ambiguous",
+    "prompt": "How do I improve my React app?"
+  },
+  {
+    "id": "ambig-02",
+    "category": "ambiguous",
+    "prompt": "Should I use a microservice architecture?"
+  },
+  {
+    "id": "ambig-03",
+    "category": "ambiguous",
+    "prompt": "What's the best programming language?"
+  },
+  {
+    "id": "factual-01",
+    "category": "factual",
+    "prompt": "Who wrote 'Pride and Prejudice'?"
+  },
+  {
+    "id": "factual-02",
+    "category": "factual",
+    "prompt": "What is the boiling point of water at sea level in degrees Celsius?"
+  },
+  {
+    "id": "factual-03",
+    "category": "factual",
+    "prompt": "Name the four innermost planets of the solar system in order from the Sun."
+  },
+  {
+    "id": "code-01",
+    "category": "code",
+    "prompt": "Refactor this Go function for clarity, keeping behaviour identical:\n\nfunc f(n int) int {\n    var s int\n    for i := 0; i < n; i++ {\n        s = s + i\n    }\n    return s\n}"
+  },
+  {
+    "id": "code-02",
+    "category": "code",
+    "prompt": "What is wrong with this Go loop, and how would you fix it?\n\nfor i := 0; i <= len(slice); i++ {\n    fmt.Println(slice[i])\n}"
+  },
+  {
+    "id": "code-03",
+    "category": "code",
+    "prompt": "Write a Go function that reverses a UTF-8 string by runes (not bytes). Include a one-line comment explaining why byte-level reversal would be wrong."
+  },
+  {
+    "id": "reasoning-01",
+    "category": "reasoning",
+    "prompt": "If three workers can paint a house in 4 days, how many days will five workers take? Assume work scales linearly with worker count and explain your calculation in one sentence."
+  },
+  {
+    "id": "reasoning-02",
+    "category": "reasoning",
+    "prompt": "A train leaves Station A at 10:00 travelling at 50 mph. A second train leaves the same station at 11:00 travelling along the same route at 70 mph. At what time does the second train catch the first?"
+  },
+  {
+    "id": "summary-01",
+    "category": "summarisation",
+    "prompt": "Summarise the following paragraph in one sentence:\n\nThe mitochondrion is a double-membrane-bound organelle found in most eukaryotic cells. They are commonly between 0.75 and 3 micrometres in area but vary considerably in size and structure. Mitochondria generate most of the cell's supply of adenosine triphosphate (ATP), which is used as a source of chemical energy."
+  }
+]


### PR DESCRIPTION
## Summary

Manually-invoked CLI that compares the LLM Council pipeline against a single-model baseline using LLM-as-judge. Smallest possible regression detector for prompt/strategy changes — not wired into CI (≈\$1–2 per pass).

For each prompt: run the council, run a single-model baseline, ask a third model in a blinded pairwise comparison "which answer is better", aggregate the verdicts. Output a JSON envelope and a one-line stdout summary.

Closes #176

## What's in

**Code change in `internal/council/`**
- Promote `stripCodeFence` → `council.StripCodeFence` (exported). The eval judge uses the same defence against fence-happy models.

**New package `internal/eval/`**
- `eval.go` — `Suite`, `Case`, `Verdict`, `Result`, `Meta`, `Output`, `Options`, `Run` orchestrator. Validates required fields (rejects `judge==baseline` to avoid self-preference bias), seeds a `math/rand/v2` PCG, iterates sequentially. Per-case errors surface as `VerdictError` without aborting the run.
- `judge.go` — `Judge.Compare` runs a pairwise comparison. System prompt explicitly instructs *"length is not a quality signal — prefer the more correct and concise answer"*. `ResponseFormat: json_object` + `StripCodeFence` + parse. Unknown verdict / malformed JSON surface as errors.
- `runner.go` — `runCouncil` captures `stage3_complete.Content` + `stage2_complete.Metadata.ConsensusW` via `EventFunc`. `runBaseline` calls `LLMClient.Complete` with a single user message.
- `report.go` — `Aggregate` → `Summary{CouncilWon, BaselineWon, Ties, Errors}`. `Summary.Format` renders the stdout line. `WriteOutput` emits indented `{meta, results}` envelope JSON.
- `testdata/golden.json` — 12 hand-crafted cases (3 ambiguous, 3 factual, 3 code, 2 reasoning, 1 summarisation).

**New binary `cmd/eval/main.go`**
- `-input`, `-out`, `-baseline-model`, `-judge-model`, `-council-type`, `-seed` flags.
- Reads same `.env` as the server. Builds the same openrouter+council registry shape as `cmd/server`. Computes input SHA-256 and echoes it + seed into output meta for replay.
- SIGINT/SIGTERM cancels mid-run between cases.

**Docs + .gitignore**
- `docs/testing-strategy.md` gains an "Evaluation Harness" section (how to run, when to run, cost note, judge-bias caveats, file map).
- `.gitignore` adds `eval-results*.json`. Golden inputs ARE checked in.

## Tests (40 new)

- `eval_test.go` (15): orchestrator happy path captures council/baseline/W; remap honours A/B order in both `councilFirst`/`baselineFirst` seeds; tie → `VerdictTie`; council/baseline errors → `VerdictError` without invoking judge; mixed outcomes don't abort; required-field validation; SHA-256 determinism; `LoadSuite`.
- `judge_test.go` (15): A/B/tie; ```json fence stripping; system-prompt verbosity-mitigation phrase asserted; `ResponseFormat: json_object` set; malformed JSON / missing verdict / unknown verdict → errors; client error propagates; truncate boundary.
- `report_test.go` (10): aggregation across mixed verdicts; unknown verdict → Errors; Format text; JSON round-trip; `error` field omitempty.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `staticcheck ./...` clean
- [x] `go test -race -count=1 ./...` — **208 pass** (was 168; +40 new)
- [x] No production code under `internal/api/`, `internal/storage/`, or `cmd/server/` changed
- [x] CI unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)