### PR TITLE
feat(.claude): apply dreaming W19 findings

### DIFF
--- a/.claude/agent-memory/tech-lead/project_architecture.md
+++ b/.claude/agent-memory/tech-lead/project_architecture.md
@@ -2,6 +2,7 @@
 name: project_architecture
 description: LLM Council Go backend — module map, key design decisions, established conventions
 type: project
+last-verified: 2026-05-10
 ---
 
 Go backend for LLM Council, a 3-stage multi-LLM deliberation system.
@@ -12,34 +13,79 @@ Go backend for LLM Council, a 3-stage multi-LLM deliberation system.
 ## Module layout
 
 ```
-cmd/server/main.go            — wire-up only; config → openrouter → council → storage → api
-internal/config/config.go     — Config struct, Load() from env; no validation today
-internal/openrouter/client.go — QueryModel() / QueryModelsParallel(); concrete type, no interface
-internal/council/types.go     — domain types: StageOneResult, StageTwoResult, StageThreeResult, Metadata, Result
-internal/council/council.go   — Council struct (concrete dep on *openrouter.Client); Stage1/2/3, RunFull, GenerateTitle
-internal/storage/storage.go   — JSON file store; atomic writes; per-conv sync.Mutex via sync.Map
-internal/api/handler.go       — HTTP handlers + SSE streaming; CORS middleware; direct dep on *council.Council and *storage.Store
+cmd/server/main.go            — wire-up + graceful shutdown (SIGINT/SIGTERM, 10s drain)
+cmd/eval/main.go              — evaluation harness CLI (council vs single-model quality)
+internal/config/config.go     — Config struct, Load() from env; supports Stage 0 clarification overrides
+internal/openrouter/client.go — Concrete LLM gateway; implements council.LLMClient interface
+internal/council/interfaces.go — LLMClient / Runner / Stage0Runner interfaces (DI seam)
+internal/council/types.go     — Domain types: CouncilType, Stage*Result, EventFunc, CompletionRequest/Response
+internal/council/council.go   — Council struct; main 3-stage pipeline (peer review)
+internal/council/runner.go    — Runner orchestration, structured logging via slog
+internal/council/rolebased.go — Role-based 2-stage pipeline (Stage 1 + Stage 3, no peer review)
+internal/council/prompts.go   — Prompt templates (per-stage)
+internal/council/rankings.go  — Stage 2 ranking aggregation
+internal/storage/storage.go   — JSON file store; atomic writes; per-conv mutex via sync.Map; UUID validation via regex
+internal/api/handler.go       — HTTP handlers + SSE streaming; CORS + security middleware via wrap()
+internal/eval/                — Eval harness: judge, report, eval runner; LLM-as-judge for council quality
 ```
 
 ## Established conventions
 
-- Atomic file writes: write to `{id}.json.tmp`, then `os.Rename`
-- Per-conversation locking: `sync.Map` of `*sync.Mutex`, acquired via `lockConv(id)`
-- UUID-validated IDs before any file path construction (path traversal prevention)
-- Request body capped at 1MB via `http.MaxBytesReader`
-- CORS: only localhost:5173 and localhost:3000 allowed
-- Data dir permissions: 0700; file permissions: 0600
-- SSE events: `data: {...}\n\n` with `type` field; no SSE `event:` line
-- `math/rand` auto-seeded (Go 1.20+), no explicit seed needed
-- External deps: only `github.com/google/uuid` and `github.com/joho/godotenv`
-- `go vet ./...` is the linting step (no staticcheck/golangci-lint yet)
+- **Atomic file writes:** write to `{id}.json.tmp`, then `os.Rename`
+- **Per-conversation locking:** `sync.Map` of `*sync.Mutex`, acquired via `lockConv(id)`
+- **UUID-validated IDs** before any file path construction (path traversal prevention).
+  Validation is via regex (`uuidRE`), no `github.com/google/uuid` dependency.
+- **Request body capped at 1MB** via `http.MaxBytesReader` (handler.go:178, 387)
+- **CORS:** still hardcoded to `localhost:5173` and `localhost:3000` (`var allowedOrigins`
+  in `internal/api/handler.go:24`). **Not yet configurable via env** — known limitation.
+- **Security headers:** `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`,
+  `Content-Security-Policy: default-src 'none'` set on every response by `wrap()`.
+- **Data dir permissions:** 0700; file permissions: 0600
+- **SSE events:** `data: {...}\n\n` with `type` field; no SSE `event:` line
+- **Structured logging via `log/slog`** — used in `runner.go`, `eval.go`, `server/main.go`,
+  `handler.go`, `storage.go`. NOT stdlib `log` package.
+- **Tests:** 17 test files across api/council/eval/storage. Real file I/O (temp dirs),
+  not mocks per `copilot-instructions.md`. Frontend has Vitest harness too.
+- **Linting:** `go vet ./...` is the gate; staticcheck/golangci-lint not yet integrated.
+- **External deps:** only `github.com/joho/godotenv v1.5.1`. Go 1.26.3.
 
 ## Key design decisions
 
