### PR TITLE
⚡ task(config): remove stale trailing comments from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@
 # Obtain from your configured provider. The variable name remains OPENROUTER_API_KEY.
 # For OpenRouter: https://openrouter.ai/keys
 # For keyless local Ollama use any non-empty placeholder, e.g. OPENROUTER_API_KEY=ollama
-OPENROUTER_API_KEY=sk-or-v1-
+OPENROUTER_API_KEY=<sk-or-v1-...>
 
 # ── Council models ──────────────────────────────────────────────────────────
 # Comma-separated list of OpenRouter model IDs for council members.
@@ -102,11 +102,3 @@ PORT=8001
 # Local Ollama:  LLM_API_BASE_URL=http://localhost:11434/v1/chat/completions
 #
 # LLM_API_BASE_URL=https://api.ollama.com/v1/chat/completions
-
-
-# https://openrouter.ai/api/v1/chat/completions
-#
-# # Original
-# http://localhost:11434/api/chat
-# # OpenRouter compatible
-# http://localhost:11434/v1/chat/completions


### PR DESCRIPTION
## Summary
- All 14 env vars were already present in `.env.example` (7 uncommented, 7 as commented-out optional defaults)
- Removes leftover URL scratchpad notes at the bottom of the file (lines 107–113) that had no instructional value
- Issue #190 was a false positive from the revival diagnostic (`grep "^[A-Z_]"` only shows uncommented lines)

Closes #190

## Test plan
- [ ] No code changes — config file cleanup only

🤖 Generated with [Claude Code](https://claude.com/claude-code)