### PR TITLE
⚖️ feat(council,config): Stage 0 — decouple clarification from council type's models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,23 @@ DEFAULT_COUNCIL_TEMPERATURE=0.7
 # Per-round question cap (chairman trims to this). Default: 3
 # CLARIFICATION_MAX_QUESTIONS_PER_ROUND=3
 
+# Stage 0 generator pool — model(s) that propose clarifying questions.
+# Single-model is the common case; a cheap fast model is usually fine here.
+# Multi-generator parallelism is supported via comma syntax for diversity.
+# Resolution chain: CLARIFICATION_MODELS (this var) → council type's Models → error.
+# When unset, Stage 0 uses whichever Models the active council type registered.
+#
+# Single-model (recommended):
+# CLARIFICATION_MODELS=openai/gpt-4o-mini
+#
+# Multi-generator (optional):
+# CLARIFICATION_MODELS=openai/gpt-4o-mini,anthropic/claude-haiku-4-5
+
+# Stage 0 arbiter — model that decides whether to ask, dedupes, prioritises.
+# Resolution chain: CLARIFICATION_ARBITER_MODEL (this var) → council type's
+# ChairmanModel → error. When unset, Stage 0 uses the council type's chairman.
+# CLARIFICATION_ARBITER_MODEL=anthropic/claude-sonnet-4-5
+
 # ── Storage ─────────────────────────────────────────────────────────────────
 # Directory where conversation JSON files are stored.
 # Created automatically if it does not exist. Default: data/conversations

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -58,6 +58,8 @@ func main() {
 		MaxRounds:            cfg.ClarificationMaxRounds,
 		MaxTotalQuestions:    cfg.ClarificationMaxTotalQuestions,
 		MaxQuestionsPerRound: cfg.ClarificationMaxQuestionsPerRound,
+		Models:               cfg.ClarificationModels,
+		ArbiterModel:         cfg.ClarificationArbiterModel,
 	}
 	handler := api.NewHandler(runner, runner, store, logger, cfg.DefaultCouncilType, clarificationCfg)
 	mux := http.NewServeMux()

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -159,7 +159,21 @@ Every `CouncilType` registration is independent. Two registrations with the same
 
 #### Stage 0 (clarification) — strategy-independent
 
-Stage 0 runs before any strategy dispatch. It is independent of the `Strategy` value and will gain its own dedicated model configuration in a future refactor (`CLARIFICATION_MODEL`, `CLARIFICATION_ARBITER_MODEL`). Today it reuses the council type's `Models` (generators) and `ChairmanModel` (arbiter) — that coupling will be removed.
+Stage 0 runs before any strategy dispatch. It is independent of the `Strategy` value and has its own dedicated model configuration:
+
+- `CLARIFICATION_MODELS` (env) — comma-separated generator pool. Single-model `CLARIFICATION_MODELS=foo/bar` is the common case (a cheap fast model usually suffices for clarifying-question generation).
+- `CLARIFICATION_ARBITER_MODEL` (env) — single model that dedupes generator candidates, prioritises, and decides whether to actually ask.
+
+Both env vars are optional. The runner resolves a two-step fall-through chain at request time:
+
+```
+generator models : cfg.Models     → ct.Models        → error
+arbiter model    : cfg.ArbiterModel → ct.ChairmanModel → error
+```
+
+The error is loud — `RunClarificationRound` returns explicitly rather than emitting `stage0_done`. This catches misconfiguration (e.g. a future strategy with no `ChairmanModel`, registered without setting `CLARIFICATION_ARBITER_MODEL`).
+
+The config loader does **not** pre-fill the Stage 0 fields from `COUNCIL_MODELS` / `CHAIRMAN_MODEL`; it leaves them empty and lets the runner do the resolution. This preserves the per-council-type fall-back hop, which is what "no existing deployments break" actually means.
 
 ### Storage (`internal/storage`)
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -4,7 +4,7 @@ The `Strategy` enum (`internal/council/types.go`) declares **7 constants**. Two 
 
 For architecture context (package layout, layer boundaries, dispatch switch) see [`architecture-v2.md`](./architecture-v2.md). For the academic background of each strategy see [`council-research-synthesis.md`](./council-research-synthesis.md).
 
