### PR TITLE
docs(.claude): switch dreaming README to systemd user timer

### DIFF
--- a/.claude/dreaming/README.md
+++ b/.claude/dreaming/README.md
@@ -10,37 +10,61 @@ Manually:
 ~/wrk/projects/llm-council/llm-council/.claude/dreaming/dreaming.sh
 ```
 
-Scheduled — **systemd user timer** (recommended, catches up missed runs):
+Scheduled — **systemd user timer** (recommended, catches up missed runs).
+Create **two** unit files at the paths shown below:
+
+`~/.config/systemd/user/dreaming-llm-council.service`:
 
 ```ini
-# ~/.config/systemd/user/dreaming-llm-council.service
 [Service]
 Type=oneshot
 ExecStart=/home/val/wrk/projects/llm-council/llm-council/.claude/dreaming/dreaming.sh
+# `claude` CLI needs OPENROUTER_API_KEY (and any other secrets the script
+# uses). systemd user units start with a near-empty environment, so the
+# script's reliance on a parent shell loading .env doesn't apply here —
+# load it explicitly. EnvironmentFile= treats the file as missing-OK only
+# when prefixed with `-`, which is what we want during first-run setup.
+EnvironmentFile=-%h/wrk/projects/llm-council/llm-council/.env
 # Use the script's own log directory (~/.cache/llm-council/, mode 0700)
 # rather than /tmp — /tmp is world-readable and could leak secrets if the
 # pass ever logs prompt content, env values, or stack traces.
 StandardOutput=append:%h/.cache/llm-council/dreaming-systemd.log
 StandardError=append:%h/.cache/llm-council/dreaming-systemd.log
+```
 
-# ~/.config/systemd/user/dreaming-llm-council.timer
+`~/.config/systemd/user/dreaming-llm-council.timer`:
+
+```ini
+[Unit]
+Description=Weekly llm-council dreaming pass
+
 [Timer]
 OnCalendar=Sun 04:00          # Nominal — комп зазвичай вимкнений
-Persistent=true                # Catch up at next login
+Persistent=true                # Catch up the most recent missed run at next login
 RandomizedDelaySec=5min        # Spread bursty boot-time catchups
 
 [Install]
 WantedBy=timers.target
 ```
 
+Activate:
+
 ```bash
 systemctl --user daemon-reload
 systemctl --user enable --now dreaming-llm-council.timer
+
+# Optional but recommended: keeps the user-level systemd manager running
+# even when you're logged out, so the timer fires on overnight catchup
+# instead of waiting for your next login session.
+loginctl enable-linger "$USER"
 ```
 
-**Чому НЕ cron:** cron не догоняє пропущених runs — якщо комп вимкнений
-у Sun 04:00, run просто втрачається. systemd `Persistent=true` запам'ятовує
-і фаєриться на наступному login.
+**Чому НЕ cron:** vanilla cron не догоняє пропущених runs — якщо комп
+вимкнений у Sun 04:00, run просто втрачається. systemd `Persistent=true`
+запам'ятовує **останній** пропущений елапс і фаєриться на наступному
+login (multi-week downtime ≠ multiple backfilled runs — one catch-up only,
+plus the next normal cadence). `anacron` would also catch up but it lacks
+per-minute granularity and rarely covers user crontabs.
 
 ## Що шукає
 
@@ -70,7 +94,7 @@ systemctl --user enable --now dreaming-llm-council.timer
 
 | | /revival | dreaming |
 |---|----------|----------|
-| Тригер | On-demand | Scheduled (cron) |
+| Тригер | On-demand | Scheduled (systemd timer) |
 | Scope | Health snapshot | Pattern detection across time |
 | Вхід | Структура зараз | Recent commits + PR comments |
 | Output | Snapshot діагноз | Trend report |

--- a/.claude/dreaming/README.md
+++ b/.claude/dreaming/README.md
@@ -17,8 +17,11 @@ Scheduled — **systemd user timer** (recommended, catches up missed runs):
 [Service]
 Type=oneshot
 ExecStart=/home/val/wrk/projects/llm-council/llm-council/.claude/dreaming/dreaming.sh
-StandardOutput=append:/tmp/dreaming-cron.log
-StandardError=append:/tmp/dreaming-cron.log
+# Use the script's own log directory (~/.cache/llm-council/, mode 0700)
+# rather than /tmp — /tmp is world-readable and could leak secrets if the
+# pass ever logs prompt content, env values, or stack traces.
+StandardOutput=append:%h/.cache/llm-council/dreaming-systemd.log
+StandardError=append:%h/.cache/llm-council/dreaming-systemd.log
 
 # ~/.config/systemd/user/dreaming-llm-council.timer
 [Timer]

--- a/.claude/dreaming/README.md
+++ b/.claude/dreaming/README.md
@@ -10,26 +10,34 @@ Manually:
 ~/wrk/projects/llm-council/llm-council/.claude/dreaming/dreaming.sh
 ```
 
