### PR TITLE
⚖️ feat(council,api,frontend): Stage 2 polymorphism via kind discriminator

### DIFF
--- a/.claude/dreaming/dreaming-prompt.md
+++ b/.claude/dreaming/dreaming-prompt.md
@@ -128,3 +128,12 @@ PRs examined: <count>
 ## 7. What I couldn't tell (need manual review)
 - ...
 ```
+
+## Output formatting
+
+- Output the report as **plain markdown**.
+- Do **NOT** wrap the entire report in a ` ```markdown ` code fence.
+- Do **NOT** add preamble like "I have enough sample data..." — start
+  directly with the `# llm-council dreaming pass — ...` heading.
+- Do **NOT** add postamble like "Report complete." — end after the
+  last section.

--- a/.claude/dreaming/dreaming.sh
+++ b/.claude/dreaming/dreaming.sh
@@ -44,11 +44,12 @@ Current branch: $(git rev-parse --abbrev-ref HEAD).
 Project root: $PROJECT_DIR.
 Write the report to stdout."
 
-claude \
+# Prompt via stdin — `--allowed-tools <tools...>` is variadic and would
+# otherwise consume the positional prompt argument.
+echo "$PROMPT" | claude \
   --print \
   --model opus \
   --allowed-tools "Read,Glob,Grep,Bash(ls:*),Bash(cat:*),Bash(wc:*),Bash(stat:*),Bash(find:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git rev-parse:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh issue list:*)" \
-  "$PROMPT" \
   > "$REPORT" 2>> "$LOG"
 
 EXIT=$?

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -91,7 +91,7 @@ Stage 2 is polymorphic. The on-the-wire envelope carries a `kind` discriminator 
 
 The `kind` field is **added** to the existing `Stage2CompleteData` shape — no field renames or removals — so today's clients keep working.
 
-For multi-round strategies (`MultiAgentDebate`, `Delphi`), the server fires `stage2_round_complete` per round, then a final `stage2_complete` when rounds end. PeerReview's existing payload corresponds to `kind: "peer_ranking"`; RoleBased's stub corresponds to `kind: "role_stub"`.
+PeerReview's existing payload corresponds to `kind: "peer_ranking"`; RoleBased's stub corresponds to `kind: "role_stub"`. For multi-round strategies (`MultiAgentDebate`, `Delphi`) — both **planned, not yet implemented** — the server is expected to fire a `stage2_round_complete` event per round followed by a final `stage2_complete` summary; this event type does not exist in the runtime today and ships with the first multi-round strategy.
 
 ### Stage 2 `kind` values
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -77,19 +77,35 @@ Every strategy emits the same event family:
 | `stage2_complete` | Intermediate processing | Yes (may be a stub) |
 | `stage3_complete` | Final synthesis | Yes |
 
-Stage 2 is polymorphic. When the Stage 2 polymorphism PR ships, the payload gains a `kind` discriminator so the frontend knows how to render it:
+Stage 2 is polymorphic. The on-the-wire envelope carries a `kind` discriminator so the frontend can route each event to a strategy-specific renderer:
 
 ```jsonc
 {
-  "kind": "peer_ranking | vote_tally | rank_refine | debate_round
-         | moa_aggregator | delphi_round | role_stub",
-  "round": 1,
-  "data": { /* strategy-specific */ },
+  "type": "stage2_complete",
+  "kind": "<one of the seven values below>",
+  "round": 1,                    // omitted when 0; reserved for multi-round strategies
+  "data": [ /* strategy-specific payload — today []StageTwoResult */ ],
   "metadata": { /* shared envelope: council_type, label_to_model, … */ }
 }
 ```
 
