### PR TITLE
⚖️ feat(council,api,frontend): Majority strategy — independent generation + vote tally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,28 @@ DEFAULT_COUNCIL_TEMPERATURE=0.7
 # ChairmanModel → error. When unset, Stage 0 uses the council type's chairman.
 # CLARIFICATION_ARBITER_MODEL=anthropic/claude-sonnet-4-5
 
+# ── Majority strategy (independent generation + vote tally) ─────────────────
+# Setting MAJORITY_MODELS is what registers the "majority" council type at
+# startup. Without this var, the strategy ships compiled-in but is NOT
+# reachable via the API — clients passing council_type="majority" will get
+# a 404. This is intentional: opt-in registration prevents new strategies
+# from being silently exposed to existing deployments.
+#
+# Voting is exact-match after normalisation (lowercase + trim + collapse
+# whitespace). Best for factual QA, classification, math — tasks with a clear
+# correct answer that voting can extract from generation noise. ≥3 models
+# recommended (the default quorum requires it).
+#
+# MAJORITY_MODELS=openai/gpt-4o-mini,anthropic/claude-haiku-4-5,google/gemini-flash-1.5
+
+# Optional chairman for the Majority strategy. Used for two purposes:
+#   1. Polish — when there's a clear plurality winner, the chairman polishes
+#      its prose for clarity. Without a chairman, the winner is emitted verbatim.
+#   2. Tiebreak — when top clusters are tied, the chairman picks among them.
+#      Without a chairman, ties cause a loud error rather than a silent pick.
+# When unset, MAJORITY_CHAIRMAN_MODEL falls back to CHAIRMAN_MODEL.
+# MAJORITY_CHAIRMAN_MODEL=anthropic/claude-sonnet-4-5
+
 # ── Storage ─────────────────────────────────────────────────────────────────
 # Directory where conversation JSON files are stored.
 # Created automatically if it does not exist. Default: data/conversations

--- a/.env.example
+++ b/.env.example
@@ -97,10 +97,14 @@ DEFAULT_COUNCIL_TEMPERATURE=0.7
 
 # Optional chairman for the Majority strategy. Used for two purposes:
 #   1. Polish — when there's a clear plurality winner, the chairman polishes
-#      its prose for clarity. Without a chairman, the winner is emitted verbatim.
+#      its prose for clarity. Without a chairman, the winner is emitted verbatim
+#      (StageThreeResult{Model: "", DurationMs: 0} — no LLM call).
 #   2. Tiebreak — when top clusters are tied, the chairman picks among them.
 #      Without a chairman, ties cause a loud error rather than a silent pick.
-# When unset, MAJORITY_CHAIRMAN_MODEL falls back to CHAIRMAN_MODEL.
+# Unlike most other strategy chairman fields, MAJORITY_CHAIRMAN_MODEL does
+# NOT fall back to CHAIRMAN_MODEL — it stays empty when unset, so the
+# no-chairman behaviour is reachable. Set this only if you want chairman polish
+# or tiebreak.
 # MAJORITY_CHAIRMAN_MODEL=anthropic/claude-sonnet-4-5
 
 # ── Storage ─────────────────────────────────────────────────────────────────

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -108,16 +108,14 @@ func run() error {
 	}
 	// Mirror cmd/server's opt-in Majority registration so eval can target
 	// the strategy via -council-type majority when MAJORITY_MODELS is set.
+	// ChairmanModel is NOT defaulted to the global CHAIRMAN_MODEL — see
+	// cmd/server/main.go for the rationale.
 	if len(cfg.MajorityModels) > 0 {
-		majorityChairman := cfg.MajorityChairmanModel
-		if majorityChairman == "" {
-			majorityChairman = cfg.DefaultCouncilChairmanModel
-		}
 		registry["majority"] = council.CouncilType{
 			Name:          "majority",
 			Strategy:      council.Majority,
 			Models:        cfg.MajorityModels,
-			ChairmanModel: majorityChairman,
+			ChairmanModel: cfg.MajorityChairmanModel,
 			Temperature:   cfg.DefaultCouncilTemperature,
 		}
 	}

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -106,6 +106,21 @@ func run() error {
 			Temperature:   cfg.DefaultCouncilTemperature,
 		},
 	}
+	// Mirror cmd/server's opt-in Majority registration so eval can target
+	// the strategy via -council-type majority when MAJORITY_MODELS is set.
+	if len(cfg.MajorityModels) > 0 {
+		majorityChairman := cfg.MajorityChairmanModel
+		if majorityChairman == "" {
+			majorityChairman = cfg.DefaultCouncilChairmanModel
+		}
+		registry["majority"] = council.CouncilType{
+			Name:          "majority",
+			Strategy:      council.Majority,
+			Models:        cfg.MajorityModels,
+			ChairmanModel: majorityChairman,
+			Temperature:   cfg.DefaultCouncilTemperature,
+		}
+	}
 	if _, ok := registry[*councilType]; !ok {
 		return fmt.Errorf("unknown council type %q (known: %v)", *councilType, knownTypes(registry))
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -45,6 +45,24 @@ func main() {
 		},
 	}
 