-Cron (weekly Sunday 04:00):
-```cron
-0 4 * * 0  /home/val/wrk/projects/llm-council/llm-council/.claude/dreaming/dreaming.sh
-```
+Scheduled — **systemd user timer** (recommended, catches up missed runs):
 
-Або systemd timer:
 ```ini
 # ~/.config/systemd/user/dreaming-llm-council.service
 [Service]
 Type=oneshot
 ExecStart=/home/val/wrk/projects/llm-council/llm-council/.claude/dreaming/dreaming.sh
+StandardOutput=append:/tmp/dreaming-cron.log
+StandardError=append:/tmp/dreaming-cron.log
 
 # ~/.config/systemd/user/dreaming-llm-council.timer
 [Timer]
-OnCalendar=Sun 04:00
-Persistent=true
+OnCalendar=Sun 04:00          # Nominal — комп зазвичай вимкнений
+Persistent=true                # Catch up at next login
+RandomizedDelaySec=5min        # Spread bursty boot-time catchups
 
 [Install]
 WantedBy=timers.target
 ```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now dreaming-llm-council.timer
+```
+
+**Чому НЕ cron:** cron не догоняє пропущених runs — якщо комп вимкнений
+у Sun 04:00, run просто втрачається. systemd `Persistent=true` запам'ятовує
+і фаєриться на наступному login.
 
 ## Що шукає
 

--- a/.claude/skills/apply-dreaming/SKILL.md
+++ b/.claude/skills/apply-dreaming/SKILL.md
@@ -10,10 +10,9 @@ description: "Read the latest llm-council dreaming report and apply
 
 # /apply-dreaming (llm-council)
 
-Weekly review skill for processing dreaming reports from
-`.claude/dreaming/reports/`. Walks items interactively, routes
-substantive code changes through the project's standard PR workflow,
-applies tooling-only changes directly. Leaves an audit trail.
+Walks each dreaming-report finding interactively and leaves an audit
+trail (`[applied YYYY-MM-DD]` / `[planned …]` / `[skipped …]` markers
+appended to the report).
 
 ## When to invoke
 
@@ -205,7 +204,7 @@ Next steps:
 
 ## See also
 
-- `~/Documents/llm-wiki/wiki/dreaming.md` — concept and pattern.
-- `.claude/dreaming/dreaming-prompt.md` — what's looked for in the pass.
+- `.claude/dreaming/dreaming-prompt.md` — what the dreaming pass looks for.
+- `.claude/dreaming/README.md` — how the dreaming script is wired and run.
 - `.claude/context-essentials.md` — load-bearing rules (target of many
   promote-to-rules suggestions).

--- a/.claude/skills/apply-dreaming/SKILL.md
+++ b/.claude/skills/apply-dreaming/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: apply-dreaming
 description: "Read the latest llm-council dreaming report and apply
-  high-confidence findings to .claude/ memory, agents, context-essentials,
-  and code. Goes through the project's standard /backlog → Tech Lead →
-  /ship → /fix-review workflow for code-touching changes; direct edit for
-  .claude/ tooling changes. Annotates report with [applied YYYY-MM-DD]
-  markers. Usage: /apply-dreaming [week|latest]"
+  high-confidence findings. Routes findings through the project's
+  standard /backlog → Tech Lead → /ship → /fix-review workflow for
+  code-touching changes AND for changes to load-bearing .claude/
+  files (agent prompts, context-essentials). Direct edit only for
+  agent-local memory and tooling scripts. Annotates report with
+  [applied YYYY-MM-DD] markers."
+user-invocable: true
+argument-hint: "[week|latest]"
 ---
 
 # /apply-dreaming (llm-council)
@@ -55,6 +58,20 @@ Read REPORT. For each numbered sub-item, extract:
   - "code change / refactor / fix bug" → `code-change`
   - else → `other`
 
+**Confidence inheritance.** Reports state confidence at the **section
+level** (e.g. `§2 — confidence: high`), not always per item. When a
+sub-item has no explicit `confidence` field, inherit it from the
+enclosing section. Default to `medium` only when neither item nor
+section declares a level.
+
+**Idempotency — skip already-marked items.** If the next non-blank
+line after an item starts with `> [applied …]`, `> [planned …]`,
+`> [skipped …]`, or `> [manual-review-required …]`, skip the item
+silently. The report is appended to (never rewritten) on each pass,
+so re-running `/apply-dreaming` on the same report processes only
+new items. Print a summary line at the start: `2026-W##: M new
+items (N already-processed skipped)`.
+
 ### 3. Show TL;DR + counts
 
 ```