-Stage 0 (clarification) runs **before** strategy dispatch and is strategy-independent — see the [Stage 0 section in architecture-v2.md](./architecture-v2.md#stage-0-clarification--strategy-independent). Future work extracts it with its own dedicated model configuration (`CLARIFICATION_MODEL`, `CLARIFICATION_ARBITER_MODEL`).
+Stage 0 (clarification) runs **before** strategy dispatch and is strategy-independent — see the [Stage 0 section in architecture-v2.md](./architecture-v2.md#stage-0-clarification--strategy-independent). It has its own dedicated model configuration (`CLARIFICATION_MODELS`, `CLARIFICATION_ARBITER_MODEL`); see `.env.example`. Both env vars are optional and fall back to the council type's `Models` / `ChairmanModel` when unset.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,8 +150,10 @@ func Load() (*Config, error) {
 	}
 
 	// Stage 0 arbiter. Empty string when unset — runner resolves the
-	// fall-through to the council type's ChairmanModel.
-	clarificationArbiterModel := os.Getenv("CLARIFICATION_ARBITER_MODEL")
+	// fall-through to the council type's ChairmanModel. Trim whitespace so
+	// an accidentally-spaced value (e.g. "   ") is treated as unset rather
+	// than as a non-empty model ID that would skip the fall-back.
+	clarificationArbiterModel := strings.TrimSpace(os.Getenv("CLARIFICATION_ARBITER_MODEL"))
 
 	llmAPIMaxRetries := 2
 	if raw := os.Getenv("LLM_API_MAX_RETRIES"); raw != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,14 @@ type Config struct {
 	ClarificationMaxTotalQuestions    int
 	ClarificationMaxQuestionsPerRound int
 
+	// Stage 0 model overrides. Both fields are intentionally left empty when
+	// their env vars are unset; the runner resolves the fall-through chain
+	// (env → council type's models → error) at request time so the per-
+	// council-type hop survives. Do NOT pre-fill from DefaultCouncilModels /
+	// DefaultCouncilChairmanModel here.
+	ClarificationModels       []string
+	ClarificationArbiterModel string
+
 	// LLMAPIMaxRetries is the number of retries the OpenRouter client attempts
 	// on transient failures (HTTP 429/502/503/504, network timeouts, EOFs).
 	// 0 disables retries. Default: 2 (3 total attempts including the initial).
@@ -128,6 +136,23 @@ func Load() (*Config, error) {
 		}
 	}
 
+	// Stage 0 generator pool. Empty slice when unset — runner resolves the
+	// fall-through to the council type's Models. Comma-separated list with
+	// whitespace trim; single-model `CLARIFICATION_MODELS=foo/bar` is the
+	// common case (yields a 1-element slice).
+	var clarificationModels []string
+	if raw := os.Getenv("CLARIFICATION_MODELS"); raw != "" {
+		for _, m := range strings.Split(raw, ",") {
+			if m = strings.TrimSpace(m); m != "" {
+				clarificationModels = append(clarificationModels, m)
+			}
+		}
+	}
+
+	// Stage 0 arbiter. Empty string when unset — runner resolves the
+	// fall-through to the council type's ChairmanModel.
+	clarificationArbiterModel := os.Getenv("CLARIFICATION_ARBITER_MODEL")
+
 	llmAPIMaxRetries := 2
 	if raw := os.Getenv("LLM_API_MAX_RETRIES"); raw != "" {
 		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
@@ -151,6 +176,8 @@ func Load() (*Config, error) {
 		ClarificationMaxRounds:            clarificationMaxRounds,
 		ClarificationMaxTotalQuestions:    clarificationMaxTotalQuestions,
 		ClarificationMaxQuestionsPerRound: clarificationMaxQuestionsPerRound,
+		ClarificationModels:               clarificationModels,
+		ClarificationArbiterModel:         clarificationArbiterModel,
 
 		LLMAPIMaxRetries: llmAPIMaxRetries,
 	}, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -138,3 +138,71 @@ func TestLoad_LLMAPIMaxRetries(t *testing.T) {
 		})
 	}
 }
