### PR TITLE
⚡ task(council): document RoleBased vs RoleBasedReview strategy distinction

### DIFF
--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -4,8 +4,20 @@ package council
 type Strategy int
 
 const (
+	// PeerReview runs the 3-stage Karpathy pipeline: parallel generation →
+	// anonymous peer ranking → chairman synthesis.
 	PeerReview Strategy = iota
+
+	// RoleBased runs a 2-stage pipeline: parallel specialist roles → chairman
+	// synthesis. Stage 2 (peer ranking) is skipped; a stub Stage2CompleteData
+	// event is emitted for SSE compatibility. Use for generic role-based councils
+	// where roles are complementary rather than competing.
 	RoleBased
+
+	// RoleBasedReview is the code-review variant of RoleBased. It shares the
+	// same execution path but carries a distinct identity so registrations can
+	// set QuorumMin = len(Roles), enforcing that every specialist role must
+	// succeed before synthesis proceeds. Use via NewCodeReviewCouncilType.
 	RoleBasedReview
 )
 
@@ -20,8 +32,8 @@ type Role struct {
 type CouncilType struct {
 	Name          string
 	Strategy      Strategy
-	Models        []string // PeerReview: all council members; RoleBased: assigned to Roles by index mod len
-	Roles         []Role   // RoleBased / RoleBasedReview: role definitions with instructions
+	Models        []string // PeerReview: all council members; RoleBased/RoleBasedReview: assigned to Roles by index mod len
+	Roles         []Role   // RoleBased/RoleBasedReview: role definitions with specialist instructions
 	ChairmanModel string
 	Temperature   float64
 	QuorumMin     int // 0 = use formula: max(2, ⌈N/2⌉+1)


### PR DESCRIPTION
## Summary
- Both `RoleBased` and `RoleBasedReview` dispatch to the same `runRoleBased` pipeline, but carry different semantic contracts
- `RoleBased` — generic complementary-role council; no quorum enforcement beyond the default formula
- `RoleBasedReview` — code-review variant; `QuorumMin = len(Roles)` so every specialist must succeed before synthesis
- Documents this distinction in the iota block with per-constant doc comments
- Updates `CouncilType` field comments to reference both constants consistently

Closes #192

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test -race -count=1 ./...` passes (208 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)