-- labelToModel mapping is ephemeral — not persisted, only in API response
-- Stage 2 is capped at 26 council members (A-Z label limit)
-- GenerateTitle uses a hardcoded model (`google/gemini-2.5-flash`) regardless of configured council
-- Title generation runs concurrently with RunFull/Stage1 to avoid blocking
-- No graceful shutdown; `http.ListenAndServe` called directly
-- No structured logging; stdlib `log` package only
-- No tests exist yet; copilot-instructions.md says to use real file I/O (temp dirs), not mocks
+- **Interfaces over concrete types** for council dependencies: `LLMClient`, `Runner`,
+  `Stage0Runner` (in `interfaces.go`). Lets handlers depend on abstraction; tests
+  use real implementations against temp dirs.
+- **labelToModel mapping is ephemeral** — not persisted, only in API response
+- **Stage 2 capped at 26 council members** (A-Z label limit)
+- **Role-based pipeline** (Stage 1 + Stage 3) for use cases that don't need peer
+  review; emits a minimal Stage2CompleteData event for SSE compatibility (`rolebased.go`)
+- **Stage 0 clarification loop** (configurable via `CLARIFICATION_*` env vars).
+  `ClarificationMaxRounds=0` disables the feature.
+  Stage 0 model overrides are intentionally NOT pre-filled from default council
+  models — runner resolves the fall-through chain at request time.
+- **Title generation** runs concurrently with RunFull/Stage1 to avoid blocking.
+  Look in current `runner.go` / `council.go` for the active model selection;
+  the previous "hardcoded `google/gemini-2.5-flash`" claim no longer matches.
+- **Graceful shutdown:** `cmd/server/main.go:74-100` — SIGINT/SIGTERM handler
+  cancels context, then `srv.Shutdown(ctx)` with 10s timeout.
+- **Retry policy:** `LLMAPIMaxRetries` config (default 2, total 3 attempts) on
+  transient OpenRouter failures (429/502/503/504, timeouts, EOFs).
+
+## What changed since 2026-03-14 (previous version of this file)
+
+This memory was rewritten on 2026-05-10 from current code state, after a
+dreaming pass (W19) flagged 4 false claims:
+- ❌ "No tests exist yet" → ✅ 17 test files
+- ❌ "No structured logging; stdlib log only" → ✅ `log/slog` in 5 modules
+- ❌ "No graceful shutdown" → ✅ `srv.Shutdown` with signal trap
+- ❌ "GenerateTitle uses hardcoded `google/gemini-2.5-flash`" → claim no longer
+  matches code; verify in current `runner.go` / `council.go` if working on titles.
+
+Two additional drifts found while rewriting:
+- Module layout grew significantly (eval package, rolebased pipeline, Stage 0
+  clarification, interfaces.go); old module list was misleadingly minimal.
+- `github.com/google/uuid` dep was removed; UUIDs validated via regex now.
+
+CORS hardcoding was also flagged as "false (PR #31 made it configurable)" by
+dreaming, but verification against actual code shows the hardcoded map is still
+in place. Treat dreaming reports as evidence, not as truth — verify against
+current code before believing claims.

--- a/.claude/agent-memory/tech-lead/project_architecture.md
+++ b/.claude/agent-memory/tech-lead/project_architecture.md
@@ -20,10 +20,11 @@ internal/openrouter/client.go — Concrete LLM gateway; implements council.LLMCl
 internal/council/interfaces.go — LLMClient / Runner / Stage0Runner interfaces (DI seam)
 internal/council/types.go     — Domain types: CouncilType, Stage*Result, EventFunc, CompletionRequest/Response
 internal/council/council.go   — Council struct; main 3-stage pipeline (peer review)
-internal/council/runner.go    — Runner orchestration, structured logging via slog
+internal/council/runner.go    — Runner orchestration + Strategy dispatch switch (3 implemented, 4 planned); structured logging via slog
 internal/council/rolebased.go — Role-based 2-stage pipeline (Stage 1 + Stage 3, no peer review)
-internal/council/prompts.go   — Prompt templates (per-stage)
-internal/council/rankings.go  — Stage 2 ranking aggregation
+internal/council/majority.go  — Majority strategy (vote-tally, opt-in via MAJORITY_MODELS); Stage 2 emits kind="vote_tally"
+internal/council/prompts.go   — Prompt templates (per-stage, per-strategy)
+internal/council/rankings.go  — Stage 2 ranking aggregation (PeerReview's Kendall's W)
 internal/storage/storage.go   — JSON file store; atomic writes; per-conv mutex via sync.Map; UUID validation via regex
 internal/api/handler.go       — HTTP handlers + SSE streaming; CORS + security middleware via wrap()
 internal/eval/                — Eval harness: judge, report, eval runner; LLM-as-judge for council quality