+
+// ── TestLoad_ClarificationModels ──────────────────────────────────────────
+//
+// The config loader must NOT pre-fill the Stage 0 model fields from
+// COUNCIL_MODELS / CHAIRMAN_MODEL when the dedicated env vars are unset.
+// Resolution is the runner's job; the config is just transport.
+
+func TestLoad_ClarificationModels_BothSet(t *testing.T) {
+	baseEnv(t)
+	setenv(t, "CLARIFICATION_MODELS", "openai/gpt-4o-mini, anthropic/claude-haiku-4-5")
+	setenv(t, "CLARIFICATION_ARBITER_MODEL", "anthropic/claude-sonnet-4-5")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantModels := []string{"openai/gpt-4o-mini", "anthropic/claude-haiku-4-5"}
+	if len(cfg.ClarificationModels) != len(wantModels) {
+		t.Fatalf("ClarificationModels: got %v, want %v", cfg.ClarificationModels, wantModels)
+	}
+	for i, m := range wantModels {
+		if cfg.ClarificationModels[i] != m {
+			t.Errorf("ClarificationModels[%d]: got %q, want %q", i, cfg.ClarificationModels[i], m)
+		}
+	}
+	if cfg.ClarificationArbiterModel != "anthropic/claude-sonnet-4-5" {
+		t.Errorf("ClarificationArbiterModel: got %q, want %q", cfg.ClarificationArbiterModel, "anthropic/claude-sonnet-4-5")
+	}
+}
+
+func TestLoad_ClarificationModels_GeneratorsSet_ArbiterUnset_LeavesArbiterEmpty(t *testing.T) {
+	baseEnv(t)
+	setenv(t, "CLARIFICATION_MODELS", "openai/gpt-4o-mini")
+	unsetenv(t, "CLARIFICATION_ARBITER_MODEL")
+	// Pre-fill CHAIRMAN_MODEL to prove the loader does NOT pre-fill from it.
+	setenv(t, "CHAIRMAN_MODEL", "google/gemini-3.1-pro-preview")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.ClarificationModels) != 1 || cfg.ClarificationModels[0] != "openai/gpt-4o-mini" {
+		t.Errorf("ClarificationModels: got %v, want [openai/gpt-4o-mini]", cfg.ClarificationModels)
+	}
+	if cfg.ClarificationArbiterModel != "" {
+		t.Errorf("ClarificationArbiterModel: got %q, want empty (resolution is the runner's job)", cfg.ClarificationArbiterModel)
+	}
+}
+
+func TestLoad_ClarificationModels_BothUnset_FieldsEmpty(t *testing.T) {
+	baseEnv(t)
+	unsetenv(t, "CLARIFICATION_MODELS")
+	unsetenv(t, "CLARIFICATION_ARBITER_MODEL")
+	// Pre-fill council defaults to prove the loader does NOT pre-fill from them.
+	setenv(t, "COUNCIL_MODELS", "model-a,model-b")
+	setenv(t, "CHAIRMAN_MODEL", "chairman-z")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.ClarificationModels) != 0 {
+		t.Errorf("ClarificationModels: got %v, want empty (legacy fall-through path)", cfg.ClarificationModels)
+	}
+	if cfg.ClarificationArbiterModel != "" {
+		t.Errorf("ClarificationArbiterModel: got %q, want empty (legacy fall-through path)", cfg.ClarificationArbiterModel)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -187,6 +187,21 @@ func TestLoad_ClarificationModels_GeneratorsSet_ArbiterUnset_LeavesArbiterEmpty(
 	}
 }
 