-For multi-round strategies (`MultiAgentDebate`, `Delphi`), the server fires `stage2_round_complete` per round, then a final `stage2_complete` when rounds end. PeerReview's existing payload corresponds to `kind: "peer_ranking"`; RoleBased's stub corresponds to `kind: "role_stub"`. The `kind` field is **added** to the existing `Stage2CompleteData` shape — no field renames or removals — so today's clients keep working.
+The `kind` field is **added** to the existing `Stage2CompleteData` shape — no field renames or removals — so today's clients keep working.
+
+For multi-round strategies (`MultiAgentDebate`, `Delphi`), the server fires `stage2_round_complete` per round, then a final `stage2_complete` when rounds end. PeerReview's existing payload corresponds to `kind: "peer_ranking"`; RoleBased's stub corresponds to `kind: "role_stub"`.
+
+### Stage 2 `kind` values
+
+| Kind | Strategy | Status | `data` shape | `round` semantics |
+|------|----------|--------|--------------|-------------------|
+| `peer_ranking` | `PeerReview` | **shipped** | `[]StageTwoResult` — each reviewer's ranked label list | always `0` |
+| `role_stub` | `RoleBased` | **shipped** | `[]` — empty; metadata carries `aggregate_rankings: []`, `consensus_w: 1.0` | always `0` |
+| `vote_tally` | `Majority` | **reserved** | per-candidate vote counts (or weighted scores), winner identifier, optional cluster groupings | always `0` |
+| `rank_refine` | `GenerateRankRefine` | **reserved** | ranked candidate list with criterion scores; top-K subset that proceeds to refinement | always `0` |
+| `debate_round` | `MultiAgentDebate` | **reserved** | per-debater critique-and-revise output for the current round; references to the round's targets | `1..N`; one event per round, then a final `stage2_complete` with summary |
+| `moa_aggregator` | `MixtureOfAgents` | **reserved** | Layer-2 aggregator outputs; references to which Layer-1 proposers fed each aggregator | always `0` (single aggregator pass) |
+| `delphi_round` | `Delphi` | **reserved** | per-rater rating list for the current round; running averages and convergence indicator | `1..N`; one event per round |
+
+Reserved kinds are not yet emitted by the runtime. The frontend `Stage2.jsx` dispatcher renders any unknown kind via a fallback view (`Stage 2 — kind: <X> (view not implemented yet)`) so a strategy in flight does not crash the UI.
 
 ---
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,10 +45,14 @@ function App() {
         })
         .map((msg) => {
           if (msg.role !== 'assistant') return msg;
+          // Derive stage2Kind for historical records (AssistantMessage doesn't persist Kind).
+          // Today only PeerReview was persisted, so default to "peer_ranking".
+          // Future strategies that persist will need their own derivation rules.
           return {
             loading: { stage0: false, stage1: false, stage2: false, stage3: false },
             error: null,
             pendingClarification: null,
+            stage2Kind: 'peer_ranking',
             ...msg,
           };
         });