@@ -42,10 +43,13 @@ internal/eval/                — Eval harness: judge, report, eval runner; LLM-
   `Content-Security-Policy: default-src 'none'` set on every response by `wrap()`.
 - **Data dir permissions:** 0700; file permissions: 0600
 - **SSE events:** `data: {...}\n\n` with `type` field; no SSE `event:` line
-- **Structured logging via `log/slog`** — used in `runner.go`, `eval.go`, `server/main.go`,
-  `handler.go`, `storage.go`. NOT stdlib `log` package.
-- **Tests:** 17 test files across api/council/eval/storage. Real file I/O (temp dirs),
-  not mocks per `copilot-instructions.md`. Frontend has Vitest harness too.
+- **Structured logging via `log/slog`** — used in 8 files: `cmd/server/main.go`,
+  `cmd/eval/main.go`, `internal/api/handler.go`, `internal/config/config.go`,
+  `internal/council/runner.go`, `internal/eval/eval.go`, `internal/openrouter/client.go`,
+  `internal/storage/storage.go`. NOT stdlib `log` package.
+- **Tests:** 14 Go test files across api/council/config/eval/openrouter/storage.
+  Real file I/O (temp dirs), not mocks per `copilot-instructions.md`. Frontend
+  has a Vitest harness as well (2 spec files).
 - **Linting:** `go vet ./...` is the gate; staticcheck/golangci-lint not yet integrated.
 - **External deps:** only `github.com/joho/godotenv v1.5.1`. Go 1.26.3.
 
@@ -56,8 +60,15 @@ internal/eval/                — Eval harness: judge, report, eval runner; LLM-
   use real implementations against temp dirs.
 - **labelToModel mapping is ephemeral** — not persisted, only in API response
 - **Stage 2 capped at 26 council members** (A-Z label limit)
-- **Role-based pipeline** (Stage 1 + Stage 3) for use cases that don't need peer
-  review; emits a minimal Stage2CompleteData event for SSE compatibility (`rolebased.go`)
+- **Strategy enum** (`internal/council/types.go`) declares 7 constants. **Three
+  implemented today:** `PeerReview` (3-stage Karpathy peer review), `RoleBased`
+  (2-stage roles → chairman; emits a minimal `Stage2CompleteData` stub), and
+  `Majority` (parallel generation → vote tally, no LLM Stage 2; opt-in registration
+  via `MAJORITY_MODELS`). **Four reserved/planned:** `GenerateRankRefine`,
+  `MultiAgentDebate`, `MixtureOfAgents`, `Delphi` — runner returns
+  `"strategy %d not implemented"`. Stage 2 carries a `kind` discriminator
+  (`peer_ranking`, `role_stub`, `vote_tally`, plus reserved kinds for the planned
+  strategies) so future strategies ship without touching shared SSE code.
 - **Stage 0 clarification loop** (configurable via `CLARIFICATION_*` env vars).
   `ClarificationMaxRounds=0` disables the feature.
   Stage 0 model overrides are intentionally NOT pre-filled from default council
@@ -65,8 +76,8 @@ internal/eval/                — Eval harness: judge, report, eval runner; LLM-
 - **Title generation** runs concurrently with RunFull/Stage1 to avoid blocking.
   Look in current `runner.go` / `council.go` for the active model selection;
   the previous "hardcoded `google/gemini-2.5-flash`" claim no longer matches.
-- **Graceful shutdown:** `cmd/server/main.go:74-100` — SIGINT/SIGTERM handler
-  cancels context, then `srv.Shutdown(ctx)` with 10s timeout.
+- **Graceful shutdown:** `cmd/server/main.go:93-118` — `signal.NotifyContext`
+  catches SIGINT/SIGTERM, then `srv.Shutdown(ctx)` with 10s timeout.
 - **Retry policy:** `LLMAPIMaxRetries` config (default 2, total 3 attempts) on
   transient OpenRouter failures (429/502/503/504, timeouts, EOFs).
 
@@ -74,8 +85,8 @@ internal/eval/                — Eval harness: judge, report, eval runner; LLM-
 
 This memory was updated and expanded on 2026-05-10 from current code state,
 after a dreaming pass (W19) flagged 4 false claims:
-- ❌ "No tests exist yet" → ✅ 17 test files
-- ❌ "No structured logging; stdlib log only" → ✅ `log/slog` in 5 modules
+- ❌ "No tests exist yet" → ✅ 14 Go test files (+ frontend Vitest harness)
+- ❌ "No structured logging; stdlib log only" → ✅ `log/slog` in 8 files
 - ❌ "No graceful shutdown" → ✅ `srv.Shutdown` with signal trap
 - ❌ "GenerateTitle uses hardcoded `google/gemini-2.5-flash`" → claim no longer
   matches code; verify in current `runner.go` / `council.go` if working on titles.