@@ -79,60 +96,64 @@ For `low`: skip silently unless user opted in.
 
 ### 5. Apply per category
 
-#### `update-rules` — context-essentials.md
+**Routing rule.** Two paths only:
+- **Plan-and-gate path** for anything load-bearing on agent or runtime
+  behaviour: `code-change`, `update-rules` (context-essentials),
+  `update-agents` (agent prompts), `add-skill`. These all draft a plan
+  and route through `/backlog → Tech Lead → /ship → /fix-review`.
+- **Direct-edit path** only for non-load-bearing artefacts:
+  `update-memory` (agent-local memory, often gitignored) and
+  `fix-tooling` (`.claude/dreaming/*.sh`, `.claude/hooks/*.sh`,
+  internal helper scripts that don't change agent prompts).
 
-Direct edit on `main` if branch protection allows (it doesn't currently —
-project has protection). So:
+Agent prompts and `context-essentials.md` ARE the runtime for the
+agent workflow — including the Tech Lead. Editing them without a
+gate would let dreaming reports silently steer the very agent that
+should review the change. Always plan-and-gate.
 
-1. Create branch: `git switch -c add-essentials-W##`
-2. Edit `.claude/context-essentials.md`. Cite source via inline comment:
-   `<!-- Refs: .claude/dreaming/reports/2026-W##.md §<id> -->`
-3. Show diff, confirm, commit.
-4. Push + `gh pr create` referencing the report.
+#### `update-rules` / `update-agents` / `add-skill` — plan-and-gate
 
-#### `update-memory` — agent-memory/<agent>/<file>.md
+Same as `code-change` (see below). Draft a plan that cites the
+dreaming finding; route through `/backlog`. Tech Lead reviews the
+proposed change to load-bearing infrastructure before it lands.
 
-These are local-only Claude Code files (often gitignored under
-`.claude/agent-memory/`). Edit directly, no PR needed:
+#### `update-memory` — agent-memory/<agent>/<file>.md (direct)
+
+Agent-local files (often gitignored under `.claude/agent-memory/`):
 
 1. Read target memory file.
 2. Apply suggested changes (rewrite if "stale", append if "missing").
 3. Set `last-verified: <today>` in frontmatter.
-4. No commit needed unless `.claude/agent-memory/` is git-tracked here
+4. Skip commit unless `.claude/agent-memory/` is git-tracked here
    (check `git check-ignore` first).
 
-#### `update-agents` — .claude/agents/*.md
+#### `fix-tooling` — scripts under .claude/ (direct + PR)
 
-These ARE typically tracked. Same as `update-rules`:
+For helper scripts (`dreaming.sh`, hook scripts, etc.) that don't
+embed agent prompts:
 
-1. Create branch.
-2. Edit agent prompt(s).
-3. Show diff, commit, push, PR.
-
-#### `add-skill` — new file under .claude/skills/
-
-1. Create branch.
-2. Scaffold `.claude/skills/<name>/SKILL.md` with frontmatter.
-3. Commit, push, PR.
-
-#### `fix-tooling` — scripts under .claude/
-
-1. Create branch.
+1. Create branch: `git switch -c fix/dreaming-W##-<slug>`.
 2. Edit script.
-3. Smoke-test if possible.
+3. Smoke-test: `bash -n <script>` for syntax; run with sample input
+   if the script has a dry-run mode.
 4. Commit, push, PR.
 
-#### `code-change`
+#### `code-change` — plan-and-gate
 
-Substantive code changes go through the project's standard workflow.
-**Don't edit code directly.** Instead:
+Substantive code changes (or any of the plan-and-gate categories
+above) go through the project's standard workflow. **Don't edit
+directly.** Instead:
 
-1. Create a draft plan referencing the dreaming finding:
+1. Draft a plan file referencing the dreaming finding:
    `.claude/plans/<priority>-dreaming-W##-<slug>.md`
-2. Plan frontmatter: `type`, `priority`, `labels`, `github_issue: null`.
-3. Plan body: cite report §<id>, evidence, suggested change.
-4. Tell user: "Created plan. Run `/backlog` to gate through Tech Lead,
-   then `/ship` for implementation."
+2. Plan frontmatter: `type`, `priority`, `labels`, `github_issue: ""`.
+3. Plan body: cite report §<id>, evidence, suggested change, files
+   to touch, acceptance criteria.
+4. Tell user: "Created plan `<priority>-dreaming-W##-<slug>`. Run
+   `/backlog <slug>` to gate it through Tech Lead — pass the **slug
+   without the priority prefix** so `/backlog` finds the existing
+   plan rather than drafting a fresh one. Then `/ship` for
+   implementation."
 
 #### `other` — manual review
 

--- a/.claude/skills/apply-dreaming/SKILL.md
+++ b/.claude/skills/apply-dreaming/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: apply-dreaming
+description: "Read the latest llm-council dreaming report and apply
+  high-confidence findings to .claude/ memory, agents, context-essentials,
+  and code. Goes through the project's standard /backlog → Tech Lead →
+  /ship → /fix-review workflow for code-touching changes; direct edit for
+  .claude/ tooling changes. Annotates report with [applied YYYY-MM-DD]
+  markers. Usage: /apply-dreaming [week|latest]"
+---
+
+# /apply-dreaming (llm-council)
+
+Weekly review skill for processing dreaming reports from
+`.claude/dreaming/reports/`. Walks items interactively, routes
+substantive code changes through the project's standard PR workflow,
+applies tooling-only changes directly. Leaves an audit trail.
+
+## When to invoke
+
+- Monday morning after Sunday 04:00 cron-run produced a fresh report.
+- Or any time after a manual `.claude/dreaming/dreaming.sh` run.
+- Or `/apply-dreaming` (with optional `latest` or `2026-W##` argument).
+
+## Inputs
+
+- Optional argument: `latest` (default) or `YYYY-W##`.
+- Project root: `~/wrk/projects/llm-council/llm-council/`.
+
+## Steps
+
+### 1. Locate report
+
+```bash
+WEEK="${1:-latest}"
+DIR=".claude/dreaming/reports"
+if [[ "$WEEK" == "latest" ]]; then
+  REPORT=$(ls -1t "$DIR"/2026-W*.md 2>/dev/null | head -1)
+else
+  REPORT="$DIR/$WEEK.md"
+fi
+```
+
+### 2. Parse into structured items
+
+Read REPORT. For each numbered sub-item, extract:
+
+- `id`, `title`, `confidence` (high/medium/low)
+- `evidence` — paths/commits/PRs cited
+- `suggestion`
+- `category` — infer from suggestion verb:
+  - "add to context-essentials" → `update-rules`
+  - "rewrite memory / refresh stale facts" → `update-memory`
+  - "merge / consolidate agents" → `update-agents`
+  - "add new skill" → `add-skill`
+  - "fix broken /ship workflow / `gh` invocation" → `fix-tooling`
+  - "code change / refactor / fix bug" → `code-change`
+  - else → `other`
+
+### 3. Show TL;DR + counts
+
+```
+2026-W##: N items (X high, Y medium, Z low)
+TL;DR: ...
+Process all? [y/select/skip-low/abort]
+```
+
+### 4. Triage walk
+
+Iterate `high → medium → low`. For each item:
+
+```
+[H 1/N] §<id>  <title>
+  Evidence: <paths/commits>
+  Suggestion: <suggestion>
+  
+  [a]pply / [s]kip / [v]erify-first / [e]vidence / [q]uit
+```
+
+For `low`: skip silently unless user opted in.
+
+### 5. Apply per category
+
+#### `update-rules` — context-essentials.md
+
+Direct edit on `main` if branch protection allows (it doesn't currently —
+project has protection). So:
+
+1. Create branch: `git switch -c add-essentials-W##`
+2. Edit `.claude/context-essentials.md`. Cite source via inline comment:
+   `<!-- Refs: .claude/dreaming/reports/2026-W##.md §<id> -->`
+3. Show diff, confirm, commit.
+4. Push + `gh pr create` referencing the report.
+
+#### `update-memory` — agent-memory/<agent>/<file>.md
+
+These are local-only Claude Code files (often gitignored under
+`.claude/agent-memory/`). Edit directly, no PR needed:
+
+1. Read target memory file.
+2. Apply suggested changes (rewrite if "stale", append if "missing").
+3. Set `last-verified: <today>` in frontmatter.
+4. No commit needed unless `.claude/agent-memory/` is git-tracked here
+   (check `git check-ignore` first).
+
+#### `update-agents` — .claude/agents/*.md
+
+These ARE typically tracked. Same as `update-rules`:
+
+1. Create branch.
+2. Edit agent prompt(s).
+3. Show diff, commit, push, PR.
+
+#### `add-skill` — new file under .claude/skills/
+
+1. Create branch.
+2. Scaffold `.claude/skills/<name>/SKILL.md` with frontmatter.
+3. Commit, push, PR.
+
+#### `fix-tooling` — scripts under .claude/
+
+1. Create branch.
+2. Edit script.
+3. Smoke-test if possible.
+4. Commit, push, PR.
+
+#### `code-change`
+
+Substantive code changes go through the project's standard workflow.
+**Don't edit code directly.** Instead:
+
+1. Create a draft plan referencing the dreaming finding:
+   `.claude/plans/<priority>-dreaming-W##-<slug>.md`
+2. Plan frontmatter: `type`, `priority`, `labels`, `github_issue: null`.
+3. Plan body: cite report §<id>, evidence, suggested change.
+4. Tell user: "Created plan. Run `/backlog` to gate through Tech Lead,
+   then `/ship` for implementation."
+
+#### `other` — manual review
+
+Print suggestion + evidence. Don't apply. Annotate
+`[manual-review-required 2026-MM-DD]`.
+
+### 6. Annotate report
+
+After each applied item, append (don't modify original):
+
+```markdown
+> [applied 2026-MM-DD: <action>; commit <sha>; PR <num>]
+```
+
+For created plans:
+```markdown
+> [planned 2026-MM-DD: .claude/plans/<file>; awaiting /backlog]
+```
+
+For skipped:
+```markdown
+> [skipped 2026-MM-DD: <reason>]
+```
+
+### 7. Final summary
+
+```
+Applied: N (direct edits on .claude/ tooling)
+Plans created: M (awaiting /backlog → Tech Lead → /ship)
+Manual review: K
+Skipped: P
+
+PRs opened: <list>
+Plans pending: <list>
+Backup: /tmp/dreaming-W##-llm-council-backup-HHMM/
+
+Next steps:
+1. Watch PRs for Copilot review (one round).
+2. Run /backlog on each plan to gate through Tech Lead.
+3. Run /ship on approved plans.
+```
+
+## Constraints (CRITICAL)
+
+- **NEVER push to main directly** — branch protection requires PR.
+- **NEVER auto-apply low confidence** without explicit request.
+- **NEVER skip Tech Lead gate for code-changes** — route through plans.
+- **ALWAYS backup before destructive operations**.
+- **ALWAYS cite report-section** in commit messages and PR body.
+- **One PR per category-batch** (don't mix `update-rules` with
+  `update-agents` in the same PR — different review focus).
+- **Confirm before destructive ops** even at high confidence.
+
+## Anti-patterns
+
+- ❌ Edit code on main directly (will fail branch protection).
+- ❌ Skip plan creation for code-changes (Tech Lead gate is mandatory).
+- ❌ Mix tooling and code changes in one PR.
+- ❌ Modify report's original suggestions (annotate only).
+- ❌ Apply CORS-style "false claims" findings without verifying against
+  current code first (the dreaming pass can be wrong; verify first).
+
+## Companion skills
+
+- `/backlog` — gate plans through Tech Lead.
+- `/ship` — implement approved plan + create PR.
+- `/fix-review` — handle Copilot/Tech Lead review rounds.
+- `/revival` — health snapshot (synchronous, complementary to dreaming).
+
+## See also
+
+- `~/Documents/llm-wiki/wiki/dreaming.md` — concept and pattern.
+- `.claude/dreaming/dreaming-prompt.md` — what's looked for in the pass.
+- `.claude/context-essentials.md` — load-bearing rules (target of many
+  promote-to-rules suggestions).


### PR DESCRIPTION
## Summary

Cron is silently dropping missed runs when the machine is offline at
the scheduled time (Sun 04:00). README was misleading — recommending cron
when the user's typical setup has computer off at night.

Switched README to recommend **systemd user timer with `Persistent=true`**,
which catches up at next user-bus start (typically Monday morning login).

## Companion changes

- `common/dreaming/README.md` + `HOW-TO-APPLY.md` — same migration
- `llm-wiki/wiki/_meta/dreaming/README.md` — same migration

All three dreaming setups now consistently document the systemd path.

## Test plan

- [ ] No build/test/lint impact (docs only)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)