+func TestLoad_ClarificationModels_ArbiterWhitespace_TreatedAsUnset(t *testing.T) {
+	// Accidental whitespace-only value must not bypass the runner's fall-back
+	// to ct.ChairmanModel. Loader trims and treats as empty.
+	baseEnv(t)
+	setenv(t, "CLARIFICATION_ARBITER_MODEL", "   ")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ClarificationArbiterModel != "" {
+		t.Errorf("ClarificationArbiterModel: got %q, want empty (whitespace must be trimmed to unset)", cfg.ClarificationArbiterModel)
+	}
+}
+
 func TestLoad_ClarificationModels_BothUnset_FieldsEmpty(t *testing.T) {
 	baseEnv(t)
 	unsetenv(t, "CLARIFICATION_MODELS")

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -297,9 +297,27 @@ func (c *Council) RunClarificationRound(
 		return fmt.Errorf("council: unknown council type %q", councilType)
 	}
 
+	// Resolve the Stage 0 model chain: env override → per-council-type → error.
+	// Both fields on cfg are optional. The runner does the resolution (not the
+	// config loader) so the per-council-type fall-back hop survives.
+	generatorModels := cfg.Models
+	if len(generatorModels) == 0 {
+		generatorModels = ct.Models
+	}
+	if len(generatorModels) == 0 {
+		return fmt.Errorf("council: stage 0 has no generator models — set CLARIFICATION_MODELS or configure the council type's Models")
+	}
+	arbiterModel := cfg.ArbiterModel
+	if arbiterModel == "" {
+		arbiterModel = ct.ChairmanModel
+	}
+	if arbiterModel == "" {
+		return fmt.Errorf("council: stage 0 has no arbiter model — set CLARIFICATION_ARBITER_MODEL or configure the council type's ChairmanModel")
+	}
+
 	// Run generators in parallel.
 	prompt := BuildStage0GeneratorPrompt(query, history)
-	candidates := c.runStage0Generators(ctx, prompt, ct.Models, ct.Temperature)
+	candidates := c.runStage0Generators(ctx, prompt, generatorModels, ct.Temperature)
 
 	// Collect all candidate question texts.
 	var allCandidates []string
@@ -310,7 +328,7 @@ func (c *Council) RunClarificationRound(
 	}
 
 	// Chairman decision.
-	questions, enough, err := c.runStage0Chairman(ctx, query, allCandidates, round, cfg, accumulated, ct.ChairmanModel, ct.Temperature)
+	questions, enough, err := c.runStage0Chairman(ctx, query, allCandidates, round, cfg, accumulated, arbiterModel, ct.Temperature)
 	if err != nil {
 		// Log and fail-open.
 		if c.logger != nil {

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -568,5 +569,194 @@ func TestRunFull_UnimplementedStrategy_ReturnsError(t *testing.T) {
 				t.Fatalf("expected 'not implemented' error, got %v", err)
 			}
 		})
+	}
+}
+
+// ── Stage 0 model resolution chain ────────────────────────────────────────
+
+// stage0Recorder is a thread-safe collector that classifies each completion
+// request as a generator or chairman call by inspecting the prompt prefix.
+// Generator prompts start with "You are helping clarify..." and chairman
+// prompts start with "You are deciding whether to ask...".
+type stage0Recorder struct {
+	mu             sync.Mutex
+	generatorCalls []string // models seen on generator-shaped prompts
+	chairmanCalls  []string // models seen on chairman-shaped prompts
+}
+
+func (r *stage0Recorder) record(req CompletionRequest) (CompletionResponse, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	body := ""
+	if len(req.Messages) > 0 {
+		body = req.Messages[0].Content
+	}
+	if strings.Contains(body, "You are helping clarify") {
+		r.generatorCalls = append(r.generatorCalls, req.Model)
+		return makeResponse(`{"questions":[{"text":"q?"}]}`), nil
+	}
+	if strings.Contains(body, "You are deciding whether to ask") {
+		r.chairmanCalls = append(r.chairmanCalls, req.Model)
+		// Return enough=true so the round terminates without emitting questions.
+		return makeResponse(`{"questions":[],"enough":true}`), nil
+	}
+	return makeResponse("{}"), nil
+}
+
+// stage0Fixture returns a Council whose registry's "test" entry has the given
+// generator pool and chairman model. The mock client uses the recorder.
+func stage0Fixture(t *testing.T, ctModels []string, ctChairman string, rec *stage0Recorder) *Council {
+	t.Helper()
+	registry := map[string]CouncilType{
+		"test": {
+			Name:          "test",
+			Strategy:      PeerReview,
+			Models:        ctModels,
+			ChairmanModel: ctChairman,
+			Temperature:   0.7,
+		},
+	}
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			return rec.record(req)
+		},
+	}
+	return NewCouncil(client, registry, nil)
+}
+
+func TestRunClarificationRound_Resolution_BothCfgFieldsSet(t *testing.T) {
+	rec := &stage0Recorder{}
+	c := stage0Fixture(t, []string{"ct-gen-1", "ct-gen-2"}, "ct-chair", rec)
+
+	cfg := ClarificationConfig{
+		MaxRounds:            2,
+		MaxTotalQuestions:    5,
+		MaxQuestionsPerRound: 3,
+		Models:               []string{"cfg-gen-1", "cfg-gen-2"},
+		ArbiterModel:         "cfg-arbiter",
+	}
+
+	if err := c.RunClarificationRound(context.Background(), "q", nil, cfg, "test", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotGens := append([]string(nil), rec.generatorCalls...)
+	wantGens := map[string]bool{"cfg-gen-1": true, "cfg-gen-2": true}
+	if len(gotGens) != 2 {
+		t.Fatalf("generator calls: got %d, want 2 (%v)", len(gotGens), gotGens)
+	}
+	for _, m := range gotGens {
+		if !wantGens[m] {
+			t.Errorf("generator model %q not in expected cfg pool", m)
+		}
+	}
+	if len(rec.chairmanCalls) != 1 || rec.chairmanCalls[0] != "cfg-arbiter" {
+		t.Errorf("chairman calls: got %v, want [cfg-arbiter]", rec.chairmanCalls)
+	}
+}
+
+func TestRunClarificationRound_Resolution_MixedCfg(t *testing.T) {
+	// cfg.Models set, cfg.ArbiterModel empty → generators use cfg.Models;
+	// arbiter falls back to ct.ChairmanModel.
+	rec := &stage0Recorder{}
+	c := stage0Fixture(t, []string{"ct-gen-1", "ct-gen-2"}, "ct-chair", rec)
+
+	cfg := ClarificationConfig{
+		MaxRounds:            2,
+		MaxTotalQuestions:    5,
+		MaxQuestionsPerRound: 3,
+		Models:               []string{"cfg-gen-only"},
+		ArbiterModel:         "",
+	}
+
+	if err := c.RunClarificationRound(context.Background(), "q", nil, cfg, "test", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rec.generatorCalls) != 1 || rec.generatorCalls[0] != "cfg-gen-only" {
+		t.Errorf("generator calls: got %v, want [cfg-gen-only]", rec.generatorCalls)
+	}
+	if len(rec.chairmanCalls) != 1 || rec.chairmanCalls[0] != "ct-chair" {
+		t.Errorf("chairman calls: got %v, want [ct-chair] (per-council-type fall-back)", rec.chairmanCalls)
+	}
+}
+
+func TestRunClarificationRound_Resolution_BothCfgFieldsEmpty_LegacyFallthrough(t *testing.T) {
+	rec := &stage0Recorder{}
+	c := stage0Fixture(t, []string{"ct-gen-1", "ct-gen-2"}, "ct-chair", rec)
+
+	cfg := ClarificationConfig{
+		MaxRounds:            2,
+		MaxTotalQuestions:    5,
+		MaxQuestionsPerRound: 3,
+		// Models / ArbiterModel intentionally zero-valued.
+	}
+
+	if err := c.RunClarificationRound(context.Background(), "q", nil, cfg, "test", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotGens := append([]string(nil), rec.generatorCalls...)
+	wantGens := map[string]bool{"ct-gen-1": true, "ct-gen-2": true}
+	if len(gotGens) != 2 {
+		t.Fatalf("generator calls: got %d, want 2 (%v)", len(gotGens), gotGens)
+	}
+	for _, m := range gotGens {
+		if !wantGens[m] {
+			t.Errorf("generator model %q not in expected ct pool", m)
+		}
+	}
+	if len(rec.chairmanCalls) != 1 || rec.chairmanCalls[0] != "ct-chair" {
+		t.Errorf("chairman calls: got %v, want [ct-chair]", rec.chairmanCalls)
+	}
+}
+
+func TestRunClarificationRound_Resolution_NoArbiter_ReturnsLoudError(t *testing.T) {
+	// Both cfg.ArbiterModel and ct.ChairmanModel empty → loud error,
+	// not silent stage0_done.
+	rec := &stage0Recorder{}
+	c := stage0Fixture(t, []string{"ct-gen-1"}, "" /* no chairman */, rec)
+
+	cfg := ClarificationConfig{
+		MaxRounds:            2,
+		MaxTotalQuestions:    5,
+		MaxQuestionsPerRound: 3,
+		// Models / ArbiterModel intentionally zero-valued.
+	}
+
+	var emitted []string
+	err := c.RunClarificationRound(context.Background(), "q", nil, cfg, "test", func(eventType string, _ any) {
+		emitted = append(emitted, eventType)
+	})
+	if err == nil {
+		t.Fatal("expected error when both cfg.ArbiterModel and ct.ChairmanModel are empty")
+	}
+	if !strings.Contains(err.Error(), "arbiter model") {
+		t.Errorf("error message: got %q, want it to mention 'arbiter model'", err.Error())
+	}
+	for _, e := range emitted {
+		if e == "stage0_done" {
+			t.Error("must NOT emit stage0_done on the no-arbiter error path — must surface the error loudly")
+		}
+	}
+}
+
+func TestRunClarificationRound_Resolution_NoGenerators_ReturnsLoudError(t *testing.T) {
+	// Both cfg.Models and ct.Models empty → loud error.
+	rec := &stage0Recorder{}
+	c := stage0Fixture(t, nil /* no ct.Models */, "ct-chair", rec)
+
+	cfg := ClarificationConfig{
+		MaxRounds:            2,
+		MaxTotalQuestions:    5,
+		MaxQuestionsPerRound: 3,
+	}
+
+	err := c.RunClarificationRound(context.Background(), "q", nil, cfg, "test", nil)
+	if err == nil {
+		t.Fatal("expected error when both cfg.Models and ct.Models are empty")
+	}
+	if !strings.Contains(err.Error(), "generator models") {
+		t.Errorf("error message: got %q, want it to mention 'generator models'", err.Error())
 	}
 }

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -166,9 +166,16 @@ type ClarificationRound struct {
 	CouncilType string                  `json:"council_type,omitempty"` // persisted on round-1
 }
 
-// ClarificationConfig holds Stage 0 operational limits.
+// ClarificationConfig holds Stage 0 operational limits and model overrides.
+//
+// Models and ArbiterModel are optional. When non-empty they override the
+// council type's models for Stage 0; when empty the runner falls back to the
+// council type's Models / ChairmanModel respectively. See RunClarificationRound
+// for the resolution chain (env override → per-council-type → error).
 type ClarificationConfig struct {
 	MaxRounds            int
 	MaxTotalQuestions    int
 	MaxQuestionsPerRound int
+	Models               []string // optional; empty = use ct.Models
+	ArbiterModel         string   // optional; empty = use ct.ChairmanModel
 }


### PR DESCRIPTION
## Summary

Stage 0 (clarification) now has its own dedicated model configuration. A cheap fast model can ask clarifying questions while the chosen strategy uses stronger models for the actual deliberation. Existing deployments are unaffected — when the new env vars are unset, Stage 0 falls back to today's behaviour.

Closes #203

## Resolution chain (runtime, in `RunClarificationRound`)

```
generator models : cfg.Models       → ct.Models       → error
arbiter model    : cfg.ArbiterModel  → ct.ChairmanModel → error
```

The errors are loud — `RunClarificationRound` returns explicitly rather than emitting `stage0_done`. Catches misconfiguration (e.g. a future strategy with no `ChairmanModel` registered without setting `CLARIFICATION_ARBITER_MODEL`).

## Why config doesn't pre-fill defaults

The config loader leaves `ClarificationModels` / `ClarificationArbiterModel` empty when their env vars are unset rather than pre-filling from `COUNCIL_MODELS` / `CHAIRMAN_MODEL`. The runner does the resolution. This preserves the per-council-type fall-back hop — which is what "no existing deployments break" actually means.

## What's in

**Backend:**
- `Config` gains `ClarificationModels []string` and `ClarificationArbiterModel string`
- `ClarificationConfig` gains `Models []string` and `ArbiterModel string`
- `RunClarificationRound` resolves the two-step chain and returns loud errors when both hops are empty
- Wired through `cmd/server/main.go`'s `ClarificationConfig` literal

**Tests (210 → was 202):**
- `config_test`: 3 cases — both set, generators-only-set proves loader doesn't pre-fill, both unset
- `runner_test`: 5 cases — all-cfg-set, mixed config split, legacy fall-through, no-arbiter loud error, no-generators loud error

**Docs:**
- `.env.example` documents both vars with the single-model form as primary
- `docs/architecture-v2.md` Stage 0 subsection rewritten with explicit resolution chain
- `docs/strategies.md` updated — singular `CLARIFICATION_MODEL` → plural `CLARIFICATION_MODELS`

## Out of scope

- Per-strategy clarification config (single global Stage 0 config today)
- Stage 0 prompt customisation
- Removing the legacy fall-through (deferred to a future cleanup PR after deployments migrate)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes (210 tests, +8)
- [x] `npm run lint && npm run test` pass (frontend untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)