--- a/.claude/agent-memory/tech-lead/project_architecture.md
+++ b/.claude/agent-memory/tech-lead/project_architecture.md
@@ -72,8 +72,8 @@ internal/eval/                — Eval harness: judge, report, eval runner; LLM-
 
 ## What changed since 2026-03-14 (previous version of this file)
 
-This memory was rewritten on 2026-05-10 from current code state, after a
-dreaming pass (W19) flagged 4 false claims:
+This memory was updated and expanded on 2026-05-10 from current code state,
+after a dreaming pass (W19) flagged 4 false claims:
 - ❌ "No tests exist yet" → ✅ 17 test files
 - ❌ "No structured logging; stdlib log only" → ✅ `log/slog` in 5 modules
 - ❌ "No graceful shutdown" → ✅ `srv.Shutdown` with signal trap

--- a/.claude/agents/go-security-reviewer.md
+++ b/.claude/agents/go-security-reviewer.md
@@ -1,13 +1,27 @@
 ---
 name: go-security-reviewer
-description: "Use this agent when you need to analyze Go or JavaScript/React source code, configuration files, or dependency manifests for security vulnerabilities, insecure coding practices, hardcoded secrets, dangerous API usage, or configuration risks. Invoke it after writing new Go code, before merging a pull request, when reviewing authentication/authorization logic, when adding new dependencies, or when modifying configuration files like Dockerfiles, .env files, or Kubernetes manifests.\\n\\n<example>\\nContext: The user has just written a new HTTP handler that processes user input and queries a database.\\nuser: \"I've just finished writing the new user search handler in handlers/search.go\"\\nassistant: \"Great, let me review that for security issues.\"\\n<commentary>\\nSince new Go code handling user input and database queries was just written, proactively launch the go-security-reviewer agent to check for injection vulnerabilities, missing authentication, and other security risks.\\n</commentary>\\nassistant: \"I'll use the go-security-reviewer agent to analyze handlers/search.go for security vulnerabilities before we proceed.\"\\n</example>\\n\\n<example>\\nContext: The user has added a new dependency to go.mod and updated configuration files.\\nuser: \"I added the github.com/some/library package to go.mod and updated config.yaml with the new settings\"\\nassistant: \"I'll launch the go-security-reviewer agent to check the new dependency for known vulnerabilities and review the configuration changes for security risks.\"\\n<commentary>\\nDependency and configuration changes are high-risk moments. Use the go-security-reviewer agent to scan go.mod and config.yaml immediately.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user is implementing an authentication middleware.\\nuser: \"Can you review my auth middleware in middleware/auth.go?\"\\nassistant: \"Absolutely — I'll use the go-security-reviewer agent to perform a thorough security analysis of your authentication middleware.\"\\n<commentary>\\nAuthentication code is security-critical. Use the go-security-reviewer agent to verify access control, session validation, token handling, and absence of bypass vulnerabilities.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user has written a function that executes shell commands.\\nuser: \"Here's my command runner implementation in cmd/runner.go\"\\nassistant: \"Let me have the go-security-reviewer agent analyze this for command injection and unsafe API usage.\"\\n<commentary>\\nCode involving os/exec is a high-risk area. Immediately invoke the go-security-reviewer agent to detect command injection, unsafe input handling, and misuse of dangerous Go APIs.\\n</commentary>\\n</example>"
+description: "**Backend (Go) security audit only.** Analyzes Go source code, configuration files (Dockerfile, .env, CI/CD, K8s manifests, docker-compose), and dependency manifests (`go.mod`, `go.sum`) for vulnerabilities. Invoke after new Go code, before merging a backend-touching PR, when reviewing auth/authz logic, when adding deps, or when changing config. **For React frontend code, use `security-reviewer` instead** (the two agents have non-overlapping scopes and may run together on full-stack PRs).\\n\\n<example>\\nContext: The user has just written a new HTTP handler in Go.\\nuser: \"I've just finished writing the new user search handler in internal/api/handlers/search.go\"\\nassistant: \"I'll use go-security-reviewer to analyze handlers/search.go for injection, path-traversal, and authn issues.\"\\n</example>\\n\\n<example>\\nContext: The user has added a new dependency to go.mod and updated configuration.\\nuser: \"I added github.com/some/library to go.mod and updated docker-compose.yml\"\\nassistant: \"I'll launch go-security-reviewer to check the dep for known CVEs and review the docker-compose changes.\"\\n</example>\\n\\n<example>\\nContext: The user has written a function that executes shell commands.\\nuser: \"Here's my command runner in cmd/runner.go\"\\nassistant: \"Let me have go-security-reviewer analyze this for command injection and unsafe os/exec usage.\"\\n</example>"
 tools: Bash, Glob, Grep, Read
 model: haiku
 color: blue
 memory: project
 ---
 