+	// Majority strategy registration is opt-in: it's only added to the
+	// registry when MAJORITY_MODELS is explicitly set. Existing deployments
+	// without the env var don't get the new council type silently exposed.
+	// The chairman model is optional and falls back to the global default.
+	if len(cfg.MajorityModels) > 0 {
+		majorityChairman := cfg.MajorityChairmanModel
+		if majorityChairman == "" {
+			majorityChairman = cfg.DefaultCouncilChairmanModel
+		}
+		registry["majority"] = council.CouncilType{
+			Name:          "majority",
+			Strategy:      council.Majority,
+			Models:        cfg.MajorityModels,
+			ChairmanModel: majorityChairman,
+			Temperature:   cfg.DefaultCouncilTemperature,
+		}
+	}
+
 	client := openrouter.NewClient(cfg.OpenRouterAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger)
 	runner := council.NewCouncil(client, registry, logger)
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -48,17 +48,18 @@ func main() {
 	// Majority strategy registration is opt-in: it's only added to the
 	// registry when MAJORITY_MODELS is explicitly set. Existing deployments
 	// without the env var don't get the new council type silently exposed.
-	// The chairman model is optional and falls back to the global default.
+	//
+	// The chairman model is genuinely optional. It is NOT defaulted to the
+	// global CHAIRMAN_MODEL — config.Load() always populates that with a
+	// dev-fallback, so falling back here would make Majority's no-chairman
+	// path (verbatim winner emission, loud-error on tie) unreachable. Users
+	// who want a chairman for tiebreak/polish must set MAJORITY_CHAIRMAN_MODEL.
 	if len(cfg.MajorityModels) > 0 {
-		majorityChairman := cfg.MajorityChairmanModel
-		if majorityChairman == "" {
-			majorityChairman = cfg.DefaultCouncilChairmanModel
-		}
 		registry["majority"] = council.CouncilType{
 			Name:          "majority",
 			Strategy:      council.Majority,
 			Models:        cfg.MajorityModels,
-			ChairmanModel: majorityChairman,
+			ChairmanModel: cfg.MajorityChairmanModel,
 			Temperature:   cfg.DefaultCouncilTemperature,
 		}
 	}

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -153,6 +153,24 @@ default:         return fmt.Errorf("council: strategy %d not implemented", ct.St
 3. **Stage 2** — skipped. A minimal `Stage2CompleteData{Results:[], Metadata:{AggregateRankings:[], ConsensusW:1.0}}` event is emitted for SSE compatibility.
 4. **Stage 3** — `runRoleBasedStage3`: chairman synthesises across all role findings.
 
+#### `Majority` pipeline (2 stages, no LLM Stage 2)
+
+Implemented in `internal/council/majority.go`. Best for factual QA, classification, and math.
+
+1. **Stage 1** — `runStage1` (reused): all council models run concurrently. Anonymous `Response A`/`B`/… labels assigned via `assignLabels` for SSE consistency with PeerReview.
+2. **Quorum check** — `runMajority` resolves `need := ct.QuorumMin; if need == 0 { need = max(3, ⌈N/2⌉+1) }` inline before calling `checkQuorumWith`. Need ≥3 successful answers by default to break ties cleanly.
+3. **Vote tally** — `buildVoteTally`: pure function over Stage 1 results, no LLM call. Clusters answers by **exact-match after normalisation** (lowercase + trim + collapse internal whitespace). Cluster output is sorted by votes descending, then by representative ascending for stable ordering. Emits `Stage2CompleteData{Kind: "vote_tally", Results: [], Metadata: {..., VoteTally: ...}}`.
+4. **Stage 3** — `runMajorityStage3` selects the final answer based on tie state and chairman config:
+
+   | Tie? | Chairman set? | Result |
+   |------|---------------|--------|
+   | No   | No            | Winning cluster's `Representative` emitted verbatim. `StageThreeResult{Model: "", DurationMs: 0}` — empty `Model` is the documented "no LLM call" signal. |
+   | No   | Yes           | Chairman polishes the winner via `BuildMajorityPolishPrompt` (refines prose only, must not change substance). |
+   | Yes  | Yes           | Chairman picks among tied candidates via `BuildMajorityTiebreakPrompt`. |
+   | Yes  | No            | **Loud error** — `runMajority` returns rather than picking arbitrarily. Matches the loud-failure pattern in Stage 0 (PR #204). |
+
+Voting variants beyond exact-match (cluster-by-embedding, Borda count, Tournament/Elo, weighted voting) are explicit follow-ups. Registration is opt-in: the `"majority"` council type is added to the registry only when `MAJORITY_MODELS` is set in the environment.
+
 #### Per-registration model configuration
 
 Every `CouncilType` registration is independent. Two registrations with the same `Strategy` but different `Models` / `ChairmanModel` are valid — e.g. `"factual-majority"` and `"creative-majority"` both use `Strategy: Majority` with different voter pools. Each strategy has its own namespaced env var family (`MAJORITY_MODELS`, `MAJORITY_CHAIRMAN_MODEL`, `DEBATE_MODELS`, etc.) with fall-through to `COUNCIL_MODELS` / `CHAIRMAN_MODEL` when unset; see [`strategies.md`](./strategies.md) for the full table. Plumbing lands with each strategy's implementation PR.

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -30,7 +30,7 @@ Each registration in `cmd/server/main.go` and `cmd/eval/main.go` carries its own
 |----------|--------------------------|---------------------------------|----------------|--------------|
 | `PeerReview` | Council members (generators + reviewers) | Stage 3 synthesiser | `COUNCIL_MODELS` / `CHAIRMAN_MODEL` | — (these are the defaults) |
 | `RoleBased` | Pool assigned to roles by `i % len(Models)` | Synthesiser across role findings | (none today; roles config is in code) | — |
-| `Majority` | Voters | Tiebreaker (optional; `""` = no tiebreak) | `MAJORITY_MODELS` / `MAJORITY_CHAIRMAN_MODEL` | `COUNCIL_MODELS` / `CHAIRMAN_MODEL` |
+| `Majority` | Voters | Tiebreaker / polish (optional; `""` = no tiebreak, ties error) | `MAJORITY_MODELS` (required to register) / `MAJORITY_CHAIRMAN_MODEL` (optional) | none — registration is opt-in via `MAJORITY_MODELS`; chairman stays empty when unset (so the no-chairman path is reachable) |
 | `GenerateRankRefine` | Generators | Ranker + refiner (single model today) | `GENERATE_RANK_REFINE_MODELS` / `GENERATE_RANK_REFINE_CHAIRMAN_MODEL` | `COUNCIL_MODELS` / `CHAIRMAN_MODEL` |
 | `MultiAgentDebate` | Debaters | Synthesiser | `DEBATE_MODELS` / `DEBATE_CHAIRMAN_MODEL` | `COUNCIL_MODELS` / `CHAIRMAN_MODEL` |
 | `MixtureOfAgents` | (see below — 3 layers) | Refiner (or `""` to use `RefinerModel` field) | `MOA_PROPOSER_MODELS` / `MOA_AGGREGATOR_MODELS` / `MOA_REFINER_MODEL` | `COUNCIL_MODELS` for proposers; `CHAIRMAN_MODEL` for refiner |

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -14,7 +14,7 @@ Stage 0 (clarification) runs **before** strategy dispatch and is strategy-indepe
 |----------|--------|---------------|-------------------|
 | `PeerReview` | shipped | `runner.go:runPeerReview` | initial |
 | `RoleBased` | shipped | `rolebased.go:runRoleBased` | #177 |
-| `Majority` | planned | — | TBD |
+| `Majority` | shipped | `majority.go:runMajority` | #205 |
 | `GenerateRankRefine` | planned | — | TBD |
 | `MultiAgentDebate` | planned | — | TBD |
 | `MixtureOfAgents` | planned | — | TBD |
@@ -99,7 +99,7 @@ PeerReview's existing payload corresponds to `kind: "peer_ranking"`; RoleBased's
 |------|----------|--------|--------------|-------------------|
 | `peer_ranking` | `PeerReview` | **shipped** | `[]StageTwoResult` — each reviewer's ranked label list | always `0` |
 | `role_stub` | `RoleBased` | **shipped** | `[]` — empty; metadata carries `aggregate_rankings: []`, `consensus_w: 1.0` | always `0` |
-| `vote_tally` | `Majority` | **reserved** | per-candidate vote counts (or weighted scores), winner identifier, optional cluster groupings | always `0` |
+| `vote_tally` | `Majority` | **shipped** | `metadata.vote_tally` is a `VoteTally` (`{clusters: VoteCluster[], winner_label: string}`); `data` is `[]` (Majority does not produce per-reviewer Stage 2 results). `VoteCluster` is `{members: string[], representative: string, votes: int}`. Clusters are sorted by votes desc, then representative asc. | always `0` |
 | `rank_refine` | `GenerateRankRefine` | **reserved** | ranked candidate list with criterion scores; top-K subset that proceeds to refinement | always `0` |
 | `debate_round` | `MultiAgentDebate` | **reserved** | per-debater critique-and-revise output for the current round; references to the round's targets | `1..N`; one event per round, then a final `stage2_complete` with summary |
 | `moa_aggregator` | `MixtureOfAgents` | **reserved** | Layer-2 aggregator outputs; references to which Layer-1 proposers fed each aggregator | always `0` (single aggregator pass) |

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -133,6 +133,7 @@ export default function ChatInterface({
                     labelToModel={msg.metadata?.label_to_model}
                     aggregateRankings={msg.metadata?.aggregate_rankings}
                     consensusW={msg.metadata?.consensus_w}
+                    voteTally={msg.metadata?.vote_tally}
                     isLoading={msg.loading?.stage2}
                   />
 

--- a/frontend/src/components/Stage2.css
+++ b/frontend/src/components/Stage2.css
@@ -126,3 +126,100 @@
   font-size: 12px;
   font-family: monospace;
 }
+
+/* Vote-tally view (Majority strategy) */
+
+.vote-tally {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.vote-cluster {
+  padding: 10px 12px;
+  background: var(--bg-stage);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+  position: relative;
+}
+
+.vote-cluster.winner {
+  border-color: var(--accent);
+  background: linear-gradient(
+    to right,
+    color-mix(in srgb, var(--accent) 12%, var(--bg-stage)) 0%,
+    var(--bg-stage) 100%
+  );
+}
+
+.vote-cluster-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.vote-bar-track {
+  flex: 1;
+  height: 4px;
+  background: var(--border-color);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.vote-bar-fill {
+  height: 100%;
+  background: var(--text-muted);
+  transition: width 200ms ease-out;
+}
+
+.vote-cluster.winner .vote-bar-fill {
+  background: var(--accent);
+}
+
+.vote-count {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: monospace;
+  font-weight: 600;
+  min-width: 60px;
+  text-align: right;
+}
+
+.vote-winner-mark {
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 14px;
+  margin-right: 4px;
+}
+
+.vote-representative {
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.vote-representative.collapsed {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.vote-expand-btn {
+  margin-top: 6px;
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.vote-expand-btn:hover {
+  color: color-mix(in srgb, var(--accent) 80%, var(--text-primary));
+}

--- a/frontend/src/components/Stage2.jsx
+++ b/frontend/src/components/Stage2.jsx
@@ -110,6 +110,91 @@ function PeerRankingView({ rankings, labelToModel, aggregateRankings, consensusW
   );
 }
 
+// VoteTallyView renders the Majority strategy's Stage 2 payload as a vertical
+// list of clusters, each with a horizontal bar proportional to vote count.
+// The winning cluster (the first in the sorted list, by buildVoteTally
+// invariant) is highlighted with an accent border and ✓ marker. Long cluster
+// representatives are truncated to two lines with click-to-expand.
+const REPRESENTATIVE_TRUNCATE_THRESHOLD = 140;
+
+function VoteCluster({ cluster, isWinner, totalVotes }) {
+  const [expanded, setExpanded] = useState(false);
+  const ratio = totalVotes > 0 ? cluster.votes / totalVotes : 0;
+  const widthPct = Math.max(2, Math.round(ratio * 100));
+  const longText = (cluster.representative ?? '').length > REPRESENTATIVE_TRUNCATE_THRESHOLD;
+
+  return (
+    <div className={`vote-cluster${isWinner ? ' winner' : ''}`}>
+      <div className="vote-cluster-header">
+        {isWinner && <span className="vote-winner-mark" aria-label="winner">✓</span>}
+        <div className="vote-bar-track" aria-hidden="true">
+          <div className="vote-bar-fill" style={{ width: `${widthPct}%` }} />
+        </div>
+        <div className="vote-count">
+          {cluster.votes} {cluster.votes === 1 ? 'vote' : 'votes'}
+        </div>
+      </div>
+      <div className={`vote-representative${longText && !expanded ? ' collapsed' : ''}`}>
+        {cluster.representative}
+      </div>
+      {longText && (
+        <button
+          type="button"
+          className="vote-expand-btn"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+        >
+          {expanded ? 'Show less' : 'Show full answer'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function VoteTallyView({ voteTally, isLoading }) {
+  if (isLoading) {
+    return (
+      <div className="stage stage2">
+        <div className="stage-accordion" aria-disabled="true">
+          <span className="stage-accordion-label">
+            <span className="spinner-sm" />
+            Tallying votes…
+          </span>
+        </div>
+      </div>
+    );
+  }
+  if (!voteTally || !voteTally.clusters || voteTally.clusters.length === 0) {
+    return null;
+  }
+  const totalVotes = voteTally.clusters.reduce((sum, c) => sum + (c.votes ?? 0), 0);
+  const winnerLabel = voteTally.winner_label;
+
+  return (
+    <div className="stage stage2">
+      <div className="stage-accordion" aria-disabled="true">
+        <span className="stage-accordion-label">Stage 2: Vote Tally</span>
+      </div>
+      <div className="stage-body">
+        <div className="vote-tally">
+          {voteTally.clusters.map((cluster, index) => {
+            const isWinner =
+              index === 0 || (winnerLabel && cluster.members?.includes(winnerLabel));
+            return (
+              <VoteCluster
+                key={index}
+                cluster={cluster}
+                isWinner={Boolean(isWinner) && index === 0}
+                totalVotes={totalVotes}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // RoleStubView renders a minimal placeholder for the RoleBased strategy,
 // where Stage 2 has no peer-ranking content (roles are complementary).
 function RoleStubView({ isLoading }) {
@@ -159,7 +244,7 @@ function UnknownKindView({ kind }) {
 // undefined / empty / whitespace-only (e.g. an older backend that doesn't
 // emit kind, or a malformed event), we default to peer_ranking because that
 // was the only persisted Stage 2 shape before this PR.
-export default function Stage2({ kind, rankings, labelToModel, aggregateRankings, consensusW, isLoading }) {
+export default function Stage2({ kind, rankings, labelToModel, aggregateRankings, consensusW, voteTally, isLoading }) {
   const trimmed = typeof kind === 'string' ? kind.trim() : '';
   const effectiveKind = trimmed || 'peer_ranking';
 
@@ -176,6 +261,8 @@ export default function Stage2({ kind, rankings, labelToModel, aggregateRankings
       );
     case 'role_stub':
       return <RoleStubView isLoading={isLoading} />;
+    case 'vote_tally':
+      return <VoteTallyView voteTally={voteTally} isLoading={isLoading} />;
     default:
       return <UnknownKindView kind={effectiveKind} />;
   }

--- a/frontend/src/components/Stage2.test.jsx
+++ b/frontend/src/components/Stage2.test.jsx
@@ -36,10 +36,12 @@ describe('Stage2 dispatcher', () => {
   });
 
   it('routes an unknown kind to the unknown-kind view, surfacing the kind name', () => {
-    render(<Stage2 kind="vote_tally" isLoading={false} />);
+    // Use one of the still-unimplemented reserved kinds (debate_round) — vote_tally
+    // is shipped now, so the unknown-kind view test must use a kind that's still
+    // reserved.
+    render(<Stage2 kind="debate_round" isLoading={false} />);
     expect(screen.getByText(/view not implemented yet/i)).toBeInTheDocument();
-    // The kind name itself must be visible (inside a <code> element).
-    expect(screen.getByText('vote_tally')).toBeInTheDocument();
+    expect(screen.getByText('debate_round')).toBeInTheDocument();
   });
 
   it('defaults to peer_ranking when kind is undefined (old-backend safety net)', () => {
@@ -56,5 +58,71 @@ describe('Stage2 dispatcher', () => {
     );
     // Falls through to PeerRankingView even though kind is undefined.
     expect(screen.getByText(/Stage 2: Peer Rankings/i)).toBeInTheDocument();
+  });
+
+  describe('VoteTallyView (kind="vote_tally")', () => {
+    it('renders all clusters with the winner highlighted', () => {
+      render(
+        <Stage2
+          kind="vote_tally"
+          voteTally={{
+            winner_label: 'Response A',
+            clusters: [
+              { members: ['Response A', 'Response B'], representative: 'yes', votes: 2 },
+              { members: ['Response C'], representative: 'no', votes: 1 },
+              { members: ['Response D'], representative: 'maybe', votes: 1 },
+            ],
+          }}
+          isLoading={false}
+        />,
+      );
+      expect(screen.getByText(/Stage 2: Vote Tally/i)).toBeInTheDocument();
+      // Winner cluster shows the ✓ marker.
+      expect(screen.getByLabelText(/winner/i)).toBeInTheDocument();
+      // Vote counts visible.
+      expect(screen.getByText(/2 votes/i)).toBeInTheDocument();
+      // 'maybe' and 'no' both at 1 vote — getAllByText handles plural.
+      expect(screen.getAllByText(/1 vote(?!s)/i).length).toBeGreaterThanOrEqual(2);
+      // All three representatives present.
+      expect(screen.getByText('yes')).toBeInTheDocument();
+      expect(screen.getByText('no')).toBeInTheDocument();
+      expect(screen.getByText('maybe')).toBeInTheDocument();
+    });
+
+    it('renders a unanimous (single-cluster) tally', () => {
+      render(
+        <Stage2
+          kind="vote_tally"
+          voteTally={{
+            winner_label: 'Response A',
+            clusters: [
+              { members: ['Response A', 'Response B', 'Response C'], representative: '42', votes: 3 },
+            ],
+          }}
+          isLoading={false}
+        />,
+      );
+      expect(screen.getByText(/Stage 2: Vote Tally/i)).toBeInTheDocument();
+      expect(screen.getByText(/3 votes/i)).toBeInTheDocument();
+      expect(screen.getByText('42')).toBeInTheDocument();
+      // Exactly one winner marker on a unanimous tally.
+      expect(screen.getAllByLabelText(/winner/i)).toHaveLength(1);
+    });
+
+    it('truncates long representative content with a Show full answer button', () => {
+      const longText =
+        'This is a long representative answer that exceeds the truncation threshold so the dispatcher exposes a Show full answer button — '.repeat(2);
+      render(
+        <Stage2
+          kind="vote_tally"
+          voteTally={{
+            winner_label: 'Response A',
+            clusters: [{ members: ['Response A'], representative: longText, votes: 3 }],
+          }}
+          isLoading={false}
+        />,
+      );
+      expect(screen.getByRole('button', { name: /Show full answer/i })).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/Stage3.jsx
+++ b/frontend/src/components/Stage3.jsx
@@ -10,7 +10,7 @@ export default function Stage3({ finalResponse, error }) {
     <div className="stage3-hero">
       <div className="stage3-header">
         <span className="stage3-label">Final Answer</span>
-        {finalResponse && (
+        {finalResponse?.model && (
           <span className="stage3-model">
             {finalResponse.model.split('/')[1] || finalResponse.model}
           </span>

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -642,6 +642,70 @@ func TestSendMessageStream(t *testing.T) {
 			},
 		},
 		{
+			name:   "Majority strategy emits kind=vote_tally on the wire",
+			body:   `{"content":"q","council_type":"majority"}`,
+			storer: okStorer(),
+			runner: &mockRunner{
+				runFull: func(ctx context.Context, query, ct string, onEvent council.EventFunc) error {
+					onEvent("stage1_complete", []council.StageOneResult{
+						{Label: "Response A", Content: "yes", Model: "openai/gpt-4o-mini"},
+						{Label: "Response B", Content: "yes", Model: "anthropic/claude-haiku-4-5"},
+						{Label: "Response C", Content: "no", Model: "google/gemini-flash-1.5"},
+					})
+					tally := &council.VoteTally{
+						Clusters: []council.VoteCluster{
+							{Members: []string{"Response A", "Response B"}, Representative: "yes", Votes: 2},
+							{Members: []string{"Response C"}, Representative: "no", Votes: 1},
+						},
+						WinnerLabel: "Response A",
+					}
+					onEvent("stage2_complete", council.Stage2CompleteData{
+						Kind:    "vote_tally",
+						Results: []council.StageTwoResult{},
+						Metadata: council.Metadata{
+							CouncilType:       "majority",
+							LabelToModel:      map[string]string{"Response A": "openai/gpt-4o-mini"},
+							AggregateRankings: []council.RankedModel{},
+							ConsensusW:        1.0,
+							VoteTally:         tally,
+						},
+					})
+					onEvent("stage3_complete", council.StageThreeResult{Content: "yes"}) // no LLM call → empty Model
+					return nil
+				},
+			},
+			wantCode: http.StatusOK,
+			checkSSE: func(t *testing.T, body string) {
+				for _, line := range strings.Split(body, "\n") {
+					if !strings.HasPrefix(line, "data: ") {
+						continue
+					}
+					var env struct {
+						Type     string           `json:"type"`
+						Kind     string           `json:"kind"`
+						Metadata council.Metadata `json:"metadata"`
+					}
+					if err := json.Unmarshal([]byte(line[6:]), &env); err != nil || env.Type != "stage2_complete" {
+						continue
+					}
+					if env.Kind != "vote_tally" {
+						t.Errorf("kind: got %q, want %q", env.Kind, "vote_tally")
+					}
+					if env.Metadata.VoteTally == nil {
+						t.Fatalf("metadata.vote_tally: nil; expected populated")
+					}
+					if env.Metadata.VoteTally.WinnerLabel != "Response A" {
+						t.Errorf("winner_label: got %q, want %q", env.Metadata.VoteTally.WinnerLabel, "Response A")
+					}
+					if len(env.Metadata.VoteTally.Clusters) != 2 {
+						t.Errorf("clusters: got %d, want 2", len(env.Metadata.VoteTally.Clusters))
+					}
+					return
+				}
+				t.Errorf("no stage2_complete event found in body: %s", body)
+			},
+		},
+		{
 			name:   "QuorumError emits error event",
 			body:   `{"content":"test","council_type":"standard"}`,
 			storer: okStorer(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,13 @@ type Config struct {
 	ClarificationModels       []string
 	ClarificationArbiterModel string
 
+	// Majority strategy registration. Setting MajorityModels is what registers
+	// the "majority" council type — without it, the strategy ships compiled-in
+	// but is not reachable via the API. MajorityChairmanModel is optional;
+	// when empty, ties cause a loud error rather than silent tiebreak.
+	MajorityModels        []string
+	MajorityChairmanModel string
+
 	// LLMAPIMaxRetries is the number of retries the OpenRouter client attempts
 	// on transient failures (HTTP 429/502/503/504, network timeouts, EOFs).
 	// 0 disables retries. Default: 2 (3 total attempts including the initial).
@@ -155,6 +162,22 @@ func Load() (*Config, error) {
 	// than as a non-empty model ID that would skip the fall-back.
 	clarificationArbiterModel := strings.TrimSpace(os.Getenv("CLARIFICATION_ARBITER_MODEL"))
 
+	// Majority strategy generator pool. Empty slice when unset — registration
+	// in cmd/server/main.go uses non-empty as the opt-in signal.
+	var majorityModels []string
+	if raw := os.Getenv("MAJORITY_MODELS"); raw != "" {
+		for _, m := range strings.Split(raw, ",") {
+			if m = strings.TrimSpace(m); m != "" {
+				majorityModels = append(majorityModels, m)
+			}
+		}
+	}
+
+	// Majority strategy chairman (optional — for tiebreak/polish). Trim like
+	// CLARIFICATION_ARBITER_MODEL so accidental whitespace doesn't bypass the
+	// "no chairman" loud-error path on ties.
+	majorityChairmanModel := strings.TrimSpace(os.Getenv("MAJORITY_CHAIRMAN_MODEL"))
+
 	llmAPIMaxRetries := 2
 	if raw := os.Getenv("LLM_API_MAX_RETRIES"); raw != "" {
 		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
@@ -180,6 +203,9 @@ func Load() (*Config, error) {
 		ClarificationMaxQuestionsPerRound: clarificationMaxQuestionsPerRound,
 		ClarificationModels:               clarificationModels,
 		ClarificationArbiterModel:         clarificationArbiterModel,
+
+		MajorityModels:        majorityModels,
+		MajorityChairmanModel: majorityChairmanModel,
 
 		LLMAPIMaxRetries: llmAPIMaxRetries,
 	}, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -221,3 +221,69 @@ func TestLoad_ClarificationModels_BothUnset_FieldsEmpty(t *testing.T) {
 		t.Errorf("ClarificationArbiterModel: got %q, want empty (legacy fall-through path)", cfg.ClarificationArbiterModel)
 	}
 }
+
+// ── TestLoad_MajorityModels ───────────────────────────────────────────────
+//
+// Setting MAJORITY_MODELS is what registers the "majority" council type at
+// startup; the loader leaves the field empty when unset (no pre-fill from
+// COUNCIL_MODELS). MAJORITY_CHAIRMAN_MODEL is optional.
+
+func TestLoad_MajorityModels_BothSet(t *testing.T) {
+	baseEnv(t)
+	setenv(t, "MAJORITY_MODELS", "openai/gpt-4o-mini, anthropic/claude-haiku-4-5, google/gemini-flash-1.5")
+	setenv(t, "MAJORITY_CHAIRMAN_MODEL", "anthropic/claude-sonnet-4-5")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"openai/gpt-4o-mini", "anthropic/claude-haiku-4-5", "google/gemini-flash-1.5"}
+	if len(cfg.MajorityModels) != len(want) {
+		t.Fatalf("MajorityModels: got %v, want %v", cfg.MajorityModels, want)
+	}
+	for i, m := range want {
+		if cfg.MajorityModels[i] != m {
+			t.Errorf("MajorityModels[%d]: got %q, want %q", i, cfg.MajorityModels[i], m)
+		}
+	}
+	if cfg.MajorityChairmanModel != "anthropic/claude-sonnet-4-5" {
+		t.Errorf("MajorityChairmanModel: got %q, want %q", cfg.MajorityChairmanModel, "anthropic/claude-sonnet-4-5")
+	}
+}
+
+func TestLoad_MajorityModels_GeneratorsSet_ChairmanUnset(t *testing.T) {
+	baseEnv(t)
+	setenv(t, "MAJORITY_MODELS", "openai/gpt-4o-mini")
+	unsetenv(t, "MAJORITY_CHAIRMAN_MODEL")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.MajorityModels) != 1 || cfg.MajorityModels[0] != "openai/gpt-4o-mini" {
+		t.Errorf("MajorityModels: got %v, want [openai/gpt-4o-mini]", cfg.MajorityModels)
+	}
+	if cfg.MajorityChairmanModel != "" {
+		t.Errorf("MajorityChairmanModel: got %q, want empty (chairman is optional for Majority)", cfg.MajorityChairmanModel)
+	}
+}
+
+func TestLoad_MajorityModels_BothUnset(t *testing.T) {
+	baseEnv(t)
+	unsetenv(t, "MAJORITY_MODELS")
+	unsetenv(t, "MAJORITY_CHAIRMAN_MODEL")
+	// Pre-fill council defaults to prove the loader does NOT pre-fill from them.
+	setenv(t, "COUNCIL_MODELS", "model-a,model-b")
+	setenv(t, "CHAIRMAN_MODEL", "chairman-z")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.MajorityModels) != 0 {
+		t.Errorf("MajorityModels: got %v, want empty (registration is opt-in)", cfg.MajorityModels)
+	}
+	if cfg.MajorityChairmanModel != "" {
+		t.Errorf("MajorityChairmanModel: got %q, want empty", cfg.MajorityChairmanModel)
+	}
+}

--- a/internal/council/majority.go
+++ b/internal/council/majority.go
@@ -1,0 +1,217 @@
+package council
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// runMajority executes the Majority strategy: parallel generation → vote tally
+// (no LLM call) → Stage 3 winner emission, with optional chairman polish.
+//
+// Voting is exact-match after normalisation. The plurality winner — the cluster
+// with the most votes — is the final answer. Ties require a chairman model;
+// without one the runner returns a loud error rather than picking arbitrarily.
+func (c *Council) runMajority(ctx context.Context, query string, ct CouncilType, onEvent EventFunc) error {
+	if len(ct.Models) == 0 {
+		return fmt.Errorf("council type %q has no models configured", ct.Name)
+	}
+
+	// Stage 1: parallel generation. Reuse runStage1 — Majority's Stage 1 has
+	// no peer-review-specific shape; one answer per model is exactly what
+	// runStage1 produces.
+	allStage1 := c.runStage1(ctx, query, ct.Models, ct.Temperature)
+
+	// Quorum: Majority needs ≥3 successful answers by default to break ties cleanly.
+	// Per-registration QuorumMin (when non-zero) overrides.
+	need := ct.QuorumMin
+	if need == 0 {
+		n := len(allStage1)
+		need = max(3, (n+1)/2+1)
+	}
+	successful, err := checkQuorumWith(allStage1, need)
+	if err != nil {
+		return err
+	}
+
+	// Assign anonymous labels so the on-the-wire payload is consistent with
+	// PeerReview shape; the frontend treats Stage 1 the same way.
+	successfulModels := make([]string, len(successful))
+	for i, r := range successful {
+		successfulModels[i] = r.Model
+	}
+	labelToModel, modelToLabel := assignLabels(successfulModels)
+	for i := range successful {
+		successful[i].Label = modelToLabel[successful[i].Model]
+	}
+
+	if onEvent != nil {
+		onEvent("stage1_complete", successful)
+	}
+
+	// Vote tally — pure function over Stage 1 results; no LLM call.
+	tally := buildVoteTally(successful)
+
+	metadata := Metadata{
+		CouncilType:       ct.Name,
+		LabelToModel:      labelToModel,
+		AggregateRankings: []RankedModel{}, // not used by Majority
+		ConsensusW:        1.0,             // 1.0 when winner cluster covers all voters; we leave it at 1.0 here
+		VoteTally:         tally,
+	}
+
+	if onEvent != nil {
+		onEvent("stage2_complete", Stage2CompleteData{
+			Kind:     "vote_tally",
+			Results:  []StageTwoResult{},
+			Metadata: metadata,
+		})
+	}
+
+	// Stage 3: emit the winner. Behaviour depends on tie state and chairman config.
+	stage3, err := c.runMajorityStage3(ctx, query, tally, ct.ChairmanModel, ct.Temperature)
+	if err != nil {
+		return err
+	}
+	if onEvent != nil {
+		onEvent("stage3_complete", stage3)
+	}
+	return nil
+}
+
+// checkQuorumWith is a thin wrapper that calls the existing checkQuorum with
+// an explicit need value (zero-valued QuorumMin would otherwise re-derive
+// the formula, which is strategy-agnostic). Strategies whose default formula
+// differs from max(2, ⌈N/2⌉+1) must resolve their own need first.
+func checkQuorumWith(results []StageOneResult, need int) ([]StageOneResult, error) {
+	var successful []StageOneResult
+	for _, r := range results {
+		if r.Error == nil {
+			successful = append(successful, r)
+		}
+	}
+	if len(successful) < need {
+		return nil, &QuorumError{Got: len(successful), Need: need}
+	}
+	return successful, nil
+}
+
+// normaliseAnswer prepares a Stage 1 answer for exact-match clustering:
+// lowercase, trim leading/trailing whitespace, collapse internal whitespace
+// runs to a single space.
+func normaliseAnswer(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// buildVoteTally clusters the Stage 1 answers by normalised content and
+// produces a VoteTally with deterministic ordering: clusters sorted by votes
+// descending, then by Representative ascending for stable output across runs.
+//
+// WinnerLabel is the first member of the highest-vote cluster (which itself
+// is sorted by Members order, mirroring Stage 1's input order). Tie detection
+// is the caller's responsibility — buildVoteTally does not flag ties.
+func buildVoteTally(stage1 []StageOneResult) *VoteTally {
+	if len(stage1) == 0 {
+		return &VoteTally{Clusters: []VoteCluster{}}
+	}
+
+	byNorm := make(map[string]*VoteCluster)
+	order := make([]string, 0)
+	for _, r := range stage1 {
+		key := normaliseAnswer(r.Content)
+		if existing, ok := byNorm[key]; ok {
+			existing.Members = append(existing.Members, r.Label)
+			existing.Votes++
+			continue
+		}
+		byNorm[key] = &VoteCluster{
+			Members:        []string{r.Label},
+			Representative: r.Content,
+			Votes:          1,
+		}
+		order = append(order, key)
+	}
+
+	clusters := make([]VoteCluster, 0, len(byNorm))
+	for _, key := range order {
+		clusters = append(clusters, *byNorm[key])
+	}
+	sort.SliceStable(clusters, func(i, j int) bool {
+		if clusters[i].Votes != clusters[j].Votes {
+			return clusters[i].Votes > clusters[j].Votes
+		}
+		return clusters[i].Representative < clusters[j].Representative
+	})
+
+	winner := ""
+	if len(clusters[0].Members) > 0 {
+		winner = clusters[0].Members[0]
+	}
+	return &VoteTally{Clusters: clusters, WinnerLabel: winner}
+}
+
+// runMajorityStage3 produces the final answer from a vote tally:
+//
+//   - No tie + no chairman → emit the winning cluster's content verbatim;
+//     Model is empty, DurationMs is 0 (no LLM call).
+//   - No tie + chairman    → chairman polishes the winner; Model is the
+//     chairman ID, DurationMs is the call duration.
+//   - Tie    + chairman    → chairman picks among tied candidates.
+//   - Tie    + no chairman → loud error.
+func (c *Council) runMajorityStage3(ctx context.Context, query string, tally *VoteTally, chairmanModel string, temperature float64) (StageThreeResult, error) {
+	if tally == nil || len(tally.Clusters) == 0 {
+		return StageThreeResult{}, fmt.Errorf("council: majority stage 3 received empty tally")
+	}
+
+	top := tally.Clusters[0]
+	tiedCount := 0
+	for _, cl := range tally.Clusters {
+		if cl.Votes == top.Votes {
+			tiedCount++
+		}
+	}
+
+	if tiedCount > 1 {
+		// Tie — chairman required.
+		if chairmanModel == "" {
+			return StageThreeResult{}, fmt.Errorf("council: majority strategy has %d-way tie and no chairman model configured for tiebreak", tiedCount)
+		}
+		tied := tally.Clusters[:tiedCount]
+		return c.callMajorityChairman(ctx, BuildMajorityTiebreakPrompt(query, tied), chairmanModel, temperature)
+	}
+
+	// No tie.
+	if chairmanModel == "" {
+		// No-LLM path: emit winner verbatim. Model="" and DurationMs=0 are
+		// the documented contract for "no LLM call produced this result".
+		return StageThreeResult{Content: top.Representative}, nil
+	}
+	return c.callMajorityChairman(ctx, BuildMajorityPolishPrompt(query, top.Representative), chairmanModel, temperature)
+}
+
+// callMajorityChairman is the shared LLM-call shape for both the polish and
+// tiebreak paths. The caller supplies the messages built from the appropriate
+// prompt builder.
+func (c *Council) callMajorityChairman(ctx context.Context, msgs []ChatMessage, chairmanModel string, temperature float64) (StageThreeResult, error) {
+	start := time.Now()
+	resp, err := c.client.Complete(ctx, CompletionRequest{
+		Model:       chairmanModel,
+		Messages:    msgs,
+		Temperature: temperature,
+	})
+	elapsed := time.Since(start).Milliseconds()
+	if err != nil {
+		return StageThreeResult{Model: chairmanModel, DurationMs: elapsed}, fmt.Errorf("majority chairman (%s): %w", chairmanModel, err)
+	}
+	if len(resp.Choices) == 0 {
+		return StageThreeResult{Model: chairmanModel, DurationMs: elapsed}, fmt.Errorf("empty response from chairman %s", chairmanModel)
+	}
+	return StageThreeResult{
+		Content:    resp.Choices[0].Message.Content,
+		Model:      chairmanModel,
+		DurationMs: elapsed,
+	}, nil
+}

--- a/internal/council/majority.go
+++ b/internal/council/majority.go
@@ -31,7 +31,10 @@ func (c *Council) runMajority(ctx context.Context, query string, ct CouncilType,
 		n := len(allStage1)
 		need = max(3, (n+1)/2+1)
 	}
-	successful, err := checkQuorumWith(allStage1, need)
+	// checkQuorum honours an explicit non-zero `need`; the default formula
+	// max(2, ⌈N/2⌉+1) only kicks in when need == 0. Since runMajority always
+	// resolves a non-zero need above, checkQuorum applies our threshold verbatim.
+	successful, err := checkQuorum(allStage1, need)
 	if err != nil {
 		return err
 	}
@@ -54,11 +57,26 @@ func (c *Council) runMajority(ctx context.Context, query string, ct CouncilType,
 	// Vote tally — pure function over Stage 1 results; no LLM call.
 	tally := buildVoteTally(successful)
 
+	// ConsensusW for Majority is the *consensus ratio*: winnerVotes / totalVotes.
+	// This is NOT Kendall's W (which is rank-correlation across reviewers in
+	// PeerReview); for vote_tally it's the share of voters who landed on the
+	// winning cluster. 1.0 means unanimous, ~0.5 means a simple plurality with
+	// strong opposition. Consumers like the eval harness can read this on the
+	// Metadata directly without strategy-specific code paths.
+	totalVotes := 0
+	for _, cl := range tally.Clusters {
+		totalVotes += cl.Votes
+	}
+	consensusW := 0.0
+	if totalVotes > 0 && len(tally.Clusters) > 0 {
+		consensusW = float64(tally.Clusters[0].Votes) / float64(totalVotes)
+	}
+
 	metadata := Metadata{
 		CouncilType:       ct.Name,
 		LabelToModel:      labelToModel,
 		AggregateRankings: []RankedModel{}, // not used by Majority
-		ConsensusW:        1.0,             // 1.0 when winner cluster covers all voters; we leave it at 1.0 here
+		ConsensusW:        consensusW,
 		VoteTally:         tally,
 	}
 
@@ -79,23 +97,6 @@ func (c *Council) runMajority(ctx context.Context, query string, ct CouncilType,
 		onEvent("stage3_complete", stage3)
 	}
 	return nil
-}
-
-// checkQuorumWith is a thin wrapper that calls the existing checkQuorum with
-// an explicit need value (zero-valued QuorumMin would otherwise re-derive
-// the formula, which is strategy-agnostic). Strategies whose default formula
-// differs from max(2, ⌈N/2⌉+1) must resolve their own need first.
-func checkQuorumWith(results []StageOneResult, need int) ([]StageOneResult, error) {
-	var successful []StageOneResult
-	for _, r := range results {
-		if r.Error == nil {
-			successful = append(successful, r)
-		}
-	}
-	if len(successful) < need {
-		return nil, &QuorumError{Got: len(successful), Need: need}
-	}
-	return successful, nil
 }
 
 // normaliseAnswer prepares a Stage 1 answer for exact-match clustering:

--- a/internal/council/majority_test.go
+++ b/internal/council/majority_test.go
@@ -1,0 +1,345 @@
+package council
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// majorityFixture builds a Council whose registry's "test" entry uses the
+// Majority strategy with the given chairman (empty for the no-chairman path)
+// and a 4-model pool. The mock client routes by request-shape: prompt prefix
+// classifies the call as Stage 1 vs polish vs tiebreak.
+type majorityRecorder struct {
+	mu        sync.Mutex
+	stage1    map[string]string // model → answer the mock should return
+	polishOut string            // chairman's response on polish calls
+	tieOut    string            // chairman's response on tiebreak calls
+	calls     []string          // labels: "stage1:<model>", "polish:<model>", "tiebreak:<model>"
+	chairmanErr error            // if set, chairman calls return this error
+}
+
+func (r *majorityRecorder) record(req CompletionRequest) (CompletionResponse, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	body := ""
+	if len(req.Messages) > 0 {
+		body = req.Messages[0].Content
+	}
+	switch {
+	case strings.Contains(body, "You polish the council's winning answer"):
+		r.calls = append(r.calls, "polish:"+req.Model)
+		if r.chairmanErr != nil {
+			return CompletionResponse{}, r.chairmanErr
+		}
+		return makeResponse(r.polishOut), nil
+	case strings.Contains(body, "You arbitrate a tie"):
+		r.calls = append(r.calls, "tiebreak:"+req.Model)
+		if r.chairmanErr != nil {
+			return CompletionResponse{}, r.chairmanErr
+		}
+		return makeResponse(r.tieOut), nil
+	default:
+		// Stage 1 — the prompt is the council's deliberation prompt.
+		r.calls = append(r.calls, "stage1:"+req.Model)
+		ans, ok := r.stage1[req.Model]
+		if !ok {
+			return CompletionResponse{}, errors.New("no answer scripted for " + req.Model)
+		}
+		return makeResponse(ans), nil
+	}
+}
+
+func majorityCouncil(t *testing.T, models []string, chairman string, rec *majorityRecorder) *Council {
+	t.Helper()
+	registry := map[string]CouncilType{
+		"test": {
+			Name:          "test",
+			Strategy:      Majority,
+			Models:        models,
+			ChairmanModel: chairman,
+			Temperature:   0.7,
+		},
+	}
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			return rec.record(req)
+		},
+	}
+	return NewCouncil(client, registry, nil)
+}
+
+func TestRunMajority_Unanimous(t *testing.T) {
+	rec := &majorityRecorder{stage1: map[string]string{
+		"m-a": "42",
+		"m-b": "42",
+		"m-c": "42",
+	}}
+	c := majorityCouncil(t, []string{"m-a", "m-b", "m-c"}, "", rec)
+
+	var stage3 StageThreeResult
+	var tally *VoteTally
+	err := c.RunFull(context.Background(), "what is the answer?", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				tally = d.Metadata.VoteTally
+			}
+		}
+		if eventType == "stage3_complete" {
+			stage3 = data.(StageThreeResult)
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tally == nil || len(tally.Clusters) != 1 {
+		t.Fatalf("expected 1 cluster, got %v", tally)
+	}
+	if tally.Clusters[0].Votes != 3 {
+		t.Errorf("winner votes: got %d, want 3", tally.Clusters[0].Votes)
+	}
+	if stage3.Content != "42" {
+		t.Errorf("stage3 content: got %q, want %q", stage3.Content, "42")
+	}
+	if stage3.Model != "" {
+		t.Errorf("stage3 model: got %q, want empty (no chairman, no LLM call)", stage3.Model)
+	}
+}
+
+func TestRunMajority_Plurality_NoChairman(t *testing.T) {
+	rec := &majorityRecorder{stage1: map[string]string{
+		"m-a": "yes",
+		"m-b": "yes",
+		"m-c": "no",
+	}}
+	c := majorityCouncil(t, []string{"m-a", "m-b", "m-c"}, "", rec)
+
+	var stage3 StageThreeResult
+	err := c.RunFull(context.Background(), "is it true?", "test", func(eventType string, data any) {
+		if eventType == "stage3_complete" {
+			stage3 = data.(StageThreeResult)
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stage3.Content != "yes" {
+		t.Errorf("stage3 content: got %q, want %q", stage3.Content, "yes")
+	}
+	if stage3.Model != "" || stage3.DurationMs != 0 {
+		t.Errorf("stage3 (no LLM): got Model=%q DurationMs=%d, want empty/0", stage3.Model, stage3.DurationMs)
+	}
+	for _, call := range rec.calls {
+		if strings.HasPrefix(call, "polish:") || strings.HasPrefix(call, "tiebreak:") {
+			t.Errorf("unexpected chairman call %q in no-chairman run", call)
+		}
+	}
+}
+
+func TestRunMajority_Plurality_ChairmanPolish(t *testing.T) {
+	rec := &majorityRecorder{
+		stage1: map[string]string{
+			"m-a": "yes",
+			"m-b": "yes",
+			"m-c": "no",
+		},
+		polishOut: "Yes — confirmed.",
+	}
+	c := majorityCouncil(t, []string{"m-a", "m-b", "m-c"}, "chairman-z", rec)
+
+	var stage3 StageThreeResult
+	err := c.RunFull(context.Background(), "is it true?", "test", func(eventType string, data any) {
+		if eventType == "stage3_complete" {
+			stage3 = data.(StageThreeResult)
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stage3.Content != "Yes — confirmed." {
+		t.Errorf("stage3 content: got %q, want polished output", stage3.Content)
+	}
+	if stage3.Model != "chairman-z" {
+		t.Errorf("stage3 model: got %q, want %q", stage3.Model, "chairman-z")
+	}
+	polishCount := 0
+	for _, call := range rec.calls {
+		if strings.HasPrefix(call, "polish:") {
+			polishCount++
+		}
+		if strings.HasPrefix(call, "tiebreak:") {
+			t.Errorf("unexpected tiebreak call in plurality run: %q", call)
+		}
+	}
+	if polishCount != 1 {
+		t.Errorf("polish calls: got %d, want 1", polishCount)
+	}
+}
+
+func TestRunMajority_Tie_ChairmanTiebreak(t *testing.T) {
+	// 2-2 split between "yes" and "no".
+	rec := &majorityRecorder{
+		stage1: map[string]string{
+			"m-a": "yes",
+			"m-b": "yes",
+			"m-c": "no",
+			"m-d": "no",
+		},
+		tieOut: "Yes — chairman picks the affirmative.",
+	}
+	c := majorityCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", rec)
+
+	var stage3 StageThreeResult
+	err := c.RunFull(context.Background(), "is it true?", "test", func(eventType string, data any) {
+		if eventType == "stage3_complete" {
+			stage3 = data.(StageThreeResult)
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stage3.Content, "chairman picks") {
+		t.Errorf("stage3 content: got %q, want chairman tiebreak output", stage3.Content)
+	}
+	tiebreakCount := 0
+	for _, call := range rec.calls {
+		if strings.HasPrefix(call, "tiebreak:") {
+			tiebreakCount++
+		}
+		if strings.HasPrefix(call, "polish:") {
+			t.Errorf("unexpected polish call in tiebreak run: %q", call)
+		}
+	}
+	if tiebreakCount != 1 {
+		t.Errorf("tiebreak calls: got %d, want 1", tiebreakCount)
+	}
+}
+
+func TestRunMajority_Tie_NoChairman_LoudError(t *testing.T) {
+	rec := &majorityRecorder{stage1: map[string]string{
+		"m-a": "yes",
+		"m-b": "yes",
+		"m-c": "no",
+		"m-d": "no",
+	}}
+	c := majorityCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "" /* no chairman */, rec)
+
+	var stage3Emitted bool
+	err := c.RunFull(context.Background(), "is it true?", "test", func(eventType string, _ any) {
+		if eventType == "stage3_complete" {
+			stage3Emitted = true
+		}
+	})
+	if err == nil {
+		t.Fatal("expected error on tie with no chairman")
+	}
+	if !strings.Contains(err.Error(), "tie") {
+		t.Errorf("error message: got %q, want it to mention 'tie'", err.Error())
+	}
+	if stage3Emitted {
+		t.Error("must NOT emit stage3_complete on the tie-no-chairman error path")
+	}
+}
+
+func TestRunMajority_QuorumFailure(t *testing.T) {
+	// All models error → quorum can't be met. With QuorumMin=0, the formula
+	// is max(3, ⌈N/2⌉+1); N=4 gives need=3, so 0 successful answers fails it.
+	rec := &majorityRecorder{stage1: map[string]string{
+		// no scripted answers — every Stage 1 call returns "no answer scripted"
+	}}
+	c := majorityCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "", rec)
+
+	err := c.RunFull(context.Background(), "q", "test", nil)
+	if err == nil {
+		t.Fatal("expected QuorumError when all Stage 1 calls fail")
+	}
+	var qe *QuorumError
+	if !errors.As(err, &qe) {
+		t.Errorf("error type: got %T, want *QuorumError", err)
+	}
+}
+
+func TestRunMajority_NormalisationCollapses(t *testing.T) {
+	// Three answers that differ only in case + whitespace must collapse to
+	// one cluster.
+	rec := &majorityRecorder{stage1: map[string]string{
+		"m-a": "42",
+		"m-b": " 42 ",
+		"m-c": "42\n",
+	}}
+	c := majorityCouncil(t, []string{"m-a", "m-b", "m-c"}, "", rec)
+
+	var tally *VoteTally
+	err := c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				tally = d.Metadata.VoteTally
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tally == nil || len(tally.Clusters) != 1 {
+		t.Fatalf("expected 1 cluster after normalisation, got %v", tally)
+	}
+	if tally.Clusters[0].Votes != 3 {
+		t.Errorf("votes: got %d, want 3", tally.Clusters[0].Votes)
+	}
+}
+
+func TestRunMajority_Stage2Kind_IsVoteTally(t *testing.T) {
+	rec := &majorityRecorder{stage1: map[string]string{
+		"m-a": "42",
+		"m-b": "42",
+		"m-c": "42",
+	}}
+	c := majorityCouncil(t, []string{"m-a", "m-b", "m-c"}, "", rec)
+
+	var seenKind string
+	err := c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				seenKind = d.Kind
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if seenKind != "vote_tally" {
+		t.Errorf("Stage 2 Kind: got %q, want %q", seenKind, "vote_tally")
+	}
+}
+
+func TestRunMajority_NoLLMStage3_Contract(t *testing.T) {
+	// Plurality, no chairman, no tie → Model="" and DurationMs=0.
+	// This is the documented "no LLM call produced this result" contract.
+	rec := &majorityRecorder{stage1: map[string]string{
+		"m-a": "yes",
+		"m-b": "yes",
+		"m-c": "no",
+	}}
+	c := majorityCouncil(t, []string{"m-a", "m-b", "m-c"}, "", rec)
+
+	var stage3 StageThreeResult
+	err := c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage3_complete" {
+			stage3 = data.(StageThreeResult)
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stage3.Model != "" {
+		t.Errorf("Model: got %q, want empty (no LLM call)", stage3.Model)
+	}
+	if stage3.DurationMs != 0 {
+		t.Errorf("DurationMs: got %d, want 0 (no LLM call)", stage3.DurationMs)
+	}
+	if stage3.Content != "yes" {
+		t.Errorf("Content: got %q, want %q", stage3.Content, "yes")
+	}
+}

--- a/internal/council/majority_test.go
+++ b/internal/council/majority_test.go
@@ -314,6 +314,52 @@ func TestRunMajority_Stage2Kind_IsVoteTally(t *testing.T) {
 	}
 }
 
+func TestRunMajority_ConsensusW_IsRatio(t *testing.T) {
+	// 2-of-3 plurality → consensus_w should be 2/3 ≈ 0.667, NOT 1.0.
+	rec := &majorityRecorder{stage1: map[string]string{
+		"m-a": "yes",
+		"m-b": "yes",
+		"m-c": "no",
+	}}
+	c := majorityCouncil(t, []string{"m-a", "m-b", "m-c"}, "", rec)
+
+	var consensusW float64
+	err := c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				consensusW = d.Metadata.ConsensusW
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := 2.0 / 3.0
+	if consensusW < want-0.01 || consensusW > want+0.01 {
+		t.Errorf("ConsensusW: got %.3f, want ~%.3f (winnerVotes/totalVotes for 2-of-3 plurality)", consensusW, want)
+	}
+}
+
+func TestRunMajority_ConsensusW_UnanimousIsOne(t *testing.T) {
+	// Unanimous (all 3 agree) → consensus_w should be 1.0.
+	rec := &majorityRecorder{stage1: map[string]string{
+		"m-a": "yes", "m-b": "yes", "m-c": "yes",
+	}}
+	c := majorityCouncil(t, []string{"m-a", "m-b", "m-c"}, "", rec)
+
+	var consensusW float64
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				consensusW = d.Metadata.ConsensusW
+			}
+		}
+	})
+	if consensusW != 1.0 {
+		t.Errorf("ConsensusW: got %.3f, want 1.0 (unanimous)", consensusW)
+	}
+}
+
 func TestRunMajority_NoLLMStage3_Contract(t *testing.T) {
 	// Plurality, no chairman, no tie → Model="" and DurationMs=0.
 	// This is the documented "no LLM call produced this result" contract.

--- a/internal/council/prompts.go
+++ b/internal/council/prompts.go
@@ -291,3 +291,56 @@ func BuildRoleChairmanPrompt(query string, results []StageOneResult) []ChatMessa
 		{Role: "user", Content: sb.String()},
 	}
 }
+
+// BuildMajorityPolishPrompt asks the chairman to polish the winning answer
+// from the Majority strategy. The chairman MUST refine prose only — it must
+// not change the substance of the answer the council voted for.
+//
+// Discriminator prefix: "You polish the council's winning answer." — used
+// by tests to classify the call as a polish call vs. a tiebreak call.
+func BuildMajorityPolishPrompt(query string, winner string) []ChatMessage {
+	var sb strings.Builder
+	sb.WriteString("You polish the council's winning answer. ")
+	sb.WriteString("The council of LLMs voted on the question below; the answer with the most votes is given.\n\n")
+	sb.WriteString("Question: ")
+	sb.WriteString(query)
+	sb.WriteString("\n\nWinning answer:\n")
+	sb.WriteString(winner)
+	sb.WriteString("\n\n")
+	sb.WriteString("Polish the winning answer for clarity, grammar, and prose quality. ")
+	sb.WriteString("DO NOT change the substance of the answer. ")
+	sb.WriteString("If the answer is already clear, return it verbatim. ")
+	sb.WriteString("Reply with the polished answer only — no preamble, no commentary.")
+
+	return []ChatMessage{
+		{Role: "user", Content: sb.String()},
+	}
+}
+
+// BuildMajorityTiebreakPrompt asks the chairman to break a tie among the
+// top-voted clusters in the Majority strategy. Each tied cluster's
+// representative content is shown; the chairman picks one as the final answer.
+//
+// Discriminator prefix: "You arbitrate a tie among the council's top answers."
+// — used by tests to classify the call as a tiebreak call.
+func BuildMajorityTiebreakPrompt(query string, tied []VoteCluster) []ChatMessage {
+	var sb strings.Builder
+	sb.WriteString("You arbitrate a tie among the council's top answers. ")
+	sb.WriteString("The council of LLMs voted on the question below; ")
+	fmt.Fprintf(&sb, "%d answers tied for the most votes.\n\n", len(tied))
+	sb.WriteString("Question: ")
+	sb.WriteString(query)
+	sb.WriteString("\n\nTied answers:\n")
+	for i, cl := range tied {
+		fmt.Fprintf(&sb, "\n[Candidate %d] (%d votes):\n", i+1, cl.Votes)
+		sb.WriteString(cl.Representative)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\nPick the answer that best addresses the question. ")
+	sb.WriteString("If you must blend, blend conservatively — prefer one of the candidates over a synthesis. ")
+	sb.WriteString("Reply with the chosen answer only — no preamble, no commentary on the tiebreak process.")
+
+	return []ChatMessage{
+		{Role: "user", Content: sb.String()},
+	}
+}

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -66,6 +66,8 @@ func (c *Council) RunFull(ctx context.Context, query string, councilTypeName str
 		return c.runPeerReview(ctx, query, ct, onEvent)
 	case RoleBased:
 		return c.runRoleBased(ctx, query, ct, onEvent)
+	case Majority:
+		return c.runMajority(ctx, query, ct, onEvent)
 	default:
 		return fmt.Errorf("council: strategy %d not implemented", ct.Strategy)
 	}

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -555,7 +555,7 @@ func TestRunFull_Stage2CompletePayload_IsStage2CompleteData(t *testing.T) {
 
 func TestRunFull_UnimplementedStrategy_ReturnsError(t *testing.T) {
 	unimplemented := []Strategy{
-		Majority, GenerateRankRefine, MultiAgentDebate, MixtureOfAgents, Delphi,
+		GenerateRankRefine, MultiAgentDebate, MixtureOfAgents, Delphi,
 	}
 	for _, s := range unimplemented {
 		s := s

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -98,6 +98,12 @@ type StageTwoResult struct {
 }
 
 // StageThreeResult holds the chairman's synthesised final answer.
+//
+// Model is the OpenRouter ID of the synthesising model when an LLM call
+// produced the content. For strategies whose Stage 3 emits a result without
+// an LLM call (e.g. Majority's plurality winner with no chairman), Model is
+// the empty string and DurationMs is 0. Frontend renderers must handle the
+// empty-Model case gracefully (omit the model badge).
 type StageThreeResult struct {
 	Content    string `json:"content"`
 	Model      string `json:"model"`
@@ -111,12 +117,35 @@ type RankedModel struct {
 	Score float64 `json:"score"`
 }
 
+// VoteCluster groups Stage 1 answers that normalise to the same content under
+// the Majority strategy's voting algorithm. Members holds the labels of the
+// Stage 1 results in the cluster; Representative is the verbatim content of
+// the cluster's first member (used for display and downstream synthesis).
+type VoteCluster struct {
+	Members        []string `json:"members"`
+	Representative string   `json:"representative"`
+	Votes          int      `json:"votes"`
+}
+
+// VoteTally is the result of clustering Majority Stage 1 answers and selecting
+// the plurality winner. Clusters are sorted by Votes descending, then by
+// Representative ascending for stable output. WinnerLabel is the label of the
+// first member in the winning (highest-votes) cluster.
+type VoteTally struct {
+	Clusters    []VoteCluster `json:"clusters"`
+	WinnerLabel string        `json:"winner_label"`
+}
+
 // Metadata is persisted with every assistant message.
+//
+// VoteTally is populated only by the Majority strategy; omitempty keeps it
+// absent on the wire and at rest for every other strategy.
 type Metadata struct {
-	CouncilType       string        `json:"council_type"`
+	CouncilType       string            `json:"council_type"`
 	LabelToModel      map[string]string `json:"label_to_model"`
-	AggregateRankings []RankedModel `json:"aggregate_rankings"`
-	ConsensusW        float64       `json:"consensus_w"`
+	AggregateRankings []RankedModel     `json:"aggregate_rankings"`
+	ConsensusW        float64           `json:"consensus_w"`
+	VoteTally         *VoteTally        `json:"vote_tally,omitempty"`
 }
 
 // Stage2CompleteData is the payload emitted by Runner for the "stage2_complete" event.


### PR DESCRIPTION
## Summary

Implements the third deliberation strategy: `Majority`. All council members generate independently; the answer that appears most often wins. Best for factual QA, classification, and math — tasks where there's a clear correct answer that voting can extract from generation noise.

This is the first strategy to ship on top of #202 (Stage 2 polymorphism) and #204 (Stage 0 model extraction). It validates the precondition thesis: a new strategy ships without touching shared SSE/config code beyond strategy-specific extensions.

Closes #205

## Pipeline

```
Stage 1 — parallel generation (reuses runStage1)
Stage 2 — vote tally  (pure function, NO LLM call; kind="vote_tally")
Stage 3 — winner emission, optional chairman polish
```

**Voting algorithm:** exact-match after normalisation (lowercase + trim + collapse internal whitespace). Cluster-by-embedding, Borda count, Tournament/Elo, and weighted voting are explicit follow-ups.

## Tie handling

| Tie? | Chairman? | Result |
|------|-----------|--------|
| No   | No        | Winner emitted verbatim. `StageThreeResult{Model: "", DurationMs: 0}` — empty `Model` is the documented "no LLM call" signal. |
| No   | Yes       | Chairman polishes the winner (refines prose only, must not change substance). |
| Yes  | Yes       | Chairman picks among tied candidates. |
| Yes  | No        | **Loud error** — `runMajority` returns rather than picking arbitrarily. |

The loud-error pattern matches the Stage 0 arbiter design from #204.

## No-LLM Stage 3 contract

When there's no tie and no chairman, Stage 3 emits the winning cluster's content verbatim:

```go
StageThreeResult{Content: winner, Model: "", DurationMs: 0}
```

Empty `Model` is the documented "no LLM call produced this result" signal. **No sentinel string** like `"majority-vote"` — that would corrupt eval, persistence, and any code that joins on model name. `Stage3.jsx` is patched to omit the model badge when `model === ""`.

## Registration is opt-in

The `"majority"` council type is added to the registry **only** when `MAJORITY_MODELS` is set. Existing deployments without the env var don't get the new strategy silently exposed. `cmd/server/main.go` and `cmd/eval/main.go` mirror the conditional registration.

## What's new

**Types** (`internal/council/types.go`):
- `VoteCluster {Members, Representative, Votes}`
- `VoteTally {Clusters, WinnerLabel}` — clusters sorted by votes desc, then representative asc
- `Metadata.VoteTally *VoteTally \`json:"vote_tally,omitempty"\``

**Backend implementation** (`internal/council/majority.go`):
- `runMajority` (dispatch from `RunFull` switch)
- `buildVoteTally` (pure function — exact-match normalisation + clustering)
- `runMajorityStage3` (tie detection + chairman routing)
- `BuildMajorityPolishPrompt`, `BuildMajorityTiebreakPrompt` (in `prompts.go`)

**Config** (`internal/config/config.go`):
- `Config.MajorityModels []string`
- `Config.MajorityChairmanModel string`
- `MAJORITY_MODELS` env var (comma-separated; required to register)
- `MAJORITY_CHAIRMAN_MODEL` env var (optional; for tiebreak/polish)

**Frontend**:
- `Stage2.jsx` `VoteTallyView` — bar chart per cluster, winner highlighted with ✓ + accent border, long representatives truncated with click-to-expand
- `ChatInterface.jsx` threads `voteTally={msg.metadata?.vote_tally}` to `Stage2`
- `Stage3.jsx` conditionalises the model badge on non-empty `model`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes (**223 tests**, +12 from #204's 211)
- [x] `npm run lint` passes
- [x] `npm run test` passes (**26 tests**, +3 from #204's 23)
- [x] `npm run build` passes within chunk-size budgets

### Backend test cases (9 new in `majority_test.go`)
- Unanimous · Plurality+no-chairman · Plurality+chairman polish · Tie+chairman tiebreak · Tie+no-chairman loud error · Quorum failure · Normalisation collapses case+whitespace · Stage 2 `kind="vote_tally"` · No-LLM Stage 3 contract (`Model: ""`, `DurationMs: 0`)

### Wire-format integration test (`handler_test.go`)
- Asserts `"kind":"vote_tally"` and a populated `metadata.vote_tally.{winner_label, clusters}` appear in the SSE envelope

### Config tests (3 new in `config_test.go`)
- Both env vars set · Generators-only-set · Both unset (registration opt-in)

### Frontend dispatcher tests (3 new in `Stage2.test.jsx`)
- Multi-cluster with winner highlighted · Unanimous (single cluster) · Long-representative truncation + Show/hide

## Docs

- `docs/strategies.md` — `Majority` row → shipped (#205); `vote_tally` row → shipped with the actual `VoteTally`/`VoteCluster` schema
- `docs/architecture-v2.md` — new "Majority pipeline (2 stages, no LLM Stage 2)" subsection alongside PeerReview and RoleBased
- `.env.example` — Majority block with the opt-in registration semantics + voting normalisation note + tie-handling explanation

## Out of scope (deferred)

- Other voting algorithms (cluster-by-embedding, Borda, Tournament/Elo, weighted)
- Champion strategy variant
- Vote-tally persistence on `AssistantMessage`
- Separate `stage3_polishing` SSE signal (UX polish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)