### PR TITLE
⚡ task(ci): pin go-version to 1.26.3 to match go.mod toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.3"
           cache: true
 
       - name: Install staticcheck


### PR DESCRIPTION
## Summary
- Changes `go-version: "1.26"` to `"1.26.3"` in `.github/workflows/ci.yml`
- Matches the `go 1.26.3` + `toolchain go1.26.3` pins in `go.mod`
- Eliminates patch-level version ambiguity between CI and the declared toolchain

Closes #191

## Test plan
- [ ] CI passes with the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)