-You are an elite security engineer specializing in Go and JavaScript/React application security. You have deep expertise in static analysis, vulnerability detection, secure coding practices, and both the Go standard library and the React/browser security footprint. You think like an attacker but act like a defender — your mission is to find security weaknesses before they reach production and provide developers with precise, actionable remediation guidance.
+You are an elite security engineer specializing in **Go application
+security and infrastructure-as-code review**. You have deep expertise
+in static analysis, vulnerability detection, secure coding practices,
+and the Go standard library. You think like an attacker but act like
+a defender — your mission is to find security weaknesses before they
+reach production and provide developers with precise, actionable
+remediation guidance.
+
+**Scope boundary:** This agent reviews ONLY Go source code, Go
+manifests (`go.mod`, `go.sum`), and infrastructure configuration
+(Dockerfile, docker-compose, .env, CI/CD workflows, K8s manifests,
+Terraform). For React frontend code (`frontend/`), use
+[`security-reviewer`](./security-reviewer.md) instead. The two agents
+have non-overlapping scopes and may both run on a PR that touches
+both backend and frontend.
 
 You adhere to the project's design principles: DRY, YAGNI, KISS, SOLID, and GRASP. Your analysis is thorough but focused — you report real issues, not noise.
 

--- a/.claude/agents/go-security-reviewer.md
+++ b/.claude/agents/go-security-reviewer.md
@@ -188,27 +188,6 @@ Apply these Go-specific checks always:
 
 ---
 
-## JavaScript / React Security Rules
-
-Apply these checks whenever files under `frontend/` are in scope:
-
-### 1. XSS via unsafe HTML rendering
-All LLM output MUST be rendered through `react-markdown`. Passing LLM-generated strings directly into raw HTML injection is a critical XSS risk — flag any such usage at CRITICAL severity.
-
-### 2. Hardcoded secrets in JS source
-Scan for API keys, tokens, or credentials embedded in `.js` / `.jsx` files using the same patterns as Go secret detection. Flag at CRITICAL. Note: `VITE_*` env vars are expected and safe — only flag literals that look like real credentials.
-
-### 3. eval() and equivalent dynamic execution
-Flag any use of `eval()`, `new Function(...)`, or `setTimeout`/`setInterval` with a string argument. These are HIGH severity when any part of the string is user- or LLM-supplied.
-
-### 4. Unvalidated redirects
-Flag any `window.location` assignment or `<a href={...}>` where the href value comes from external data (API response, URL params) without validation. Severity: MEDIUM.
-
-### 5. LLM output must go through react-markdown
-This is a rendering contract, not just a style choice. LLM responses can contain arbitrary markdown, code blocks, and link syntax. Any component that renders `stage1_responses`, `stage2_reviews`, or `stage3_synthesis` content must use `react-markdown`. Bypassing this is HIGH severity.
-
----
-
 ## Limitations — Be Transparent
 
 Always note at the end of your report:

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,12 +1,17 @@
 ---
 name: security-reviewer
-description: Use when new code has been written or modified and needs a security audit before a PR is created. Analyzes source code for OWASP Top 10 vulnerabilities, XSS risks, injection vectors, hardcoded secrets, and insecure patterns. Report-only — never modifies code. Invoke proactively after implementing features that handle user input, render LLM output, or make API calls.
+description: "**Frontend security audit only.** Use when new code has been written or modified in `frontend/` (React 19 + Vite 8, plain JavaScript) and needs a security audit before a PR. Focus areas: XSS via LLM output rendering, API URL injection, fetch boundary integrity, env-var leakage. Report-only — never modifies code. **For backend Go code, use `go-security-reviewer` instead.** Both agents may run on a PR that touches both frontend and backend; they do not overlap in scope."
 tools: Bash, Glob, Grep, Read
 model: haiku
 color: blue
 ---
 
 You are an application security engineer auditing the **LLM Council frontend** — a React 19 + Vite 8 single-page app in plain JavaScript (no TypeScript). You review recently written or modified code for security vulnerabilities. You **report only** — never modify code.
+
+**Scope boundary:** This agent reviews ONLY `frontend/`. For Go backend
+code, configuration files (Dockerfile, .env, CI), and dependency
+manifests, use [`go-security-reviewer`](./go-security-reviewer.md)
+instead.
 
 ## Stack Context
 

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -39,6 +39,16 @@ contract and require Tech Lead override.
 - **PRs** are squash-merged. Never merge commits or rebase-merge.
 - **`/fix-review`** runs 3 rounds: security + simplifier + tech-lead → arbiter.
 
+## Docs discipline
+
+- **Mark planned vs current explicitly.** When a doc describes a feature
+  not yet wired into code, prefix the section with `PLANNED:` or
+  `NOT YET WIRED:`. Never write future-tense behaviour as if it were
+  current. Recurring `/fix-review` theme — see dreaming W19 §2.
+- **Update `CLAUDE.md`, `architecture-v2.md`, `strategies.md`
+  together** when a feature lands. Drift between these three is the
+  most common review comment in this repo.
+
 ## Banned patterns
 
 - No `--no-verify` on git operations.