@@ -60,7 +64,7 @@ function App() {
         } else {
           messages.push({
             role: 'assistant',
-            stage1: null, stage2: null, stage3: null, metadata: null,
+            stage1: null, stage2: null, stage2Kind: null, stage3: null, metadata: null,
             loading: { stage0: false, stage1: false, stage2: false, stage3: false },
             error: null,
             pendingClarification,
@@ -137,6 +141,8 @@ function App() {
     stage2_start: () => updateLast((msg) => { msg.loading.stage2 = true; }),
     stage2_complete: (event) => updateLast((msg) => {
       msg.stage2 = event.data;
+      // Default to "peer_ranking" when an older backend doesn't emit `kind`.
+      msg.stage2Kind = event.kind ?? 'peer_ranking';
       msg.metadata = event.metadata;
       msg.loading.stage2 = false;
     }),
@@ -173,7 +179,7 @@ function App() {
 
       const assistantMessage = {
         role: 'assistant',
-        stage1: null, stage2: null, stage3: null, metadata: null,
+        stage1: null, stage2: null, stage2Kind: null, stage3: null, metadata: null,
         loading: { stage0: false, stage1: true, stage2: false, stage3: false },
         error: null,
         pendingClarification: null,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,31 @@ import ChatInterface from './components/ChatInterface';
 import { api } from './api';
 import './App.css';
 
+// Maps a persisted council_type (or a strategy-emitted Stage 2 kind) to the
+// kind value the Stage2 dispatcher expects. Today only PeerReview is
+// persistable, so "default" → "peer_ranking". Future strategies extend the
+// switch when their registrations begin persisting. Empty / whitespace / null
+// inputs all collapse to "peer_ranking" — the safe pre-this-PR default.
+function deriveStage2Kind(councilType) {
+  const ct = (councilType ?? '').trim();
+  if (!ct) return 'peer_ranking';
+  switch (ct) {
+    case 'default':
+      return 'peer_ranking';
+    default:
+      return 'peer_ranking';
+  }
+}
+
+// normaliseStage2Kind treats null/undefined/empty/whitespace as missing and
+// falls back to "peer_ranking". A non-empty value is returned as-is so the
+// dispatcher routes to UnknownKindView when the backend emits a kind the
+// frontend genuinely doesn't recognise.
+function normaliseStage2Kind(raw) {
+  const trimmed = (raw ?? '').trim();
+  return trimmed || 'peer_ranking';
+}
+
 function App() {
   const [conversations, setConversations] = useState([]);
   const [currentConversationId, setCurrentConversationId] = useState(null);
@@ -45,14 +70,14 @@ function App() {
         })
         .map((msg) => {
           if (msg.role !== 'assistant') return msg;
-          // Derive stage2Kind for historical records (AssistantMessage doesn't persist Kind).
-          // Today only PeerReview was persisted, so default to "peer_ranking".
-          // Future strategies that persist will need their own derivation rules.
+          // AssistantMessage doesn't persist Kind, so derive stage2Kind from
+          // metadata.council_type for replay. Falls back to "peer_ranking" for
+          // missing council_type — matches the pre-this-PR rendering default.
           return {
             loading: { stage0: false, stage1: false, stage2: false, stage3: false },
             error: null,
             pendingClarification: null,
-            stage2Kind: 'peer_ranking',
+            stage2Kind: deriveStage2Kind(msg.metadata?.council_type),
             ...msg,
           };
         });
@@ -141,8 +166,10 @@ function App() {
     stage2_start: () => updateLast((msg) => { msg.loading.stage2 = true; }),
     stage2_complete: (event) => updateLast((msg) => {
       msg.stage2 = event.data;
-      // Default to "peer_ranking" when an older backend doesn't emit `kind`.
-      msg.stage2Kind = event.kind ?? 'peer_ranking';
+      // Treat null / undefined / empty / whitespace-only as missing and
+      // fall back to "peer_ranking". Without this, an older backend or a
+      // malformed event would route the dispatcher to UnknownKindView.
+      msg.stage2Kind = normaliseStage2Kind(event.kind);
       msg.metadata = event.metadata;
       msg.loading.stage2 = false;
     }),

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -128,6 +128,7 @@ export default function ChatInterface({
 
                   {/* Stage 2 */}
                   <Stage2
+                    kind={msg.stage2Kind}
                     rankings={msg.stage2}
                     labelToModel={msg.metadata?.label_to_model}
                     aggregateRankings={msg.metadata?.aggregate_rankings}

--- a/frontend/src/components/Stage2.jsx
+++ b/frontend/src/components/Stage2.jsx
@@ -11,7 +11,9 @@ function consensusLabel(w) {
   return 'weak';
 }
 
-export default function Stage2({ rankings, labelToModel, aggregateRankings, consensusW, isLoading }) {
+// PeerRankingView renders the 3-tab ranking + aggregate panel for the
+// PeerReview strategy. Unchanged from the pre-dispatcher Stage 2 body.
+function PeerRankingView({ rankings, labelToModel, aggregateRankings, consensusW, isLoading }) {
   const [expanded, setExpanded] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
 
@@ -106,4 +108,73 @@ export default function Stage2({ rankings, labelToModel, aggregateRankings, cons
       )}
     </div>
   );
+}
+
+// RoleStubView renders a minimal placeholder for the RoleBased strategy,
+// where Stage 2 has no peer-ranking content (roles are complementary).
+function RoleStubView({ isLoading }) {
+  if (isLoading) {
+    return (
+      <div className="stage stage2">
+        <div className="stage-accordion" aria-disabled="true">
+          <span className="stage-accordion-label">
+            <span className="spinner-sm" />
+            Stage 2…
+          </span>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="stage stage2">
+      <div className="stage-accordion" aria-disabled="true">
+        <span className="stage-accordion-label">
+          Stage 2: roles are complementary — no peer ranking.
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// UnknownKindView is the safety net for strategy kinds the frontend doesn't
+// know how to render yet. It surfaces the kind name so the gap is visible
+// in development without crashing the UI.
+function UnknownKindView({ kind }) {
+  return (
+    <div className="stage stage2">
+      <div className="stage-accordion" aria-disabled="true">
+        <span className="stage-accordion-label">
+          Stage 2 — kind: <code>{kind}</code> (view not implemented yet)
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// Stage2 dispatches to the right sub-renderer based on `kind`. The dispatcher
+// is the only public component; the views above are private to this module.
+//
+// `kind` propagates from the SSE stage2_complete event (or, for replayed
+// historical conversations, is derived in App.jsx). When it is null/undefined
+// (e.g. an older backend that doesn't emit kind), we default to peer_ranking
+// because that was the only persisted Stage 2 shape before this PR.
+export default function Stage2({ kind, rankings, labelToModel, aggregateRankings, consensusW, isLoading }) {
+  const effectiveKind = kind ?? 'peer_ranking';
+
+  switch (effectiveKind) {
+    case 'peer_ranking':
+      return (
+        <PeerRankingView
+          rankings={rankings}
+          labelToModel={labelToModel}
+          aggregateRankings={aggregateRankings}
+          consensusW={consensusW}
+          isLoading={isLoading}
+        />
+      );
+    case 'role_stub':
+      return <RoleStubView isLoading={isLoading} />;
+    default:
+      return <UnknownKindView kind={effectiveKind} />;
+  }
 }

--- a/frontend/src/components/Stage2.jsx
+++ b/frontend/src/components/Stage2.jsx
@@ -155,11 +155,13 @@ function UnknownKindView({ kind }) {
 // is the only public component; the views above are private to this module.
 //
 // `kind` propagates from the SSE stage2_complete event (or, for replayed
-// historical conversations, is derived in App.jsx). When it is null/undefined
-// (e.g. an older backend that doesn't emit kind), we default to peer_ranking
-// because that was the only persisted Stage 2 shape before this PR.
+// historical conversations, is derived in App.jsx). When it is null /
+// undefined / empty / whitespace-only (e.g. an older backend that doesn't
+// emit kind, or a malformed event), we default to peer_ranking because that
+// was the only persisted Stage 2 shape before this PR.
 export default function Stage2({ kind, rankings, labelToModel, aggregateRankings, consensusW, isLoading }) {
-  const effectiveKind = kind ?? 'peer_ranking';
+  const trimmed = typeof kind === 'string' ? kind.trim() : '';
+  const effectiveKind = trimmed || 'peer_ranking';
 
   switch (effectiveKind) {
     case 'peer_ranking':

--- a/frontend/src/components/Stage2.test.jsx
+++ b/frontend/src/components/Stage2.test.jsx
@@ -1,0 +1,60 @@
+// Tests for Stage2.jsx — the dispatcher routes by `kind` to one of three
+// sub-renderers (PeerRankingView, RoleStubView, UnknownKindView). These tests
+// drive each branch without mounting the rest of App.
+
+import { render, screen } from '@testing-library/react';
+import Stage2 from './Stage2';
+
+describe('Stage2 dispatcher', () => {
+  it('routes kind="peer_ranking" to the peer-ranking view', () => {
+    render(
+      <Stage2
+        kind="peer_ranking"
+        rankings={[
+          { reviewer_label: 'Response A', rankings: ['Response A', 'Response B'] },
+        ]}
+        labelToModel={{ 'Response A': 'openai/gpt-4o', 'Response B': 'anthropic/claude-haiku-4-5' }}
+        aggregateRankings={[
+          { model: 'openai/gpt-4o', score: 1.5 },
+          { model: 'anthropic/claude-haiku-4-5', score: 2.5 },
+        ]}
+        consensusW={0.8}
+        isLoading={false}
+      />,
+    );
+    // Peer-ranking view renders the strong-consensus pill.
+    expect(screen.getByText(/Stage 2: Peer Rankings/i)).toBeInTheDocument();
+    expect(screen.getByText(/W=0.80/i)).toBeInTheDocument();
+  });
+
+  it('routes kind="role_stub" to the role-stub view', () => {
+    render(<Stage2 kind="role_stub" isLoading={false} />);
+    expect(
+      screen.getByText(/roles are complementary — no peer ranking/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Stage 2: Peer Rankings/i)).not.toBeInTheDocument();
+  });
+
+  it('routes an unknown kind to the unknown-kind view, surfacing the kind name', () => {
+    render(<Stage2 kind="vote_tally" isLoading={false} />);
+    expect(screen.getByText(/view not implemented yet/i)).toBeInTheDocument();
+    // The kind name itself must be visible (inside a <code> element).
+    expect(screen.getByText('vote_tally')).toBeInTheDocument();
+  });
+
+  it('defaults to peer_ranking when kind is undefined (old-backend safety net)', () => {
+    render(
+      <Stage2
+        rankings={[
+          { reviewer_label: 'Response A', rankings: ['Response A'] },
+        ]}
+        labelToModel={{ 'Response A': 'openai/gpt-4o' }}
+        aggregateRankings={[]}
+        consensusW={0.0}
+        isLoading={false}
+      />,
+    );
+    // Falls through to PeerRankingView even though kind is undefined.
+    expect(screen.getByText(/Stage 2: Peer Rankings/i)).toBeInTheDocument();
+  });
+});

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -486,16 +486,21 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// sendStage2SSE emits the spec-correct stage2_complete shape:
-	// { "type": "stage2_complete", "data": [...], "metadata": {...} }
-	// metadata is a top-level field, not nested under data.
+	// { "type": "stage2_complete", "kind": "...", "data": [...], "metadata": {...}, "round": N }
+	// kind discriminates the strategy-specific payload (peer_ranking, role_stub, …);
+	// round is omitted when zero (reserved for future multi-round strategies).
 	sendStage2SSE := func(d council.Stage2CompleteData) {
 		type stage2Payload struct {
 			Type     string                   `json:"type"`
+			Kind     string                   `json:"kind"`
+			Round    int                      `json:"round,omitempty"`
 			Data     []council.StageTwoResult `json:"data"`
 			Metadata council.Metadata         `json:"metadata"`
 		}
 		b, err := json.Marshal(stage2Payload{
 			Type:     "stage2_complete",
+			Kind:     d.Kind,
+			Round:    d.Round,
 			Data:     d.Results,
 			Metadata: d.Metadata,
 		})

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -497,9 +497,17 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 			Data     []council.StageTwoResult `json:"data"`
 			Metadata council.Metadata         `json:"metadata"`
 		}
+		// Default empty Kind to "peer_ranking" so a Stage2CompleteData built
+		// without an explicit Kind (e.g. by older callers or test fakes) does
+		// not produce wire-level `"kind":""`, which would route the frontend
+		// dispatcher to the unknown-kind view.
+		kind := d.Kind
+		if kind == "" {
+			kind = "peer_ranking"
+		}
 		b, err := json.Marshal(stage2Payload{
 			Type:     "stage2_complete",
-			Kind:     d.Kind,
+			Kind:     kind,
 			Round:    d.Round,
 			Data:     d.Results,
 			Metadata: d.Metadata,

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -607,27 +607,35 @@ func TestSendMessageStream(t *testing.T) {
 					if !strings.HasPrefix(line, "data: ") {
 						continue
 					}
+					raw := []byte(line[6:])
+					// First-pass: typed unmarshal for value assertions.
 					var env struct {
 						Type     string                   `json:"type"`
 						Kind     string                   `json:"kind"`
-						Round    int                      `json:"round,omitempty"`
 						Data     []council.StageTwoResult `json:"data"`
 						Metadata council.Metadata         `json:"metadata"`
 					}
-					if err := json.Unmarshal([]byte(line[6:]), &env); err != nil || env.Type != "stage2_complete" {
+					if err := json.Unmarshal(raw, &env); err != nil || env.Type != "stage2_complete" {
 						continue
 					}
 					if env.Kind != "peer_ranking" {
 						t.Errorf("kind: got %q, want %q", env.Kind, "peer_ranking")
-					}
-					if env.Round != 0 {
-						t.Errorf("round: got %d, want 0 (omitempty default)", env.Round)
 					}
 					if env.Metadata.ConsensusW != 0.9 {
 						t.Errorf("consensus_w: got %f, want 0.9", env.Metadata.ConsensusW)
 					}
 					if env.Metadata.LabelToModel["Response A"] != "openai/gpt-4o" {
 						t.Errorf("label_to_model: got %v", env.Metadata.LabelToModel)
+					}
+					// Second-pass: raw key inspection — `round` must be ABSENT when zero
+					// (omitempty), not present-but-zero. A typed int unmarshal cannot
+					// distinguish absence from explicit zero, so check the key directly.
+					var keys map[string]json.RawMessage
+					if err := json.Unmarshal(raw, &keys); err != nil {
+						t.Fatalf("re-unmarshal as map: %v", err)
+					}
+					if _, present := keys["round"]; present {
+						t.Errorf("round: must be omitted when zero (omitempty), but key was present in JSON: %s", string(raw))
 					}
 					break
 				}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -564,6 +564,7 @@ func TestSendMessageStream(t *testing.T) {
 						{Label: "Response A", Content: "Go is a compiled language"},
 					})
 					onEvent("stage2_complete", council.Stage2CompleteData{
+						Kind: "peer_ranking",
 						Results: []council.StageTwoResult{
 							{ReviewerLabel: "Response A", Rankings: []string{"Response A"}},
 						},
@@ -600,19 +601,27 @@ func TestSendMessageStream(t *testing.T) {
 					t.Errorf("last event: got %v, want 'complete'", types)
 				}
 
-				// stage2_complete must have metadata as a TOP-LEVEL field per the
-				// streaming spec: { "type": "stage2_complete", "data": [...], "metadata": {...} }
+				// stage2_complete must have kind + metadata as TOP-LEVEL fields per the
+				// streaming spec: { "type": "stage2_complete", "kind": "...", "data": [...], "metadata": {...}, "round"?: N }
 				for _, line := range strings.Split(body, "\n") {
 					if !strings.HasPrefix(line, "data: ") {
 						continue
 					}
 					var env struct {
-						Type     string               `json:"type"`
+						Type     string                   `json:"type"`
+						Kind     string                   `json:"kind"`
+						Round    int                      `json:"round,omitempty"`
 						Data     []council.StageTwoResult `json:"data"`
-						Metadata council.Metadata     `json:"metadata"`
+						Metadata council.Metadata         `json:"metadata"`
 					}
 					if err := json.Unmarshal([]byte(line[6:]), &env); err != nil || env.Type != "stage2_complete" {
 						continue
+					}
+					if env.Kind != "peer_ranking" {
+						t.Errorf("kind: got %q, want %q", env.Kind, "peer_ranking")
+					}
+					if env.Round != 0 {
+						t.Errorf("round: got %d, want 0 (omitempty default)", env.Round)
 					}
 					if env.Metadata.ConsensusW != 0.9 {
 						t.Errorf("consensus_w: got %f, want 0.9", env.Metadata.ConsensusW)

--- a/internal/council/rolebased.go
+++ b/internal/council/rolebased.go
@@ -44,7 +44,7 @@ func (c *Council) runRoleBased(ctx context.Context, query string, ct CouncilType
 		ConsensusW:        1.0, // roles are complementary, not competing
 	}
 	if onEvent != nil {
-		onEvent("stage2_complete", Stage2CompleteData{Results: []StageTwoResult{}, Metadata: meta})
+		onEvent("stage2_complete", Stage2CompleteData{Kind: "role_stub", Results: []StageTwoResult{}, Metadata: meta})
 	}
 
 	// Stage 3: chairman synthesis.

--- a/internal/council/rolebased_test.go
+++ b/internal/council/rolebased_test.go
@@ -148,6 +148,12 @@ func TestRunRoleBased_Stage2CompleteData_HasLabelToModel(t *testing.T) {
 	if !ok {
 		t.Fatalf("stage2_complete data must be Stage2CompleteData, got %T", stage2Data)
 	}
+	if d.Kind != "role_stub" {
+		t.Errorf("Kind: got %q, want %q", d.Kind, "role_stub")
+	}
+	if d.Round != 0 {
+		t.Errorf("Round: got %d, want 0", d.Round)
+	}
 	if d.Metadata.LabelToModel == nil {
 		t.Fatal("LabelToModel must not be nil")
 	}

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -124,7 +124,7 @@ func (c *Council) runPeerReview(ctx context.Context, query string, ct CouncilTyp
 	}
 
 	if onEvent != nil {
-		onEvent("stage2_complete", Stage2CompleteData{Results: stage2Results, Metadata: metadata})
+		onEvent("stage2_complete", Stage2CompleteData{Kind: "peer_ranking", Results: stage2Results, Metadata: metadata})
 	}
 
 	// Stage 3 — Chairman synthesis.

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -525,6 +525,12 @@ func TestRunFull_Stage2CompletePayload_IsStage2CompleteData(t *testing.T) {
 	if !ok {
 		t.Fatalf("stage2_complete payload: got %T, want Stage2CompleteData", stage2Data)
 	}
+	if d.Kind != "peer_ranking" {
+		t.Errorf("Kind: got %q, want %q", d.Kind, "peer_ranking")
+	}
+	if d.Round != 0 {
+		t.Errorf("Round: got %d, want 0", d.Round)
+	}
 	if d.Metadata.CouncilType != "default" {
 		t.Errorf("Metadata.CouncilType: got %q, want %q", d.Metadata.CouncilType, "default")
 	}

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -122,7 +122,16 @@ type Metadata struct {
 // Stage2CompleteData is the payload emitted by Runner for the "stage2_complete" event.
 // It bundles peer-review results with the computed aggregate metadata so callers
 // (e.g. the SSE handler) can surface both in one event.
+//
+// Kind discriminates the strategy-specific payload shape. Today's two implemented
+// values are "peer_ranking" (PeerReview) and "role_stub" (RoleBased). Five more
+// are reserved for planned strategies; see docs/strategies.md for their schemas.
+//
+// Round is reserved for future multi-round strategies (MultiAgentDebate, Delphi).
+// Today both implemented strategies emit a single stage2_complete with Round=0.
 type Stage2CompleteData struct {
+	Kind     string           `json:"kind"`
+	Round    int              `json:"round,omitempty"`
 	Results  []StageTwoResult `json:"results"`
 	Metadata Metadata         `json:"metadata"`
 }


### PR DESCRIPTION
## Summary

Stage 2 events now carry a `kind` discriminator so future strategies can ship their own Stage 2 payloads through the same SSE envelope. PeerReview emits `kind: "peer_ranking"`; RoleBased emits `kind: "role_stub"`. The frontend `Stage2.jsx` is now a dispatcher routing by kind, with a graceful fallback for unknown kinds.

This is the precondition for every new strategy (`Majority`, `GenerateRankRefine`, `MultiAgentDebate`, `MixtureOfAgents`, `Delphi`) — each can ship without touching the SSE protocol.

Closes #201

## Wire shape

```jsonc
{
  "type": "stage2_complete",
  "kind": "peer_ranking",      // NEW — strategy-specific payload discriminator
  "round": 1,                  // NEW — omitted when 0; reserved for multi-round strategies
  "data": [/* StageTwoResult[] today */],
  "metadata": { /* unchanged */ }
}
```

The existing hand-rolled `stage2Payload` struct in `handler.go` was extended in place — no wrapper introduced.

## Backward & forward compat

- **Forward (new backend, old client):** clients that ignore `kind` get the same `data` and `metadata` they always have.
- **Backward (old backend, new frontend):** `event.kind` is `undefined` → `App.jsx` defaults `stage2Kind` to `"peer_ranking"`, so the dispatcher routes to `PeerRankingView` rather than `UnknownKindView`.
- **Replay of stored conversations:** `AssistantMessage` is **not** gaining a `Kind` field. `App.jsx` derives `stage2Kind` for historical records (today's only persistable kind is `peer_ranking`).

## Frontend dispatcher

`Stage2.jsx` decomposed into:
- `PeerRankingView` — existing peer-ranking UI, extracted unchanged
- `RoleStubView` — minimal collapsed accordion ("Stage 2: roles are complementary — no peer ranking")
- `UnknownKindView` — surfaces the kind name + "view not implemented yet" without crashing

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes (202 tests)
- [x] PeerReview emits `Kind: "peer_ranking"` (`runner_test`)
- [x] RoleBased emits `Kind: "role_stub"` (`rolebased_test`)
- [x] Wire-format integration test confirms `"kind":"peer_ranking"` appears in the SSE envelope and `"round"` is omitted when 0 (`handler_test`)
- [x] `npm run lint` passes
- [x] `npm run test` passes (23 tests, +4 from new `Stage2.test.jsx` covering all three dispatcher branches + undefined-kind default)
- [x] `npm run build` passes (chunk sizes within limits)

## Docs

- `docs/strategies.md` Stage 2 polymorphism section gets the full `kind` value table — 2 shipped (`peer_ranking`, `role_stub`), 5 reserved (`vote_tally`, `rank_refine`, `debate_round`, `moa_aggregator`, `delphi_round`) — with each kind's data shape and round semantics.

## Note

This branch carries one extra commit (`56f050e — fix(.claude): pipe prompt via stdin`) inherited from `add-3-dreaming`. The squash merge will fold it into this PR's main commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)