### PR TITLE
⚡ fix(eval): replace fmt.Println with fmt.Fprintf(os.Stdout)

### DIFF
--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -156,7 +156,7 @@ func run() error {
 	}
 
 	summary := eval.Aggregate(results)
-	fmt.Println(summary.Format(len(results)))
+	fmt.Fprintf(os.Stdout, "%s\n", summary.Format(len(results)))
 	fmt.Fprintf(os.Stderr, "wrote %s (seed=%d, sha256=%s)\n", *outPath, chosenSeed, meta.InputSHA256)
 	return nil
 }

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -156,8 +156,12 @@ func run() error {
 	}
 
 	summary := eval.Aggregate(results)
-	fmt.Fprintf(os.Stdout, "%s\n", summary.Format(len(results)))
-	fmt.Fprintf(os.Stderr, "wrote %s (seed=%d, sha256=%s)\n", *outPath, chosenSeed, meta.InputSHA256)
+	if _, err := fmt.Fprintf(os.Stdout, "%s\n", summary.Format(len(results))); err != nil {
+		return fmt.Errorf("write summary: %w", err)
+	}
+	if _, err := fmt.Fprintf(os.Stderr, "wrote %s (seed=%d, sha256=%s)\n", *outPath, chosenSeed, meta.InputSHA256); err != nil {
+		return fmt.Errorf("write stderr: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Replace `fmt.Println(summary.Format(len(results)))` with `fmt.Fprintf(os.Stdout, "%s\n", ...)` in `cmd/eval/main.go:159`
- Matches the existing `fmt.Fprintf(os.Stderr, ...)` pattern on the next line
- `/housekeeping` check 2 now passes

Closes #187

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (208 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)