@@ -47,3 +57,4 @@ contract and require Tech Lead override.
 - No state writes outside `App.jsx`.
 - No TypeScript in `frontend/`.
 - No commits skipping pre-commit hooks unless user explicitly requests.
+- No `fmt.Println` in `cmd/` packages — use the configured logger.

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -4,7 +4,7 @@
 > with matcher='compact') and emphasized to the compactor (via PreCompact
 > hook). Source of truth for rules that MUST survive context summarization.
 >
-> Keep this file under ~50 lines — every line costs tokens on each
+> Keep this file under ~60 lines — every line costs tokens on each
 > re-injection.
 
 ## Frontend architecture (immutable)

--- a/.claude/dreaming/reports/2026-W19.md
+++ b/.claude/dreaming/reports/2026-W19.md
@@ -1,0 +1,102 @@
+# llm-council dreaming pass — 2026-W19
+
+Date: 2026-05-09
+Branch surveyed: feature/stage2-kind-discriminator
+Commits examined: ~50 (since 2026-02-09, 90-day window; ~30 in last 30 days)
+PRs examined: 20 merged
+
+## TL;DR
+- **`tech-lead/project_architecture.md` is materially stale** (~55 days old) — claims "no tests exist," "stdlib `log` only," "CORS hardcoded," all of which are false post-#26/#31/#33. Refresh or delete before tech-lead reasons from it again.
+- **`tech-lead/known_issues.md` Critical section needs re-verification** — three "Critical" items (no API key validation, Stage3 error swallow, no graceful shutdown) date from 2026-03-14 and are not annotated as resolved despite ~165 PRs of activity since.
+- **Recurring `/fix-review` theme**: docs drift between `strategies.md`, `architecture-v2.md`, `CLAUDE.md` — 4 hits in PR #200 alone (planned-vs-current confusion, tense mismatches). Candidate for a context-essentials note or doc-maintainer skill.
+- **Possible agent overlap**: `security-reviewer.md` (5.8K) and `go-security-reviewer.md` (24.8K) coexist — purposes/triggers should be explicitly disambiguated or one consolidated.
+
+## 1. Context-essentials drift
+
+All four frontend rules and the banned-patterns list were checked against the working tree and the last 30 days of merged code.
+
+- **Rule "No raw HTML rendering of LLM output"** — Evidence: `grep dangerouslySetInnerHTML|innerHTML=` over `frontend/src/` returns nothing. Severity: none. ✅
+- **Rule "Components are pure UI; no `fetch` / `api.js` calls"** — Evidence: `grep fetch(` over `frontend/src/components/` returns nothing; `setCurrentConversation` confined to `App.jsx:8-222`. Severity: none. ✅ (Local UI state via `useState` in `Stage0/1/2.jsx`, `ChatInterface.jsx` is bounded to local widget concerns: `expanded`, `activeTab`, `input`, `context`, `draftAnswers` — none of these touch the assistant-message shape.)
+- **Rule "No `--no-verify`"** — Evidence: `git log --grep=no-verify` returns one match (commit f228d4d), but inspection shows it's the dreaming-pass *feature description* enumerating what to grep for, not a real bypass. Severity: none. ✅
+- **Rule "Backend Go; `go vet` and `go test` before /ship"** — Evidence: CI workflow added in #119, Go version pinned to 1.26.3 in #195. Severity: none. ✅
+- **Rule "Plans deleted after issue creation"** — Evidence: `.claude/plans/` contains only `README.md`. Severity: none. ✅
+- **Rule "No TypeScript in frontend"** — Evidence: no `.ts`/`.tsx` files committed. Severity: none. ✅
+
+Confidence: **high** — no drift in the 30-day window.
+
+## 2. Recurring /fix-review themes
+
+Sampled arbiter summaries / Copilot reviews on PRs #200, #199, #198, #197, #188, #185, #182, #181, #178, #177, #163, #161, #160, #155.
+
+- **"Docs drift / planned-vs-current confusion"** — n=4+ in PR #200 alone (strategies.md quorum table read as implemented; `kind` discriminator phrased as backward-compat; `RoleBased` `len(Roles)` quorum set at registration vs runtime; tense mismatch in architecture-v2.md). Also surfaced in PR #198 (Strategy enum: which variants are actually wired?), PR #196 (RoleBased vs RoleBasedReview distinction needed a dedicated PR to document).
+  - Suggest: add a context-essentials line — "When introducing future-tense features in docs, mark them explicitly (`PLANNED:` / `NOT YET WIRED:`) rather than implying current behaviour." Or extend `docs-maintainer` agent to lint for planned-vs-current ambiguity.
+  - Confidence: high.
+
+- **"Repo-policy violations re-introduced"** — `fmt.Println` in `cmd/eval` (#188) had to be cleaned up despite the existing repo rule. Pattern: rules enforced in `internal/` are not enforced in newly added `cmd/` packages.
+  - Suggest: extend `make lint` / `static-analysis` agent to scan `cmd/` too (one-off PR, may already be done — needs verification).
+  - Confidence: medium.
+
+- **"Tests not added for new defaults"** — PR #160 (Stage 0 default flip) merged with Copilot flagging missing assertions for the new default behaviour. Low-confidence comment suppressed but the gap was real.
+  - Suggest: tech-lead checklist item — "Default-value changes require tests covering both the new default and the explicit opt-out path."
+  - Confidence: medium.
+
+- **"Stage 0 needed many follow-ups"** — #155 introduces → #156 docs → #160 enables-by-default → #161 frontend fix → #163 fence-stripping fix → #179 env-var doc fix. Six PRs in ~14 days.
+  - Suggest: stronger tech-lead gate on first-shot of large stage features (acceptance criteria explicitly include "default-on path" and "documented env vars").
+  - Confidence: medium.
+
+## 3. Stale plans
+
+- None. `.claude/plans/` contains only `README.md`. The "delete plan after issue creation" workflow is being followed cleanly. ✅
+
+## 4. Agent-memory health
+
+- **tech-lead/project_architecture.md** (mtime 2026-03-15, ~55 days old):
+  - Claims **"No tests exist yet"** — false (Vitest harness in #181, council/storage/handler tests since #26/#37/#38).
+  - Claims **"No structured logging; stdlib `log` package only"** — likely false; PR #33 mentions `slog.Warn` for write errors. Needs verification.
+  - Claims **"CORS: only localhost:5173 and localhost:3000 allowed"** — false; PR #31 made `CORSOrigins` configurable via env.
+  - Claims **"GenerateTitle uses a hardcoded model"** — false; `TitleModel` field added in PR #27.
+  - Severity: **medium-high**. Tech-lead reasons from this; outdated facts will produce outdated guidance.
+  - Suggest: rewrite from current state, or add a "supersedes lines X–Y" annotation.
+
+- **tech-lead/known_issues.md** (mtime 2026-03-23, ~47 days old):
+  - "Critical" items are unannotated despite likely resolution: "No API key validation at startup," "Stage3SynthesizeFinal never returns an error," "No graceful shutdown" — all dating from 2026-03-14, none cross-referenced to a closed PR.
+  - "High" items partially marked resolved (`✅ PR #25/27/31/37`), good pattern — extend to Critical block.
+  - Severity: medium. Suggest: a 30-min audit pass to mark each Critical/Medium item as resolved or open with current PR/issue number.
+
+- **go-security-reviewer/project_frontend_security_posture.md** (mtime 2026-04-01, ~38 days old):
+  - References open issues #53 (no CSP) and #54 (backend errors leaked to UI). Status of these issues is unverified.
+  - Otherwise consistent with current frontend posture.
+  - Suggest: re-verify open-issue numbers; close-out the memory if both fixed.
+
+- **agent-memory/MEMORY.md** (top-level): empty placeholder ("Add pointers here as agents write memories"). Acceptable but indicates no project-wide shared memory has accreted — agents are operating with siloed memories only. Worth deciding whether to keep this layer or collapse it.
+
+- No duplicates detected across agents (each MEMORY index disjoint).
+
+## 5. Skill / agent inventory
+
+- **Agents (11):** `bug-fixer`, `ci-build-agent`, `code-generator`, `code-simplifier`, `docs-maintainer`, `go-security-reviewer`, `pm-issue-writer`, `security-reviewer`, `static-analysis`, `tech-lead`, `test-generator`.
+  - **Overlap suspect**: `security-reviewer.md` (5.8K) vs `go-security-reviewer.md` (24.8K). Both invoked from `/find-bugs` and `/fix-review` flows. Need an explicit "when each fires" disambiguator in their frontmatter.
+  - Confidence: medium (would need both agent definitions read in full to confirm).
+
+- **Skills (10):** `backlog`, `find-bugs`, `fix-review`, `housekeeping`, `improve`, `lib`, `review-deps`, `revival`, `self-learn`, `ship`. All committed within the last ~30 days (#178). No usage telemetry available, so obsolescence cannot be measured directly.
+  - `revival` (10.7K) is the largest; skill description ("self-diagnosis through biological metaphors") is uncommonly framed — verify it's actually being run, not just shipped.
+  - Suggest: add a counter / log line in each skill so future dreaming passes can detect dead skills.
+
+## 6. Patterns I noticed
+
+- **Refactor cadence after late-design realisations**: `RoleBasedReview` shipped (#177), was renamed to `RoleBased` 7 days later (#198), then the entire code-review feature surface ripped out (#199). Three PRs to undo what one PR introduced. Likely the underlying issue was that "code-review" was conflated with the `RoleBased` strategy; better to gate strategy-vs-feature naming at Tech Lead before code-generator. Worth a `tech-lead` memory: *"If a strategy and a feature share a name, raise it as a design smell before approving."*
+
+- **CI tooling churn just before policy enforcement**: pin go-version (#195) → drop fmt.Println (#188) → split bundle (#197) all in the same week as the dreaming-pass infrastructure (#185, #200). Consistent with a "stabilise the rails, then enforce" arc — healthy.
+
+- **Frontend test coverage just bootstrapped (#181, 2026-05-02)** but agent memory still says "no tests." Memories are not auto-refreshed by PRs that invalidate them; the dreaming pass is currently the only mechanism for that.
+
+- **Top-level memory in user's auto-memory system contradicts repo state**: `MEMORY.md` index entry [project_v2_design_decisions.md](project_v2_design_decisions.md) is described as *"v2 planning phase status"* but `CLAUDE.md` says "v2 shipping. The v1 implementation is archived on `archive/v1`. v2 is the active codebase". Auto-memory may need a refresh prompt similar to the agent-memory dreaming pass.
+
+## 7. What I couldn't tell (need manual review)
+
+- Whether `security-reviewer` and `go-security-reviewer` actually have distinct, documented invocation triggers, or whether one is dead.
+- Whether GitHub issues #53 (no CSP) and #54 (backend errors leak to UI) referenced in `go-security-reviewer/project_frontend_security_posture.md` are still open.
+- Whether the three "Critical" items in `tech-lead/known_issues.md` are silently resolved, or genuinely still open.
+- Whether each of the 10 skills in `.claude/skills/` has been invoked in a recent transcript — no usage signal exists in the repo.
+- Whether `slog` is actually adopted across `internal/` (relevant to `tech-lead/project_architecture.md` line 44).
+- Whether the user-level auto-memory `project_context.md` ("v2 planning phase") is just a stale title — content not inspected this pass.


### PR DESCRIPTION
## Summary

Three changes from the [W19 dreaming pass report](.claude/dreaming/reports/2026-W19.md) — async curation pass that ran 2026-05-09. Read-only audit found drift in three places; this PR applies the fixes.

### 1. `context-essentials.md`: docs discipline + cmd/ Println ban (W19 §2)

Recurring `/fix-review` theme across PR #200 (and earlier): planned-vs-current confusion in `strategies.md` / `architecture-v2.md` / `CLAUDE.md`. New rule: prefix not-yet-wired sections with `PLANNED:` / `NOT YET WIRED:`. Plus: no `fmt.Println` in `cmd/` packages — pattern enforced in `internal/` should extend to `cmd/`.

### 2. `tech-lead/project_architecture.md`: rewrite from current code (W19 §4)

Old version (2026-03-14, ~57 days) had four claims that **don't match current code**:

| Old claim | Actual state |
|-----------|--------------|
| ❌ "No tests exist" | ✅ 17 test files (api/council/eval/storage) |
| ❌ "stdlib `log` only" | ✅ `log/slog` in 5 modules |
| ❌ "No graceful shutdown" | ✅ `srv.Shutdown(ctx)` at `cmd/server/main.go:74` |
| ❌ "GenerateTitle hardcoded `gemini-2.5-flash`" | No longer matches code |

Rewrite reflects current state and adds: Stage 0 clarification, eval package, role-based pipeline, `interfaces.go` (LLMClient/Runner/Stage0Runner DI seam). Memory now includes "What changed since 2026-03-14" trailer for traceability.

**Notable**: dreaming claimed CORS was made configurable via env in PR #31 — verification against actual code shows the hardcoded `var allowedOrigins` map is still there. Memory now reflects code-truth, not dreaming-claim. Lesson: dreaming reports are evidence, verify against current code.

### 3. Security agents: explicit scope boundaries (W19 §5)

`security-reviewer.md` (5.8K) and `go-security-reviewer.md` (24.8K) had overlapping descriptions ("analyze Go or JavaScript/React"). Now:

- **`security-reviewer`** = frontend (React) ONLY
- **`go-security-reviewer`** = Go + infra-as-code (Docker, .env, CI/CD, K8s, Terraform) ONLY

Both descriptions now reference each other and clarify they have non-overlapping scopes (may both run on full-stack PRs).

## Test plan

- [ ] No build/test/lint impact expected (only `.claude/` files touched)
- [ ] CI checks pass via `gh pr checks`

## Files

```
.claude/agent-memory/tech-lead/project_architecture.md  | 94 ++++++++++++-----
.claude/agents/go-security-reviewer.md                  | 18 +++-
.claude/agents/security-reviewer.md                     |  7 +-
.claude/context-essentials.md                           | 11 ++
.claude/dreaming/reports/2026-W19.md                    | + new (audit trail)
```

Refs: `.claude/dreaming/reports/2026-W19.md` §2, §4, §5

🤖 Generated with [Claude Code](https://claude.com/claude-code)