### PR TITLE
⚖️ feat(council,api,frontend): GenerateRankRefine strategy — generate → rank → refine top-K

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,32 @@ DEFAULT_COUNCIL_TEMPERATURE=0.7
 # or tiebreak.
 # MAJORITY_CHAIRMAN_MODEL=anthropic/claude-sonnet-4-5
 
+# ── GenerateRankRefine strategy (generate → rank → refine top-K) ─────────────
+# Setting GENERATE_RANK_REFINE_MODELS registers the "generate-rank-refine"
+# council type at startup — BUT the chairman var is also REQUIRED. Unlike
+# Majority, this strategy has no no-LLM path: Stage 2 ranking and Stage 3
+# refinement are both LLM calls. If models are set without the chairman, the
+# server logs a warning and skips registration so requests fail-fast at
+# startup rather than silently at request time.
+#
+# Best for creative writing, analysis, code generation — tasks where diverse
+# generation matters and per-criterion ranking gives more leverage than
+# peer-review consensus. Default RefineTopK=3 (top 3 candidates advance to
+# refinement); quorum default max(K+1, 3) so at least one candidate is
+# always rejected (the "rank-to-filter" point).
+#
+# Hardcoded ranking criteria for v1: correctness, clarity, completeness,
+# originality. Per-registration / per-request criteria customisation is a
+# planned future variant.
+#
+# GENERATE_RANK_REFINE_MODELS=openai/gpt-4o-mini,anthropic/claude-haiku-4-5,google/gemini-flash-1.5,qwen/qwen3.6-plus
+
+# Required when GENERATE_RANK_REFINE_MODELS is set. The chairman is called
+# twice per request: once to rank (Stage 2), once to refine (Stage 3). Both
+# calls go to the same model. Splitting into separate ranker / refiner models
+# is a future variant.
+# GENERATE_RANK_REFINE_CHAIRMAN_MODEL=anthropic/claude-sonnet-4-5
+
 # ── Storage ─────────────────────────────────────────────────────────────────
 # Directory where conversation JSON files are stored.
 # Created automatically if it does not exist. Default: data/conversations

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -119,6 +119,22 @@ func run() error {
 			Temperature:   cfg.DefaultCouncilTemperature,
 		}
 	}
+	// Mirror cmd/server's opt-in GenerateRankRefine registration. Both env
+	// vars are required (no no-LLM path); skip with a warn if chairman is
+	// missing.
+	if len(cfg.GenerateRankRefineModels) > 0 {
+		if cfg.GenerateRankRefineChairmanModel == "" {
+			logger.Warn("GENERATE_RANK_REFINE_MODELS set but GENERATE_RANK_REFINE_CHAIRMAN_MODEL is empty; skipping registration of \"generate-rank-refine\" council type")
+		} else {
+			registry["generate-rank-refine"] = council.CouncilType{
+				Name:          "generate-rank-refine",
+				Strategy:      council.GenerateRankRefine,
+				Models:        cfg.GenerateRankRefineModels,
+				ChairmanModel: cfg.GenerateRankRefineChairmanModel,
+				Temperature:   cfg.DefaultCouncilTemperature,
+			}
+		}
+	}
 	if _, ok := registry[*councilType]; !ok {
 		return fmt.Errorf("unknown council type %q (known: %v)", *councilType, knownTypes(registry))
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,6 +64,25 @@ func main() {
 		}
 	}
 
+	// GenerateRankRefine registration is opt-in AND requires both env vars.
+	// Unlike Majority, this strategy has no no-LLM path — Stage 2 ranking is
+	// always an arbiter call and Stage 3 refinement is always a chairman call.
+	// If models are set but the chairman is missing, log a warning and skip
+	// registration rather than fail at request time.
+	if len(cfg.GenerateRankRefineModels) > 0 {
+		if cfg.GenerateRankRefineChairmanModel == "" {
+			logger.Warn("GENERATE_RANK_REFINE_MODELS set but GENERATE_RANK_REFINE_CHAIRMAN_MODEL is empty; skipping registration of \"generate-rank-refine\" council type")
+		} else {
+			registry["generate-rank-refine"] = council.CouncilType{
+				Name:          "generate-rank-refine",
+				Strategy:      council.GenerateRankRefine,
+				Models:        cfg.GenerateRankRefineModels,
+				ChairmanModel: cfg.GenerateRankRefineChairmanModel,
+				Temperature:   cfg.DefaultCouncilTemperature,
+			}
+		}
+	}
+
 	client := openrouter.NewClient(cfg.OpenRouterAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger)
 	runner := council.NewCouncil(client, registry, logger)
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -171,6 +171,24 @@ Implemented in `internal/council/majority.go`. Best for factual QA, classificati
 
 Voting variants beyond exact-match (cluster-by-embedding, Borda count, Tournament/Elo, weighted voting) are explicit follow-ups. Registration is opt-in: the `"majority"` council type is added to the registry only when `MAJORITY_MODELS` is set in the environment.
 
+#### `GenerateRankRefine` pipeline (3 stages, arbiter + refiner)
+
+Implemented in `internal/council/generaterankrefine.go`. Best for creative writing, analysis, and code generation — tasks where diverse generation matters and per-criterion ranking gives more leverage than peer-review consensus.
+
+1. **Stage 1** — `runStage1` (reused): all council models run concurrently. Anonymous `Response A`/`B`/… labels assigned via `assignLabels`.
+2. **Quorum check** — `runGenerateRankRefine` resolves `need` inline before calling `checkQuorum`:
+   - `k = max(ct.RefineTopK, 3)` (default `3`)
+   - `need = max(k+1, 3)` when `QuorumMin == 0`
+   - The `k+1` floor enforces "at least one rejection" — refining all candidates defeats the rank-to-filter point.
+3. **Stage 2** — `runRankStage`: single LLM call to `ct.ChairmanModel` with `BuildRankPrompt`. The arbiter scores each candidate against four hardcoded criteria (`correctness`, `clarity`, `completeness`, `originality`) on `[0.0, 1.0]` per criterion, then computes a `total_score`. Per-criterion scores are clamped to `[0.0, 1.0]`; `total_score` is recomputed from clamped values and clamped to `[0.0, len(criteria)]` (defends against arbiter responses with internally-inconsistent or out-of-range numbers). Unknown labels are dropped with a warn log; missing criterion values default to `0.0` with a warn log. **Parse failures are loud errors** — Stage 2 IS the entire ranking; silent fall-through would leak unranked candidates into refinement.
+4. **Sorting + advancing.** Rankings are sorted by `total_score` descending, then by `Label` ascending for stable output. Exactly `k` candidates are marked `Advancing: true`. Tie at the `k` boundary is resolved deterministically by the secondary `Label` sort — no rebalancing, no chairman tiebreak.
+5. **Stage 2 SSE event:** emits `Stage2CompleteData{Kind: "rank_refine", Results: [], Metadata: {..., RankRefine: ...}}`. The `RankRefine` payload carries the full `Rankings`, `TopK`, and `Criteria`.
+6. **Stage 3** — `runRefineStage`: single LLM call to `ct.ChairmanModel` with `BuildRankRefinePrompt`. The chairman receives the top-K candidates and is instructed to **refine, not blend** — pick strong threads, don't average. Failure path matches `runStage3` and `runRoleBasedStage3` (returns `StageThreeResult{Model, DurationMs, Error}` with the wrapped error).
+
+Cost: **N + 2** LLM calls per request (N generation + 1 rank + 1 refine). Both the rank and refine calls go to `ct.ChairmanModel`. Splitting into separate `RankerModel`/`RefinerModel` fields is a future variant.
+
+Registration is opt-in AND requires both `GENERATE_RANK_REFINE_MODELS` and `GENERATE_RANK_REFINE_CHAIRMAN_MODEL`. If models alone are set, the server logs a warning at startup and skips registration so requests fail-fast at startup rather than silently at request time.
+
 #### Per-registration model configuration
 
 Every `CouncilType` registration is independent. Two registrations with the same `Strategy` but different `Models` / `ChairmanModel` are valid — e.g. `"factual-majority"` and `"creative-majority"` both use `Strategy: Majority` with different voter pools. Each strategy has its own namespaced env var family (`MAJORITY_MODELS`, `MAJORITY_CHAIRMAN_MODEL`, `DEBATE_MODELS`, etc.) with fall-through to `COUNCIL_MODELS` / `CHAIRMAN_MODEL` when unset; see [`strategies.md`](./strategies.md) for the full table. Plumbing lands with each strategy's implementation PR.

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -15,10 +15,23 @@ Stage 0 (clarification) runs **before** strategy dispatch and is strategy-indepe
 | `PeerReview` | shipped | `runner.go:runPeerReview` | initial |
 | `RoleBased` | shipped | `rolebased.go:runRoleBased` | #177 |
 | `Majority` | shipped | `majority.go:runMajority` | #205 |
-| `GenerateRankRefine` | planned | — | TBD |
+| `GenerateRankRefine` | shipped | `generaterankrefine.go:runGenerateRankRefine` | #210 |
 | `MultiAgentDebate` | planned | — | TBD |
 | `MixtureOfAgents` | planned | — | TBD |
 | `Delphi` | planned | — | TBD |
+
+### LLM-call cost (per request, ignoring Stage 0)
+
+Operators pick strategies on cost as much as on output quality. For a council of N members:
+
+| Strategy | LLM calls | Notes |
+|----------|-----------|-------|
+| `PeerReview` | **2N + 1** | N generation + N peer review + 1 chairman synthesis |
+| `RoleBased` | **N + 1** | N role outputs + 1 chairman synthesis |
+| `Majority` | **N + (0 or 1)** | N generation; 0 chairman calls when there's a clear plurality and no chairman is configured; 1 for tiebreak or polish |
+| `GenerateRankRefine` | **N + 2** | N generation + 1 ranking + 1 refinement (both go to the chairman) |
+
+`MultiAgentDebate`, `MixtureOfAgents`, and `Delphi` are still planned; their costs will be added when each ships.
 
 ---
 
@@ -100,7 +113,7 @@ PeerReview's existing payload corresponds to `kind: "peer_ranking"`; RoleBased's
 | `peer_ranking` | `PeerReview` | **shipped** | `[]StageTwoResult` — each reviewer's ranked label list | always `0` |
 | `role_stub` | `RoleBased` | **shipped** | `[]` — empty; metadata carries `aggregate_rankings: []`, `consensus_w: 1.0` | always `0` |
 | `vote_tally` | `Majority` | **shipped** | `metadata.vote_tally` is a `VoteTally` (`{clusters: VoteCluster[], winner_label: string}`); `data` is `[]` (Majority does not produce per-reviewer Stage 2 results). `VoteCluster` is `{members: string[], representative: string, votes: int}`. Clusters are sorted by votes desc, then representative asc. | always `0` |
-| `rank_refine` | `GenerateRankRefine` | **reserved** | ranked candidate list with criterion scores; top-K subset that proceeds to refinement | always `0` |
+| `rank_refine` | `GenerateRankRefine` | **shipped** | `metadata.rank_refine` is a `RankRefine` (`{rankings: RankedCandidate[], top_k: int, criteria: string[]}`); `data` is `[]` (the ranking lives in metadata, not per-reviewer). `RankedCandidate` is `{label: string, scores: map<string, float64>, total_score: float64, advancing: bool}`. Rankings are sorted by `total_score` desc, then `label` asc. Exactly `top_k` candidates have `advancing: true`. Per-criterion scores clamped to `[0.0, 1.0]`; `total_score` to `[0.0, len(criteria)]`. | always `0` |
 | `debate_round` | `MultiAgentDebate` | **reserved** | per-debater critique-and-revise output for the current round; references to the round's targets | `1..N`; one event per round, then a final `stage2_complete` with summary |
 | `moa_aggregator` | `MixtureOfAgents` | **reserved** | Layer-2 aggregator outputs; references to which Layer-1 proposers fed each aggregator | always `0` (single aggregator pass) |
 | `delphi_round` | `Delphi` | **reserved** | per-rater rating list for the current round; running averages and convergence indicator | `1..N`; one event per round |

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -130,10 +130,12 @@ export default function ChatInterface({
                   <Stage2
                     kind={msg.stage2Kind}
                     rankings={msg.stage2}
+                    stage1={msg.stage1}
                     labelToModel={msg.metadata?.label_to_model}
                     aggregateRankings={msg.metadata?.aggregate_rankings}
                     consensusW={msg.metadata?.consensus_w}
                     voteTally={msg.metadata?.vote_tally}
+                    rankRefine={msg.metadata?.rank_refine}
                     isLoading={msg.loading?.stage2}
                   />
 

--- a/frontend/src/components/Stage2.css
+++ b/frontend/src/components/Stage2.css
@@ -223,3 +223,120 @@
 .vote-expand-btn:hover {
   color: color-mix(in srgb, var(--accent) 80%, var(--text-primary));
 }
+
+/* Rank-refine view (GenerateRankRefine strategy) */
+
+.rank-refine-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.rank-candidate {
+  padding: 12px;
+  background: var(--bg-stage);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+}
+
+.rank-candidate.advancing {
+  border-color: var(--accent);
+  background: linear-gradient(
+    to right,
+    color-mix(in srgb, var(--accent) 10%, var(--bg-stage)) 0%,
+    var(--bg-stage) 70%
+  );
+}
+
+.rank-candidate-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.rank-candidate-label {
+  font-family: monospace;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.rank-advancing-badge {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 9999px;
+}
+
+.rank-total-score {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-family: monospace;
+}
+
+.rank-criteria-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.rank-criterion-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rank-criterion-name {
+  flex: 0 0 90px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  text-transform: capitalize;
+}
+
+.rank-criterion-track {
+  flex: 1;
+  height: 4px;
+  background: var(--border-color);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.rank-criterion-fill {
+  height: 100%;
+  background: var(--text-muted);
+  transition: width 200ms ease-out;
+}
+
+.rank-candidate.advancing .rank-criterion-fill {
+  background: var(--accent);
+}
+
+.rank-criterion-score {
+  flex: 0 0 36px;
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-family: monospace;
+}
+
+.rank-candidate-content {
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.rank-candidate-content.collapsed {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/frontend/src/components/Stage2.jsx
+++ b/frontend/src/components/Stage2.jsx
@@ -195,6 +195,112 @@ function VoteTallyView({ voteTally, isLoading }) {
   );
 }
 
+// RankRefineView renders the GenerateRankRefine strategy's Stage 2 payload:
+// a vertical list of ranked candidates, each row showing the label, total
+// score, and a horizontal bar per criterion (4 mini-bars per row, each
+// 0.0–1.0). Top-K rows have an "Advancing to refinement" badge + accent
+// border. Long candidate content is truncated with click-to-expand, same
+// pattern as VoteTallyView.
+function RankRefineCandidate({ candidate, criteria, candidateContent }) {
+  const [expanded, setExpanded] = useState(false);
+  const longText = (candidateContent ?? '').length > REPRESENTATIVE_TRUNCATE_THRESHOLD;
+  const total = candidate.total_score?.toFixed?.(2) ?? '0.00';
+
+  return (
+    <div className={`rank-candidate${candidate.advancing ? ' advancing' : ''}`}>
+      <div className="rank-candidate-header">
+        <span className="rank-candidate-label">{candidate.label}</span>
+        {candidate.advancing && (
+          <span className="rank-advancing-badge" aria-label="advancing to refinement">
+            ↑ advancing
+          </span>
+        )}
+        <span className="rank-total-score">total {total}</span>
+      </div>
+      <div className="rank-criteria-bars">
+        {criteria.map((name) => {
+          const score = candidate.scores?.[name] ?? 0;
+          const widthPct = Math.max(2, Math.round(score * 100));
+          return (
+            <div className="rank-criterion-row" key={name}>
+              <span className="rank-criterion-name">{name}</span>
+              <div className="rank-criterion-track" aria-hidden="true">
+                <div className="rank-criterion-fill" style={{ width: `${widthPct}%` }} />
+              </div>
+              <span className="rank-criterion-score">{score.toFixed(2)}</span>
+            </div>
+          );
+        })}
+      </div>
+      {candidateContent && (
+        <>
+          <div className={`rank-candidate-content${longText && !expanded ? ' collapsed' : ''}`}>
+            {candidateContent}
+          </div>
+          {longText && (
+            <button
+              type="button"
+              className="vote-expand-btn"
+              onClick={() => setExpanded((v) => !v)}
+              aria-expanded={expanded}
+            >
+              {expanded ? 'Show less' : 'Show full answer'}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function RankRefineView({ rankRefine, rankings: stage1Rankings, isLoading }) {
+  if (isLoading) {
+    return (
+      <div className="stage stage2">
+        <div className="stage-accordion" aria-disabled="true">
+          <span className="stage-accordion-label">
+            <span className="spinner-sm" />
+            Ranking candidates…
+          </span>
+        </div>
+      </div>
+    );
+  }
+  if (!rankRefine || !rankRefine.rankings || rankRefine.rankings.length === 0) {
+    return null;
+  }
+  // Stage 1 results are passed through `rankings` for content lookup by label.
+  const contentByLabel = {};
+  if (Array.isArray(stage1Rankings)) {
+    for (const r of stage1Rankings) {
+      if (r?.label) contentByLabel[r.label] = r.content ?? '';
+    }
+  }
+  const criteria = Array.isArray(rankRefine.criteria) ? rankRefine.criteria : [];
+
+  return (
+    <div className="stage stage2">
+      <div className="stage-accordion" aria-disabled="true">
+        <span className="stage-accordion-label">
+          Stage 2: Rank &amp; Refine ({rankRefine.top_k ?? 0} advancing of {rankRefine.rankings.length})
+        </span>
+      </div>
+      <div className="stage-body">
+        <div className="rank-refine-list">
+          {rankRefine.rankings.map((c, i) => (
+            <RankRefineCandidate
+              key={`${c.label}-${i}`}
+              candidate={c}
+              criteria={criteria}
+              candidateContent={contentByLabel[c.label]}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // RoleStubView renders a minimal placeholder for the RoleBased strategy,
 // where Stage 2 has no peer-ranking content (roles are complementary).
 function RoleStubView({ isLoading }) {
@@ -244,7 +350,17 @@ function UnknownKindView({ kind }) {
 // undefined / empty / whitespace-only (e.g. an older backend that doesn't
 // emit kind, or a malformed event), we default to peer_ranking because that
 // was the only persisted Stage 2 shape before this PR.
-export default function Stage2({ kind, rankings, labelToModel, aggregateRankings, consensusW, voteTally, isLoading }) {
+export default function Stage2({
+  kind,
+  rankings,
+  labelToModel,
+  aggregateRankings,
+  consensusW,
+  voteTally,
+  rankRefine,
+  stage1,
+  isLoading,
+}) {
   const trimmed = typeof kind === 'string' ? kind.trim() : '';
   const effectiveKind = trimmed || 'peer_ranking';
 
@@ -263,6 +379,8 @@ export default function Stage2({ kind, rankings, labelToModel, aggregateRankings
       return <RoleStubView isLoading={isLoading} />;
     case 'vote_tally':
       return <VoteTallyView voteTally={voteTally} isLoading={isLoading} />;
+    case 'rank_refine':
+      return <RankRefineView rankRefine={rankRefine} rankings={stage1} isLoading={isLoading} />;
     default:
       return <UnknownKindView kind={effectiveKind} />;
   }

--- a/frontend/src/components/Stage2.test.jsx
+++ b/frontend/src/components/Stage2.test.jsx
@@ -125,4 +125,104 @@ describe('Stage2 dispatcher', () => {
       expect(screen.getByRole('button', { name: /Show full answer/i })).toBeInTheDocument();
     });
   });
+
+  describe('RankRefineView (kind="rank_refine")', () => {
+    const fullRankRefine = {
+      top_k: 3,
+      criteria: ['correctness', 'clarity', 'completeness', 'originality'],
+      rankings: [
+        {
+          label: 'Response A',
+          scores: { correctness: 0.9, clarity: 0.9, completeness: 0.9, originality: 0.9 },
+          total_score: 3.6,
+          advancing: true,
+        },
+        {
+          label: 'Response B',
+          scores: { correctness: 0.7, clarity: 0.7, completeness: 0.7, originality: 0.7 },
+          total_score: 2.8,
+          advancing: true,
+        },
+        {
+          label: 'Response C',
+          scores: { correctness: 0.5, clarity: 0.5, completeness: 0.5, originality: 0.5 },
+          total_score: 2.0,
+          advancing: true,
+        },
+        {
+          label: 'Response D',
+          scores: { correctness: 0.3, clarity: 0.3, completeness: 0.3, originality: 0.3 },
+          total_score: 1.2,
+          advancing: false,
+        },
+        {
+          label: 'Response E',
+          scores: { correctness: 0.2, clarity: 0.2, completeness: 0.2, originality: 0.2 },
+          total_score: 0.8,
+          advancing: false,
+        },
+      ],
+    };
+
+    it('renders all candidates with the top-K marked advancing', () => {
+      render(<Stage2 kind="rank_refine" rankRefine={fullRankRefine} isLoading={false} />);
+      expect(screen.getByText(/Stage 2: Rank & Refine/i)).toBeInTheDocument();
+      // 3 advancing badges (top-K).
+      expect(screen.getAllByLabelText(/advancing/i)).toHaveLength(3);
+      // All five labels rendered.
+      for (const label of ['Response A', 'Response B', 'Response C', 'Response D', 'Response E']) {
+        expect(screen.getByText(label)).toBeInTheDocument();
+      }
+      // Criterion names appear (capitalized in CSS but plain text in DOM).
+      expect(screen.getAllByText('correctness').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('clarity').length).toBeGreaterThan(0);
+    });
+
+    it('renders a single advancing candidate when top-K is 1', () => {
+      const oneOf = {
+        top_k: 1,
+        criteria: ['correctness', 'clarity', 'completeness', 'originality'],
+        rankings: [
+          {
+            label: 'Response A',
+            scores: { correctness: 1, clarity: 1, completeness: 1, originality: 1 },
+            total_score: 4,
+            advancing: true,
+          },
+          {
+            label: 'Response B',
+            scores: { correctness: 0.5, clarity: 0.5, completeness: 0.5, originality: 0.5 },
+            total_score: 2,
+            advancing: false,
+          },
+        ],
+      };
+      render(<Stage2 kind="rank_refine" rankRefine={oneOf} isLoading={false} />);
+      expect(screen.getAllByLabelText(/advancing/i)).toHaveLength(1);
+      // Header reports "1 advancing of 2".
+      expect(screen.getByText(/1 advancing of 2/i)).toBeInTheDocument();
+    });
+
+    it('truncates long candidate content with a Show full answer button', () => {
+      const longText =
+        'A long candidate answer that exceeds the truncation threshold so the dispatcher exposes a Show full answer button — '.repeat(2);
+      const stage1 = [
+        { label: 'Response A', content: longText },
+      ];
+      const tally = {
+        top_k: 1,
+        criteria: ['correctness', 'clarity', 'completeness', 'originality'],
+        rankings: [
+          {
+            label: 'Response A',
+            scores: { correctness: 0.9, clarity: 0.9, completeness: 0.9, originality: 0.9 },
+            total_score: 3.6,
+            advancing: true,
+          },
+        ],
+      };
+      render(<Stage2 kind="rank_refine" rankRefine={tally} stage1={stage1} isLoading={false} />);
+      expect(screen.getByRole('button', { name: /Show full answer/i })).toBeInTheDocument();
+    });
+  });
 });

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -706,6 +706,86 @@ func TestSendMessageStream(t *testing.T) {
 			},
 		},
 		{
+			name:   "GenerateRankRefine strategy emits kind=rank_refine on the wire",
+			body:   `{"content":"q","council_type":"generate-rank-refine"}`,
+			storer: okStorer(),
+			runner: &mockRunner{
+				runFull: func(ctx context.Context, query, ct string, onEvent council.EventFunc) error {
+					onEvent("stage1_complete", []council.StageOneResult{
+						{Label: "Response A", Content: "answer a", Model: "openai/gpt-4o-mini"},
+						{Label: "Response B", Content: "answer b", Model: "anthropic/claude-haiku-4-5"},
+						{Label: "Response C", Content: "answer c", Model: "google/gemini-flash-1.5"},
+						{Label: "Response D", Content: "answer d", Model: "qwen/qwen3.6-plus"},
+					})
+					tally := &council.RankRefine{
+						TopK:     3,
+						Criteria: []string{"correctness", "clarity", "completeness", "originality"},
+						Rankings: []council.RankedCandidate{
+							{Label: "Response A", Scores: map[string]float64{"correctness": 0.9, "clarity": 0.9, "completeness": 0.9, "originality": 0.9}, TotalScore: 3.6, Advancing: true},
+							{Label: "Response B", Scores: map[string]float64{"correctness": 0.7, "clarity": 0.7, "completeness": 0.7, "originality": 0.7}, TotalScore: 2.8, Advancing: true},
+							{Label: "Response C", Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5, "originality": 0.5}, TotalScore: 2.0, Advancing: true},
+							{Label: "Response D", Scores: map[string]float64{"correctness": 0.3, "clarity": 0.3, "completeness": 0.3, "originality": 0.3}, TotalScore: 1.2, Advancing: false},
+						},
+					}
+					onEvent("stage2_complete", council.Stage2CompleteData{
+						Kind:    "rank_refine",
+						Results: []council.StageTwoResult{},
+						Metadata: council.Metadata{
+							CouncilType:       "generate-rank-refine",
+							LabelToModel:      map[string]string{"Response A": "openai/gpt-4o-mini"},
+							AggregateRankings: []council.RankedModel{},
+							ConsensusW:        0.625, // 2.5 / 4
+							RankRefine:        tally,
+						},
+					})
+					onEvent("stage3_complete", council.StageThreeResult{Content: "refined", Model: "chairman-z", DurationMs: 100})
+					return nil
+				},
+			},
+			wantCode: http.StatusOK,
+			checkSSE: func(t *testing.T, body string) {
+				for _, line := range strings.Split(body, "\n") {
+					if !strings.HasPrefix(line, "data: ") {
+						continue
+					}
+					var env struct {
+						Type     string           `json:"type"`
+						Kind     string           `json:"kind"`
+						Metadata council.Metadata `json:"metadata"`
+					}
+					if err := json.Unmarshal([]byte(line[6:]), &env); err != nil || env.Type != "stage2_complete" {
+						continue
+					}
+					if env.Kind != "rank_refine" {
+						t.Errorf("kind: got %q, want %q", env.Kind, "rank_refine")
+					}
+					if env.Metadata.RankRefine == nil {
+						t.Fatalf("metadata.rank_refine: nil; expected populated")
+					}
+					if env.Metadata.RankRefine.TopK != 3 {
+						t.Errorf("top_k: got %d, want 3", env.Metadata.RankRefine.TopK)
+					}
+					if len(env.Metadata.RankRefine.Rankings) != 4 {
+						t.Errorf("rankings: got %d, want 4", len(env.Metadata.RankRefine.Rankings))
+					}
+					if len(env.Metadata.RankRefine.Criteria) != 4 {
+						t.Errorf("criteria: got %d, want 4", len(env.Metadata.RankRefine.Criteria))
+					}
+					advancing := 0
+					for _, r := range env.Metadata.RankRefine.Rankings {
+						if r.Advancing {
+							advancing++
+						}
+					}
+					if advancing != 3 {
+						t.Errorf("advancing count: got %d, want 3", advancing)
+					}
+					return
+				}
+				t.Errorf("no stage2_complete event found in body: %s", body)
+			},
+		},
+		{
 			name:   "QuorumError emits error event",
 			body:   `{"content":"test","council_type":"standard"}`,
 			storer: okStorer(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,14 @@ type Config struct {
 	MajorityModels        []string
 	MajorityChairmanModel string
 
+	// GenerateRankRefine strategy registration. BOTH GenerateRankRefineModels
+	// AND GenerateRankRefineChairmanModel must be set for the council type to
+	// be registered — unlike Majority, this strategy has no no-LLM path
+	// (Stage 2 ranking and Stage 3 refinement are both LLM calls). When models
+	// are set but chairman is missing, registration is skipped with a warn log.
+	GenerateRankRefineModels        []string
+	GenerateRankRefineChairmanModel string
+
 	// LLMAPIMaxRetries is the number of retries the OpenRouter client attempts
 	// on transient failures (HTTP 429/502/503/504, network timeouts, EOFs).
 	// 0 disables retries. Default: 2 (3 total attempts including the initial).
@@ -178,6 +186,22 @@ func Load() (*Config, error) {
 	// "no chairman" loud-error path on ties.
 	majorityChairmanModel := strings.TrimSpace(os.Getenv("MAJORITY_CHAIRMAN_MODEL"))
 
+	// GenerateRankRefine generator pool. Empty slice when unset — registration
+	// in cmd/server/main.go also requires the chairman var, otherwise the
+	// strategy can't run (no no-LLM path).
+	var generateRankRefineModels []string
+	if raw := os.Getenv("GENERATE_RANK_REFINE_MODELS"); raw != "" {
+		for _, m := range strings.Split(raw, ",") {
+			if m = strings.TrimSpace(m); m != "" {
+				generateRankRefineModels = append(generateRankRefineModels, m)
+			}
+		}
+	}
+
+	// GenerateRankRefine chairman (required when models are set; whitespace-trim
+	// to match CLARIFICATION_ARBITER_MODEL / MAJORITY_CHAIRMAN_MODEL).
+	generateRankRefineChairmanModel := strings.TrimSpace(os.Getenv("GENERATE_RANK_REFINE_CHAIRMAN_MODEL"))
+
 	llmAPIMaxRetries := 2
 	if raw := os.Getenv("LLM_API_MAX_RETRIES"); raw != "" {
 		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
@@ -206,6 +230,9 @@ func Load() (*Config, error) {
 
 		MajorityModels:        majorityModels,
 		MajorityChairmanModel: majorityChairmanModel,
+
+		GenerateRankRefineModels:        generateRankRefineModels,
+		GenerateRankRefineChairmanModel: generateRankRefineChairmanModel,
 
 		LLMAPIMaxRetries: llmAPIMaxRetries,
 	}, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -287,3 +287,87 @@ func TestLoad_MajorityModels_BothUnset(t *testing.T) {
 		t.Errorf("MajorityChairmanModel: got %q, want empty", cfg.MajorityChairmanModel)
 	}
 }
+
+// ── TestLoad_GenerateRankRefineModels ─────────────────────────────────────
+//
+// Both GENERATE_RANK_REFINE_MODELS and GENERATE_RANK_REFINE_CHAIRMAN_MODEL
+// must be set for the council type to register (no no-LLM path). Loader
+// leaves both fields empty when env vars unset (no pre-fill); the wiring
+// in cmd/server/main.go decides whether to register based on both fields.
+
+func TestLoad_GenerateRankRefineModels_BothSet(t *testing.T) {
+	baseEnv(t)
+	setenv(t, "GENERATE_RANK_REFINE_MODELS", "openai/gpt-4o-mini, anthropic/claude-haiku-4-5, google/gemini-flash-1.5, qwen/qwen3.6-plus")
+	setenv(t, "GENERATE_RANK_REFINE_CHAIRMAN_MODEL", "anthropic/claude-sonnet-4-5")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"openai/gpt-4o-mini", "anthropic/claude-haiku-4-5", "google/gemini-flash-1.5", "qwen/qwen3.6-plus"}
+	if len(cfg.GenerateRankRefineModels) != len(want) {
+		t.Fatalf("GenerateRankRefineModels: got %v, want %v", cfg.GenerateRankRefineModels, want)
+	}
+	for i, m := range want {
+		if cfg.GenerateRankRefineModels[i] != m {
+			t.Errorf("GenerateRankRefineModels[%d]: got %q, want %q", i, cfg.GenerateRankRefineModels[i], m)
+		}
+	}
+	if cfg.GenerateRankRefineChairmanModel != "anthropic/claude-sonnet-4-5" {
+		t.Errorf("GenerateRankRefineChairmanModel: got %q, want %q", cfg.GenerateRankRefineChairmanModel, "anthropic/claude-sonnet-4-5")
+	}
+}
+
+func TestLoad_GenerateRankRefineModels_ModelsOnly_ChairmanEmpty(t *testing.T) {
+	baseEnv(t)
+	setenv(t, "GENERATE_RANK_REFINE_MODELS", "openai/gpt-4o-mini")
+	unsetenv(t, "GENERATE_RANK_REFINE_CHAIRMAN_MODEL")
+	// Loader does NOT pre-fill from CHAIRMAN_MODEL — registration site decides
+	// whether the partial config is enough (it isn't, for this strategy).
+	setenv(t, "CHAIRMAN_MODEL", "global-chairman")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.GenerateRankRefineModels) != 1 || cfg.GenerateRankRefineModels[0] != "openai/gpt-4o-mini" {
+		t.Errorf("GenerateRankRefineModels: got %v, want [openai/gpt-4o-mini]", cfg.GenerateRankRefineModels)
+	}
+	if cfg.GenerateRankRefineChairmanModel != "" {
+		t.Errorf("GenerateRankRefineChairmanModel: got %q, want empty (loader does not pre-fill from CHAIRMAN_MODEL)", cfg.GenerateRankRefineChairmanModel)
+	}
+}
+
+func TestLoad_GenerateRankRefineModels_BothUnset(t *testing.T) {
+	baseEnv(t)
+	unsetenv(t, "GENERATE_RANK_REFINE_MODELS")
+	unsetenv(t, "GENERATE_RANK_REFINE_CHAIRMAN_MODEL")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.GenerateRankRefineModels) != 0 {
+		t.Errorf("GenerateRankRefineModels: got %v, want empty", cfg.GenerateRankRefineModels)
+	}
+	if cfg.GenerateRankRefineChairmanModel != "" {
+		t.Errorf("GenerateRankRefineChairmanModel: got %q, want empty", cfg.GenerateRankRefineChairmanModel)
+	}
+}
+
+func TestLoad_GenerateRankRefineModels_ChairmanWhitespace_TreatedAsUnset(t *testing.T) {
+	// Match CLARIFICATION_ARBITER_MODEL / MAJORITY_CHAIRMAN_MODEL behaviour:
+	// whitespace-only chairman is trimmed to empty so the registration
+	// gate fires correctly.
+	baseEnv(t)
+	setenv(t, "GENERATE_RANK_REFINE_MODELS", "m-a")
+	setenv(t, "GENERATE_RANK_REFINE_CHAIRMAN_MODEL", "   ")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.GenerateRankRefineChairmanModel != "" {
+		t.Errorf("GenerateRankRefineChairmanModel: got %q, want empty (whitespace trim)", cfg.GenerateRankRefineChairmanModel)
+	}
+}

--- a/internal/council/generaterankrefine.go
+++ b/internal/council/generaterankrefine.go
@@ -1,0 +1,283 @@
+package council
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+)
+
+// defaultRankRefineCriteria is the v1 fixed set of ranking criteria. Per-
+// registration and per-request overrides are deferred — the load-bearing risk
+// for this strategy lives in prompt engineering, not config schema.
+var defaultRankRefineCriteria = []string{"correctness", "clarity", "completeness", "originality"}
+
+// defaultRefineTopK is used when CouncilType.RefineTopK is zero-valued.
+const defaultRefineTopK = 3
+
+// runGenerateRankRefine executes the 3-stage GenerateRankRefine pipeline:
+//
+//   - Stage 1: parallel generation across ct.Models (reuses runStage1)
+//   - Stage 2: single arbiter LLM call ranking the candidates against
+//     defaultRankRefineCriteria, with per-criterion scores in [0.0, 1.0]
+//     and total in [0.0, len(criteria)]; emits kind="rank_refine"
+//   - Stage 3: chairman refines the top-K into the final answer
+//
+// Both Stage 2 and Stage 3 use ct.ChairmanModel. Splitting them into separate
+// RankerModel/RefinerModel fields is deferred — see docs/strategies.md.
+func (c *Council) runGenerateRankRefine(ctx context.Context, query string, ct CouncilType, onEvent EventFunc) error {
+	if len(ct.Models) == 0 {
+		return fmt.Errorf("council type %q has no models configured", ct.Name)
+	}
+	if ct.ChairmanModel == "" {
+		return fmt.Errorf("council type %q has no chairman model configured (GenerateRankRefine requires both ranking and refinement calls)", ct.Name)
+	}
+
+	k := ct.RefineTopK
+	if k == 0 {
+		k = defaultRefineTopK
+	}
+
+	// Stage 1 — parallel generation.
+	allStage1 := c.runStage1(ctx, query, ct.Models, ct.Temperature)
+
+	// Quorum: max(K+1, 3) by default — the K+1 floor enforces "at least one
+	// rejection." Refining all candidates defeats the rank-to-filter point.
+	need := ct.QuorumMin
+	if need == 0 {
+		need = max(k+1, 3)
+	}
+	successful, err := checkQuorum(allStage1, need)
+	if err != nil {
+		return err
+	}
+
+	// Anonymous labels for SSE consistency with PeerReview shape.
+	successfulModels := make([]string, len(successful))
+	for i, r := range successful {
+		successfulModels[i] = r.Model
+	}
+	labelToModel, modelToLabel := assignLabels(successfulModels)
+	for i := range successful {
+		successful[i].Label = modelToLabel[successful[i].Model]
+	}
+
+	if onEvent != nil {
+		onEvent("stage1_complete", successful)
+	}
+
+	// Stage 2 — single arbiter call ranks candidates.
+	rankings, err := c.runRankStage(ctx, query, successful, defaultRankRefineCriteria, k, ct.ChairmanModel, ct.Temperature)
+	if err != nil {
+		return err
+	}
+
+	// Mark exactly k advancing — top-k by sort order even on ties (deterministic
+	// via secondary Label sort in runRankStage). If we have fewer than k
+	// rankings (defensive — quorum already guarantees N >= k+1, so this is
+	// only reachable if the arbiter dropped candidates as unknown labels),
+	// mark all of them and proceed with what we have.
+	advanceCount := k
+	if advanceCount > len(rankings) {
+		advanceCount = len(rankings)
+	}
+	for i := range rankings {
+		rankings[i].Advancing = i < advanceCount
+	}
+
+	tally := &RankRefine{
+		Rankings: rankings,
+		TopK:     k,
+		Criteria: defaultRankRefineCriteria,
+	}
+
+	metadata := Metadata{
+		CouncilType:       ct.Name,
+		LabelToModel:      labelToModel,
+		AggregateRankings: []RankedModel{},
+		ConsensusW:        averageScoreOf(rankings, defaultRankRefineCriteria),
+		RankRefine:        tally,
+	}
+
+	if onEvent != nil {
+		onEvent("stage2_complete", Stage2CompleteData{
+			Kind:     "rank_refine",
+			Results:  []StageTwoResult{},
+			Metadata: metadata,
+		})
+	}
+
+	// Stage 3 — refine the top-K. Build a label→content map of advancing
+	// candidates from the Stage 1 successful list, then call the chairman.
+	advancing := pickAdvancing(successful, rankings)
+	stage3, err := c.runRefineStage(ctx, query, advancing, defaultRankRefineCriteria, ct.ChairmanModel, ct.Temperature)
+	if err != nil {
+		// runRefineStage already populates Model + DurationMs on the result;
+		// emit nothing further and return the wrapped error.
+		return err
+	}
+	if onEvent != nil {
+		onEvent("stage3_complete", stage3)
+	}
+	return nil
+}
+
+// pickAdvancing returns the Stage 1 results corresponding to the advancing
+// rankings, in ranking order (best first). The mapping is by Label.
+func pickAdvancing(stage1 []StageOneResult, rankings []RankedCandidate) []StageOneResult {
+	byLabel := make(map[string]StageOneResult, len(stage1))
+	for _, r := range stage1 {
+		byLabel[r.Label] = r
+	}
+	out := make([]StageOneResult, 0, len(rankings))
+	for _, r := range rankings {
+		if !r.Advancing {
+			continue
+		}
+		if s1, ok := byLabel[r.Label]; ok {
+			out = append(out, s1)
+		}
+	}
+	return out
+}
+
+// averageScoreOf returns the mean TotalScore divided by len(criteria) so the
+// resulting value is in [0.0, 1.0] — useful as a "council quality" signal
+// surfaced via Metadata.ConsensusW (consistent with how Majority repurposes
+// that field for its consensus ratio).
+func averageScoreOf(rankings []RankedCandidate, criteria []string) float64 {
+	if len(rankings) == 0 || len(criteria) == 0 {
+		return 0.0
+	}
+	var sum float64
+	for _, r := range rankings {
+		sum += r.TotalScore
+	}
+	avg := sum / float64(len(rankings))
+	return avg / float64(len(criteria))
+}
+
+// runRankStage calls the arbiter once with the full candidate set + criteria
+// and returns the parsed, validated, sorted rankings. Loud error on any
+// parse failure — Stage 2 IS the entire ranking, so silent fall-through
+// would corrupt refinement.
+func (c *Council) runRankStage(ctx context.Context, query string, candidates []StageOneResult, criteria []string, k int, chairmanModel string, temperature float64) ([]RankedCandidate, error) {
+	prompt := BuildRankPrompt(query, candidates, criteria, k)
+	resp, err := c.client.Complete(ctx, CompletionRequest{
+		Model:          chairmanModel,
+		Messages:       prompt,
+		Temperature:    temperature,
+		ResponseFormat: &ResponseFormat{Type: "json_object"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rank-refine arbiter (%s): %w", chairmanModel, err)
+	}
+	if len(resp.Choices) == 0 {
+		return nil, fmt.Errorf("rank-refine arbiter: %w", errNoChoices)
+	}
+
+	body := StripCodeFence(resp.Choices[0].Message.Content)
+	var parsed struct {
+		Rankings []struct {
+			Label      string             `json:"label"`
+			Scores     map[string]float64 `json:"scores"`
+			TotalScore float64            `json:"total_score"`
+		} `json:"rankings"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		return nil, fmt.Errorf("rank-refine arbiter: %w", err)
+	}
+
+	// Build a known-labels set so we can drop hallucinated labels with a warn.
+	known := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		known[c.Label] = true
+	}
+
+	out := make([]RankedCandidate, 0, len(parsed.Rankings))
+	maxTotal := float64(len(criteria)) // upper bound for TotalScore clamp
+	for _, r := range parsed.Rankings {
+		if !known[r.Label] {
+			if c.logger != nil {
+				c.logger.Warn("rank-refine: unknown label dropped", slog.String("label", r.Label))
+			}
+			continue
+		}
+		// Per-criterion clamp + missing-criterion default.
+		scores := make(map[string]float64, len(criteria))
+		for _, name := range criteria {
+			v, ok := r.Scores[name]
+			if !ok {
+				if c.logger != nil {
+					c.logger.Warn("rank-refine: missing criterion in score", slog.String("label", r.Label), slog.String("criterion", name))
+				}
+				v = 0.0
+			}
+			scores[name] = clamp(v, 0.0, 1.0)
+		}
+		// Recompute TotalScore from clamped values rather than trusting the
+		// arbiter's number — avoids the case where an arbiter returns
+		// internally-inconsistent scores + total.
+		var total float64
+		for _, name := range criteria {
+			total += scores[name]
+		}
+		total = clamp(total, 0.0, maxTotal)
+
+		out = append(out, RankedCandidate{
+			Label:      r.Label,
+			Scores:     scores,
+			TotalScore: total,
+		})
+	}
+
+	// Sort descending by TotalScore, ascending by Label as deterministic
+	// tiebreak. Tie at the K boundary: top-K by sort order, no rebalancing,
+	// no chairman tiebreak.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].TotalScore != out[j].TotalScore {
+			return out[i].TotalScore > out[j].TotalScore
+		}
+		return out[i].Label < out[j].Label
+	})
+
+	return out, nil
+}
+
+// runRefineStage calls the chairman with the top-K candidates and asks for a
+// refined synthesis. Both success and error paths populate Model + DurationMs
+// so error-path observability matches the success path (consistent with
+// runStage3 and runRoleBasedStage3).
+func (c *Council) runRefineStage(ctx context.Context, query string, advancing []StageOneResult, criteria []string, chairmanModel string, temperature float64) (StageThreeResult, error) {
+	start := time.Now()
+	msgs := BuildRankRefinePrompt(query, advancing, criteria)
+	resp, err := c.client.Complete(ctx, CompletionRequest{
+		Model:       chairmanModel,
+		Messages:    msgs,
+		Temperature: temperature,
+	})
+	elapsed := time.Since(start).Milliseconds()
+	result := StageThreeResult{Model: chairmanModel, DurationMs: elapsed}
+	if err != nil {
+		result.Error = err
+		return result, fmt.Errorf("rank-refine refiner (%s): %w", chairmanModel, err)
+	}
+	if len(resp.Choices) == 0 {
+		result.Error = fmt.Errorf("empty response from refiner %s", chairmanModel)
+		return result, result.Error
+	}
+	result.Content = resp.Choices[0].Message.Content
+	return result, nil
+}
+
+func clamp(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/internal/council/generaterankrefine_test.go
+++ b/internal/council/generaterankrefine_test.go
@@ -1,0 +1,615 @@
+package council
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// rankRefineRecorder is a thread-safe collector that classifies each completion
+// request as a Stage 1 generation, a rank arbiter call, or a refine call by
+// inspecting the prompt prefix:
+//   - Generator prompts are the council's deliberation prompt (Stage 1) — they
+//     contain the question text and no discriminator phrase.
+//   - Rank prompts start with "You rank council answers."
+//   - Refine prompts start with "You refine the top-K council answers."
+type rankRefineRecorder struct {
+	mu          sync.Mutex
+	stage1      map[string]string // model → answer to return
+	rankOut     string            // arbiter's JSON response
+	refineOut   string            // refiner's response
+	rankErr     error             // if non-nil, rank call returns this error
+	refineErr   error             // if non-nil, refine call returns this error
+	calls       []string          // labels: "stage1:<model>", "rank:<model>", "refine:<model>"
+	rankPrompt  string            // last rank prompt (for assertions)
+	refinePrompt string           // last refine prompt (for assertions)
+}
+
+func (r *rankRefineRecorder) record(req CompletionRequest) (CompletionResponse, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	body := ""
+	if len(req.Messages) > 0 {
+		body = req.Messages[0].Content
+	}
+	switch {
+	case strings.Contains(body, "You rank council answers"):
+		r.calls = append(r.calls, "rank:"+req.Model)
+		r.rankPrompt = body
+		if r.rankErr != nil {
+			return CompletionResponse{}, r.rankErr
+		}
+		return makeResponse(r.rankOut), nil
+	case strings.Contains(body, "You refine the top-K council answers"):
+		r.calls = append(r.calls, "refine:"+req.Model)
+		r.refinePrompt = body
+		if r.refineErr != nil {
+			return CompletionResponse{}, r.refineErr
+		}
+		return makeResponse(r.refineOut), nil
+	default:
+		// Stage 1 generation.
+		r.calls = append(r.calls, "stage1:"+req.Model)
+		ans, ok := r.stage1[req.Model]
+		if !ok {
+			return CompletionResponse{}, errors.New("no answer scripted for " + req.Model)
+		}
+		return makeResponse(ans), nil
+	}
+}
+
+func rankRefineCouncil(t *testing.T, models []string, chairman string, refineTopK int, rec *rankRefineRecorder) *Council {
+	t.Helper()
+	registry := map[string]CouncilType{
+		"test": {
+			Name:          "test",
+			Strategy:      GenerateRankRefine,
+			Models:        models,
+			ChairmanModel: chairman,
+			Temperature:   0.7,
+			RefineTopK:    refineTopK,
+		},
+	}
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			return rec.record(req)
+		},
+	}
+	return NewCouncil(client, registry, nil)
+}
+
+// rankResponseJSON is a helper to build a rank-arbiter JSON response.
+func rankResponseJSON(t *testing.T, entries []rankEntry) string {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString(`{"rankings":[`)
+	for i, e := range entries {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(`{"label":"`)
+		b.WriteString(e.Label)
+		b.WriteString(`","scores":{`)
+		j := 0
+		for k, v := range e.Scores {
+			if j > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString(`"`)
+			b.WriteString(k)
+			b.WriteString(`":`)
+			fmtFloat(&b, v)
+			j++
+		}
+		b.WriteString(`},"total_score":`)
+		fmtFloat(&b, e.Total)
+		b.WriteString(`}`)
+	}
+	b.WriteString(`]}`)
+	return b.String()
+}
+
+// fmtFloat writes a compact decimal representation of v into b — used by
+// rankResponseJSON when building arbiter response fixtures.
+func fmtFloat(b *strings.Builder, v float64) {
+	b.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+}
+
+type rankEntry struct {
+	Label  string
+	Scores map[string]float64
+	Total  float64
+}
+
+// ── 1. Happy path ─────────────────────────────────────────────────────────
+
+func TestRunGenerateRankRefine_HappyPath(t *testing.T) {
+	rec := &rankRefineRecorder{
+		stage1: map[string]string{
+			"m-a": "answer a", "m-b": "answer b", "m-c": "answer c",
+			"m-d": "answer d", "m-e": "answer e",
+		},
+		rankOut: rankResponseJSON(t, []rankEntry{
+			{Label: "Response A", Scores: map[string]float64{"correctness": 0.8, "clarity": 0.8, "completeness": 0.8, "originality": 0.8}, Total: 3.2},
+			{Label: "Response B", Scores: map[string]float64{"correctness": 0.7, "clarity": 0.7, "completeness": 0.7, "originality": 0.7}, Total: 2.8},
+			{Label: "Response C", Scores: map[string]float64{"correctness": 0.6, "clarity": 0.6, "completeness": 0.6, "originality": 0.6}, Total: 2.4},
+			{Label: "Response D", Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5, "originality": 0.5}, Total: 2.0},
+			{Label: "Response E", Scores: map[string]float64{"correctness": 0.4, "clarity": 0.4, "completeness": 0.4, "originality": 0.4}, Total: 1.6},
+		}),
+		refineOut: "## Refined Answer\n\nThe synthesised answer.",
+	}
+	c := rankRefineCouncil(t, []string{"m-a", "m-b", "m-c", "m-d", "m-e"}, "chairman-z", 0 /* default k=3 */, rec)
+
+	var seenKind string
+	var tally *RankRefine
+	var stage3 StageThreeResult
+	err := c.RunFull(context.Background(), "what is the answer?", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				seenKind = d.Kind
+				tally = d.Metadata.RankRefine
+			}
+		}
+		if eventType == "stage3_complete" {
+			stage3 = data.(StageThreeResult)
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if seenKind != "rank_refine" {
+		t.Errorf("Stage 2 Kind: got %q, want %q", seenKind, "rank_refine")
+	}
+	if tally == nil {
+		t.Fatal("Metadata.RankRefine: nil")
+	}
+	if tally.TopK != 3 {
+		t.Errorf("TopK: got %d, want 3", tally.TopK)
+	}
+	if len(tally.Rankings) != 5 {
+		t.Fatalf("Rankings: got %d, want 5", len(tally.Rankings))
+	}
+	advancing := 0
+	for _, r := range tally.Rankings {
+		if r.Advancing {
+			advancing++
+		}
+	}
+	if advancing != 3 {
+		t.Errorf("advancing count: got %d, want 3", advancing)
+	}
+	if !strings.Contains(stage3.Content, "Refined Answer") {
+		t.Errorf("stage3 content: got %q, want refined output", stage3.Content)
+	}
+	if stage3.Model != "chairman-z" {
+		t.Errorf("stage3 model: got %q, want %q", stage3.Model, "chairman-z")
+	}
+}
+
+// ── 2. Quorum failure ─────────────────────────────────────────────────────
+
+func TestRunGenerateRankRefine_QuorumFailure(t *testing.T) {
+	// k=3 (default), need = max(4, 3) = 4. Scripting only 2 successful answers.
+	rec := &rankRefineRecorder{
+		stage1: map[string]string{
+			"m-a": "ok", "m-b": "ok",
+			// m-c, m-d, m-e have no scripted answer → errors → quorum fails
+		},
+	}
+	c := rankRefineCouncil(t, []string{"m-a", "m-b", "m-c", "m-d", "m-e"}, "chairman-z", 0, rec)
+
+	err := c.RunFull(context.Background(), "q", "test", nil)
+	if err == nil {
+		t.Fatal("expected QuorumError")
+	}
+	var qe *QuorumError
+	if !errors.As(err, &qe) {
+		t.Errorf("error type: got %T, want *QuorumError", err)
+	}
+	if qe != nil && qe.Need != 4 {
+		t.Errorf("QuorumError.Need: got %d, want 4 (max(k+1=4, 3))", qe.Need)
+	}
+}
+
+// ── 3. Custom RefineTopK ──────────────────────────────────────────────────
+
+func TestRunGenerateRankRefine_CustomTopK(t *testing.T) {
+	rec := &rankRefineRecorder{
+		stage1: map[string]string{
+			"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d", "m-e": "e", "m-f": "f",
+		},
+		rankOut: rankResponseJSON(t, []rankEntry{
+			{Label: "Response A", Scores: map[string]float64{"correctness": 1, "clarity": 1, "completeness": 1, "originality": 1}, Total: 4.0},
+			{Label: "Response B", Scores: map[string]float64{"correctness": 0.8, "clarity": 0.8, "completeness": 0.8, "originality": 0.8}, Total: 3.2},
+			{Label: "Response C", Scores: map[string]float64{"correctness": 0.6, "clarity": 0.6, "completeness": 0.6, "originality": 0.6}, Total: 2.4},
+			{Label: "Response D", Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5, "originality": 0.5}, Total: 2.0},
+			{Label: "Response E", Scores: map[string]float64{"correctness": 0.4, "clarity": 0.4, "completeness": 0.4, "originality": 0.4}, Total: 1.6},
+			{Label: "Response F", Scores: map[string]float64{"correctness": 0.3, "clarity": 0.3, "completeness": 0.3, "originality": 0.3}, Total: 1.2},
+		}),
+		refineOut: "refined",
+	}
+	c := rankRefineCouncil(t, []string{"m-a", "m-b", "m-c", "m-d", "m-e", "m-f"}, "chairman-z", 5 /* custom k */, rec)
+
+	var tally *RankRefine
+	err := c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				tally = d.Metadata.RankRefine
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tally == nil || tally.TopK != 5 {
+		t.Fatalf("TopK: got %v, want 5", tally)
+	}
+	advancing := 0
+	for _, r := range tally.Rankings {
+		if r.Advancing {
+			advancing++
+		}
+	}
+	if advancing != 5 {
+		t.Errorf("advancing: got %d, want 5", advancing)
+	}
+}
+
+// ── 4. Default RefineTopK ─────────────────────────────────────────────────
+
+// Covered implicitly by TestRunGenerateRankRefine_HappyPath (RefineTopK=0 → defaults to 3).
+// Adding a focused test on the field default to nail it down explicitly.
+
+func TestRunGenerateRankRefine_DefaultTopKIsThree(t *testing.T) {
+	rec := &rankRefineRecorder{
+		stage1: map[string]string{"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d"},
+		rankOut: rankResponseJSON(t, []rankEntry{
+			{Label: "Response A", Scores: map[string]float64{"correctness": 0.9, "clarity": 0.9, "completeness": 0.9, "originality": 0.9}, Total: 3.6},
+			{Label: "Response B", Scores: map[string]float64{"correctness": 0.7, "clarity": 0.7, "completeness": 0.7, "originality": 0.7}, Total: 2.8},
+			{Label: "Response C", Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5, "originality": 0.5}, Total: 2.0},
+			{Label: "Response D", Scores: map[string]float64{"correctness": 0.3, "clarity": 0.3, "completeness": 0.3, "originality": 0.3}, Total: 1.2},
+		}),
+		refineOut: "refined",
+	}
+	c := rankRefineCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 0, rec)
+
+	var tally *RankRefine
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				tally = d.Metadata.RankRefine
+			}
+		}
+	})
+	if tally == nil || tally.TopK != 3 {
+		t.Fatalf("TopK: got %v, want 3 (default)", tally)
+	}
+}
+
+// ── 5. Arbiter parse failure (loud error) ────────────────────────────────
+
+func TestRunGenerateRankRefine_RankParseFailure_LoudError(t *testing.T) {
+	rec := &rankRefineRecorder{
+		stage1: map[string]string{
+			"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d",
+		},
+		rankOut: "not valid json {{{",
+	}
+	c := rankRefineCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 0, rec)
+
+	var stage3Emitted bool
+	err := c.RunFull(context.Background(), "q", "test", func(eventType string, _ any) {
+		if eventType == "stage3_complete" {
+			stage3Emitted = true
+		}
+	})
+	if err == nil {
+		t.Fatal("expected loud error on rank parse failure")
+	}
+	if !strings.Contains(err.Error(), "arbiter") {
+		t.Errorf("error message: got %q, want it to mention 'arbiter'", err.Error())
+	}
+	if stage3Emitted {
+		t.Error("must NOT emit stage3_complete on rank parse failure")
+	}
+}
+
+// ── 6. Unknown labels dropped ─────────────────────────────────────────────
+
+func TestRunGenerateRankRefine_UnknownLabelsDropped(t *testing.T) {
+	rec := &rankRefineRecorder{
+		stage1: map[string]string{
+			"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d",
+		},
+		rankOut: rankResponseJSON(t, []rankEntry{
+			{Label: "Response A", Scores: map[string]float64{"correctness": 0.9, "clarity": 0.9, "completeness": 0.9, "originality": 0.9}, Total: 3.6},
+			{Label: "Response B", Scores: map[string]float64{"correctness": 0.7, "clarity": 0.7, "completeness": 0.7, "originality": 0.7}, Total: 2.8},
+			{Label: "Hallucinated Z", Scores: map[string]float64{"correctness": 1, "clarity": 1, "completeness": 1, "originality": 1}, Total: 4.0},
+			{Label: "Response C", Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5, "originality": 0.5}, Total: 2.0},
+			{Label: "Response D", Scores: map[string]float64{"correctness": 0.3, "clarity": 0.3, "completeness": 0.3, "originality": 0.3}, Total: 1.2},
+		}),
+		refineOut: "refined",
+	}
+	c := rankRefineCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 0, rec)
+
+	var tally *RankRefine
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				tally = d.Metadata.RankRefine
+			}
+		}
+	})
+	if tally == nil {
+		t.Fatal("tally nil")
+	}
+	if len(tally.Rankings) != 4 {
+		t.Errorf("rankings: got %d, want 4 (Hallucinated Z dropped)", len(tally.Rankings))
+	}
+	for _, r := range tally.Rankings {
+		if r.Label == "Hallucinated Z" {
+			t.Error("hallucinated label survived")
+		}
+	}
+}
+
+// ── 7. Refinement prompt receives top-K ──────────────────────────────────
+
+func TestRunGenerateRankRefine_RefinePromptHasTopKLabels(t *testing.T) {
+	// All 4 models return distinguishable content; assignLabels shuffles
+	// model→label mapping randomly, so we can't predict label→content. We
+	// capture LabelToModel from the stage2 metadata, derive which models
+	// got the top-3 labels (A, B, C), and assert their content reaches the
+	// refine prompt.
+	contentByModel := map[string]string{
+		"m-a": "alpha-content",
+		"m-b": "beta-content",
+		"m-c": "gamma-content",
+		"m-d": "delta-content",
+	}
+	rec := &rankRefineRecorder{
+		stage1: contentByModel,
+		rankOut: rankResponseJSON(t, []rankEntry{
+			{Label: "Response A", Scores: map[string]float64{"correctness": 0.9, "clarity": 0.9, "completeness": 0.9, "originality": 0.9}, Total: 3.6},
+			{Label: "Response B", Scores: map[string]float64{"correctness": 0.7, "clarity": 0.7, "completeness": 0.7, "originality": 0.7}, Total: 2.8},
+			{Label: "Response C", Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5, "originality": 0.5}, Total: 2.0},
+			{Label: "Response D", Scores: map[string]float64{"correctness": 0.3, "clarity": 0.3, "completeness": 0.3, "originality": 0.3}, Total: 1.2},
+		}),
+		refineOut: "refined",
+	}
+	c := rankRefineCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 0, rec)
+
+	var labelToModel map[string]string
+	if err := c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				labelToModel = d.Metadata.LabelToModel
+			}
+		}
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(labelToModel) != 4 {
+		t.Fatalf("LabelToModel: got %d entries, want 4", len(labelToModel))
+	}
+	// Top-3 advancing labels are A, B, C — their content MUST reach the refine prompt.
+	for _, label := range []string{"Response A", "Response B", "Response C"} {
+		model, ok := labelToModel[label]
+		if !ok {
+			t.Fatalf("LabelToModel missing %q", label)
+		}
+		want := contentByModel[model]
+		if !strings.Contains(rec.refinePrompt, want) {
+			t.Errorf("refine prompt missing content of advancing %s (model %s, content %q)", label, model, want)
+		}
+	}
+	// The model behind label D must NOT have its content in the refine prompt.
+	dModel := labelToModel["Response D"]
+	dContent := contentByModel[dModel]
+	if strings.Contains(rec.refinePrompt, dContent) {
+		t.Errorf("refine prompt contains non-advancing content %q (model %s, label D)", dContent, dModel)
+	}
+}
+
+// ── 8. Score parsing edge cases (clamps + missing criterion) ─────────────
+
+func TestRunGenerateRankRefine_ScoreClamping(t *testing.T) {
+	// Arbiter returns a candidate with out-of-range scores and a missing criterion.
+	rec := &rankRefineRecorder{
+		stage1: map[string]string{
+			"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d",
+		},
+		rankOut: `{"rankings":[
+			{"label":"Response A","scores":{"correctness":2.0,"clarity":-0.5,"completeness":99,"originality":0.5},"total_score":99},
+			{"label":"Response B","scores":{"correctness":0.7,"clarity":0.7,"completeness":0.7,"originality":0.7},"total_score":2.8},
+			{"label":"Response C","scores":{"correctness":0.5,"clarity":0.5},"total_score":1.0},
+			{"label":"Response D","scores":{"correctness":0.3,"clarity":0.3,"completeness":0.3,"originality":0.3},"total_score":1.2}
+		]}`,
+		refineOut: "refined",
+	}
+	c := rankRefineCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 0, rec)
+
+	var tally *RankRefine
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				tally = d.Metadata.RankRefine
+			}
+		}
+	})
+	if tally == nil {
+		t.Fatal("tally nil")
+	}
+	// Find Response A — its scores must be clamped to [0,1] each, total to len(criteria)=4.
+	var a *RankedCandidate
+	for i := range tally.Rankings {
+		if tally.Rankings[i].Label == "Response A" {
+			a = &tally.Rankings[i]
+		}
+	}
+	if a == nil {
+		t.Fatal("Response A missing")
+	}
+	for k, v := range a.Scores {
+		if v < 0.0 || v > 1.0 {
+			t.Errorf("score[%s] = %f not clamped to [0,1]", k, v)
+		}
+	}
+	if a.TotalScore < 0.0 || a.TotalScore > 4.0 {
+		t.Errorf("TotalScore = %f not clamped to [0,4]", a.TotalScore)
+	}
+	// Find Response C — missing criteria default to 0.0.
+	var rcC *RankedCandidate
+	for i := range tally.Rankings {
+		if tally.Rankings[i].Label == "Response C" {
+			rcC = &tally.Rankings[i]
+		}
+	}
+	if rcC == nil {
+		t.Fatal("Response C missing")
+	}
+	for _, name := range []string{"correctness", "clarity", "completeness", "originality"} {
+		if _, ok := rcC.Scores[name]; !ok {
+			t.Errorf("missing criterion %q must be defaulted to 0.0, but key absent", name)
+		}
+	}
+	if rcC.Scores["completeness"] != 0.0 || rcC.Scores["originality"] != 0.0 {
+		t.Errorf("missing criteria not defaulted to 0.0: %v", rcC.Scores)
+	}
+}
+
+// ── 9. Sort stability ─────────────────────────────────────────────────────
+
+func TestRunGenerateRankRefine_SortStability(t *testing.T) {
+	// Two pairs of ties: (A,B) at total=3.0; (C,D) at total=2.0. Expect the
+	// secondary sort to put A before B (by Label asc), C before D.
+	// Input order intentionally scrambles the pairs.
+	rec := &rankRefineRecorder{
+		stage1: map[string]string{
+			"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d",
+		},
+		rankOut: rankResponseJSON(t, []rankEntry{
+			{Label: "Response B", Scores: map[string]float64{"correctness": 0.75, "clarity": 0.75, "completeness": 0.75, "originality": 0.75}, Total: 3.0},
+			{Label: "Response D", Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5, "originality": 0.5}, Total: 2.0},
+			{Label: "Response A", Scores: map[string]float64{"correctness": 0.75, "clarity": 0.75, "completeness": 0.75, "originality": 0.75}, Total: 3.0},
+			{Label: "Response C", Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5, "originality": 0.5}, Total: 2.0},
+		}),
+		refineOut: "refined",
+	}
+	c := rankRefineCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 0, rec)
+
+	var tally *RankRefine
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				tally = d.Metadata.RankRefine
+			}
+		}
+	})
+	if tally == nil {
+		t.Fatal("tally nil")
+	}
+	wantOrder := []string{"Response A", "Response B", "Response C", "Response D"}
+	if len(tally.Rankings) != len(wantOrder) {
+		t.Fatalf("rankings: got %d, want %d", len(tally.Rankings), len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if tally.Rankings[i].Label != want {
+			t.Errorf("rankings[%d]: got %q, want %q", i, tally.Rankings[i].Label, want)
+		}
+	}
+}
+
+// ── 10. Tie at K boundary (deterministic) ─────────────────────────────────
+
+func TestRunGenerateRankRefine_TieAtKBoundary(t *testing.T) {
+	// k=3 default. Candidates ranked 3 and 4 share total_score=2.0.
+	// Expect the secondary Label sort to put C (3rd) before D (4th), so
+	// only C advances. Verify exactly K=3 candidates have Advancing=true.
+	rec := &rankRefineRecorder{
+		stage1: map[string]string{
+			"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d",
+		},
+		rankOut: rankResponseJSON(t, []rankEntry{
+			{Label: "Response A", Scores: map[string]float64{"correctness": 0.9, "clarity": 0.9, "completeness": 0.9, "originality": 0.9}, Total: 3.6},
+			{Label: "Response B", Scores: map[string]float64{"correctness": 0.7, "clarity": 0.7, "completeness": 0.7, "originality": 0.7}, Total: 2.8},
+			{Label: "Response C", Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5, "originality": 0.5}, Total: 2.0},
+			{Label: "Response D", Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5, "originality": 0.5}, Total: 2.0},
+		}),
+		refineOut: "refined",
+	}
+	c := rankRefineCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 0, rec)
+
+	var tally *RankRefine
+	if err := c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				tally = d.Metadata.RankRefine
+			}
+		}
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tally == nil {
+		t.Fatal("tally nil")
+	}
+	// Exactly 3 advancing.
+	advancingLabels := []string{}
+	for _, r := range tally.Rankings {
+		if r.Advancing {
+			advancingLabels = append(advancingLabels, r.Label)
+		}
+	}
+	if len(advancingLabels) != 3 {
+		t.Fatalf("advancing count: got %d (%v), want 3", len(advancingLabels), advancingLabels)
+	}
+	// C advances, D does not (deterministic by Label sort).
+	want := map[string]bool{"Response A": true, "Response B": true, "Response C": true}
+	for _, lbl := range advancingLabels {
+		if !want[lbl] {
+			t.Errorf("unexpected advancing label %q (D should NOT advance — Label sort puts C before D)", lbl)
+		}
+	}
+}
+
+// ── 11. Refine-call failure populates Model + DurationMs ─────────────────
+
+func TestRunGenerateRankRefine_RefineFailure_PopulatesModelAndDuration(t *testing.T) {
+	rec := &rankRefineRecorder{
+		stage1: map[string]string{
+			"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d",
+		},
+		rankOut: rankResponseJSON(t, []rankEntry{
+			{Label: "Response A", Scores: map[string]float64{"correctness": 0.9, "clarity": 0.9, "completeness": 0.9, "originality": 0.9}, Total: 3.6},
+			{Label: "Response B", Scores: map[string]float64{"correctness": 0.7, "clarity": 0.7, "completeness": 0.7, "originality": 0.7}, Total: 2.8},
+			{Label: "Response C", Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5, "originality": 0.5}, Total: 2.0},
+			{Label: "Response D", Scores: map[string]float64{"correctness": 0.3, "clarity": 0.3, "completeness": 0.3, "originality": 0.3}, Total: 1.2},
+		}),
+		refineErr: errors.New("upstream timeout"),
+	}
+	c := rankRefineCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 0, rec)
+
+	err := c.RunFull(context.Background(), "q", "test", nil)
+	if err == nil {
+		t.Fatal("expected error from refine call")
+	}
+	if !strings.Contains(err.Error(), "refiner") {
+		t.Errorf("error message: got %q, want it to mention 'refiner'", err.Error())
+	}
+	// Verify the rank step succeeded but the refine step failed (call sequence).
+	rankCalls, refineCalls := 0, 0
+	for _, c := range rec.calls {
+		if strings.HasPrefix(c, "rank:") {
+			rankCalls++
+		}
+		if strings.HasPrefix(c, "refine:") {
+			refineCalls++
+		}
+	}
+	if rankCalls != 1 || refineCalls != 1 {
+		t.Errorf("call sequence: got rank=%d refine=%d, want 1 of each", rankCalls, refineCalls)
+	}
+}

--- a/internal/council/prompts.go
+++ b/internal/council/prompts.go
@@ -344,3 +344,74 @@ func BuildMajorityTiebreakPrompt(query string, tied []VoteCluster) []ChatMessage
 		{Role: "user", Content: sb.String()},
 	}
 }
+
+// BuildRankPrompt asks the GenerateRankRefine arbiter to score each candidate
+// answer against a fixed set of criteria. Each criterion is scored on [0.0, 1.0];
+// total_score is the sum across criteria.
+//
+// Discriminator prefix: "You rank council answers." — used by tests to classify
+// the call as the rank step (vs the refine step's "You refine the top-K").
+func BuildRankPrompt(query string, candidates []StageOneResult, criteria []string, k int) []ChatMessage {
+	var sb strings.Builder
+	sb.WriteString("You rank council answers. ")
+	fmt.Fprintf(&sb, "%d candidate answers were generated independently for the question below; ", len(candidates))
+	fmt.Fprintf(&sb, "score each one on the criteria below, then identify the top %d that should advance to refinement.\n\n", k)
+	sb.WriteString("Question: ")
+	sb.WriteString(query)
+	sb.WriteString("\n\nCriteria (each scored 0.0–1.0):\n")
+	for _, c := range criteria {
+		fmt.Fprintf(&sb, "- %s\n", c)
+	}
+	sb.WriteString("\nCandidates:\n")
+	for _, cand := range candidates {
+		fmt.Fprintf(&sb, "\n[%s]\n%s\n", cand.Label, cand.Content)
+	}
+	sb.WriteString("\nReturn ONLY a JSON object with this shape:\n")
+	sb.WriteString("```json\n")
+	sb.WriteString("{\n  \"rankings\": [\n    {\n")
+	sb.WriteString("      \"label\": \"<exact label from above>\",\n")
+	sb.WriteString("      \"scores\": { ")
+	for i, c := range criteria {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		fmt.Fprintf(&sb, "\"%s\": <0.0..1.0>", c)
+	}
+	sb.WriteString(" },\n")
+	sb.WriteString("      \"total_score\": <sum of scores>\n")
+	sb.WriteString("    }\n  ]\n}\n```\n")
+	sb.WriteString("Score every candidate. Use the exact label string. ")
+	sb.WriteString("Be discriminating — spread scores across the range so the top-K cut is meaningful.")
+
+	return []ChatMessage{
+		{Role: "user", Content: sb.String()},
+	}
+}
+
+// BuildRankRefinePrompt asks the GenerateRankRefine refiner (the chairman) to
+// produce a final answer from the top-K advancing candidates. The instruction
+// emphasises picking strong threads over averaging — bland blends are the
+// failure mode this strategy is most prone to.
+//
+// Discriminator prefix: "You refine the top-K council answers." — used by
+// tests to classify the call as the refine step.
+func BuildRankRefinePrompt(query string, advancing []StageOneResult, criteria []string) []ChatMessage {
+	var sb strings.Builder
+	sb.WriteString("You refine the top-K council answers. ")
+	fmt.Fprintf(&sb, "An arbiter ranked %d council answers for the question below against these criteria: %s. ", len(advancing), strings.Join(criteria, ", "))
+	sb.WriteString("The top candidates are shown below; produce one refined final answer.\n\n")
+	sb.WriteString("Question: ")
+	sb.WriteString(query)
+	sb.WriteString("\n\nTop candidates:\n")
+	for i, cand := range advancing {
+		fmt.Fprintf(&sb, "\n[Candidate %d] (%s)\n%s\n", i+1, cand.Label, cand.Content)
+	}
+	sb.WriteString("\nRefine — do NOT produce a bland blend or averaged synthesis. ")
+	sb.WriteString("Pick the strongest threads from each candidate and weave them into one answer that is more accurate, clearer, and more complete than any individual candidate. ")
+	sb.WriteString("If one candidate is clearly best on every criterion, prefer it over an unnecessary synthesis. ")
+	sb.WriteString("Reply with the refined answer only — no preamble, no commentary on the ranking process.")
+
+	return []ChatMessage{
+		{Role: "user", Content: sb.String()},
+	}
+}

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -68,6 +68,8 @@ func (c *Council) RunFull(ctx context.Context, query string, councilTypeName str
 		return c.runRoleBased(ctx, query, ct, onEvent)
 	case Majority:
 		return c.runMajority(ctx, query, ct, onEvent)
+	case GenerateRankRefine:
+		return c.runGenerateRankRefine(ctx, query, ct, onEvent)
 	default:
 		return fmt.Errorf("council: strategy %d not implemented", ct.Strategy)
 	}

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -555,7 +555,7 @@ func TestRunFull_Stage2CompletePayload_IsStage2CompleteData(t *testing.T) {
 
 func TestRunFull_UnimplementedStrategy_ReturnsError(t *testing.T) {
 	unimplemented := []Strategy{
-		GenerateRankRefine, MultiAgentDebate, MixtureOfAgents, Delphi,
+		MultiAgentDebate, MixtureOfAgents, Delphi,
 	}
 	for _, s := range unimplemented {
 		s := s

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -49,7 +49,8 @@ type CouncilType struct {
 	Roles         []Role   // RoleBased only: role definitions with specialist instructions.
 	ChairmanModel string
 	Temperature   float64
-	QuorumMin     int // 0 = use formula: max(2, ⌈N/2⌉+1)
+	QuorumMin     int // 0 = strategy-specific default formula
+	RefineTopK    int // GenerateRankRefine only: how many ranked candidates advance to refinement; 0 = default (3)
 }
 
 // ChatMessage is a single turn in a conversation history.
@@ -136,16 +137,40 @@ type VoteTally struct {
 	WinnerLabel string        `json:"winner_label"`
 }
 
+// RankedCandidate is a single Stage 1 answer scored by the GenerateRankRefine
+// arbiter against a fixed set of criteria. Scores are clamped to [0.0, 1.0]
+// per criterion; TotalScore is the sum across all criteria, clamped to
+// [0.0, len(Criteria)].
+type RankedCandidate struct {
+	Label      string             `json:"label"`
+	Scores     map[string]float64 `json:"scores"`
+	TotalScore float64            `json:"total_score"`
+	Advancing  bool               `json:"advancing"`
+}
+
+// RankRefine is the Stage 2 payload for the GenerateRankRefine strategy.
+// Rankings are sorted by TotalScore descending, then by Label ascending for
+// stable output. Exactly TopK candidates have Advancing=true; ties at the
+// K boundary are broken by the secondary Label sort (no rebalancing, no
+// chairman tiebreak). Criteria lists the criterion names in fixed order.
+type RankRefine struct {
+	Rankings []RankedCandidate `json:"rankings"`
+	TopK     int               `json:"top_k"`
+	Criteria []string          `json:"criteria"`
+}
+
 // Metadata is persisted with every assistant message.
 //
-// VoteTally is populated only by the Majority strategy; omitempty keeps it
-// absent on the wire and at rest for every other strategy.
+// VoteTally is populated only by the Majority strategy; RankRefine only by
+// GenerateRankRefine. omitempty keeps each absent on the wire and at rest
+// for every other strategy.
 type Metadata struct {
 	CouncilType       string            `json:"council_type"`
 	LabelToModel      map[string]string `json:"label_to_model"`
 	AggregateRankings []RankedModel     `json:"aggregate_rankings"`
 	ConsensusW        float64           `json:"consensus_w"`
 	VoteTally         *VoteTally        `json:"vote_tally,omitempty"`
+	RankRefine        *RankRefine       `json:"rank_refine,omitempty"`
 }
 
 // Stage2CompleteData is the payload emitted by Runner for the "stage2_complete" event.


### PR DESCRIPTION
## Summary

Implements the fourth deliberation strategy: `GenerateRankRefine`. All council members generate independently (Stage 1). An arbiter ranks the candidates against four hardcoded criteria (Stage 2 — single LLM call producing per-criterion scores). The chairman refines the top-K candidates into the final answer (Stage 3 — single LLM call).

Best for creative writing, analysis, and code generation — tasks where diverse generation matters and per-criterion ranking gives more leverage than peer-review consensus.

Closes #210

## Pipeline

```
Stage 1 — parallel generation (reuses runStage1)
Stage 2 — arbiter ranks candidates against 4 criteria; kind="rank_refine"
Stage 3 — chairman refines top-K (default K=3)
```

**Cost:** `N + 2` LLM calls (N gen + 1 rank + 1 refine). Both rank and refine go to `ct.ChairmanModel`. Splitting into separate `RankerModel`/`RefinerModel` fields is a future variant.

## Hardcoded criteria

`correctness`, `clarity`, `completeness`, `originality`. Per-registration and per-request criteria customisation are explicit follow-ups — keeping them code-fixed for v1 keeps the load-bearing risk in prompt engineering rather than config schema.

## Quorum default

`max(K+1, 3)` where `K = max(ct.RefineTopK, 3)`. The `K+1` floor enforces "at least one rejection" — refining all candidates defeats the rank-to-filter point.

## Tie at K boundary

Deterministic. Secondary sort by Label resolves ties at the cut. **No rebalancing, no chairman tiebreak, exactly K advance.**

## Loud-error patterns (matching #204 Stage 0)

- **Stage 2 parse failure** → `fmt.Errorf("rank-refine arbiter: %w", err)`. Does NOT fall through. Stage 2 IS the ranking; silent fall-through would corrupt refinement.
- **Refine-call failure** → `StageThreeResult` populated with `Model` and `DurationMs` even on error (matches `runStage3` and `runRoleBasedStage3` contracts).

## Score validation

Per-criterion scores clamped to `[0.0, 1.0]`. `total_score` is **recomputed** from clamped values (not trusted from arbiter response) and clamped to `[0.0, len(criteria)]`. Defends against arbiter responses with out-of-range or internally-inconsistent numbers. Missing criteria default to `0.0` with a warn log. Unknown labels dropped with a warn log.

## Registration is opt-in AND requires both env vars

```
GENERATE_RANK_REFINE_MODELS=...           # required to register
GENERATE_RANK_REFINE_CHAIRMAN_MODEL=...   # required (rank + refine calls)
```

If models alone are set, the server logs a warning at startup and skips registration so requests fail-fast at startup rather than silently at request time.

## What's new

**Types** (`internal/council/types.go`):
- `RankedCandidate {Label, Scores, TotalScore, Advancing}`
- `RankRefine {Rankings, TopK, Criteria}`
- `Metadata.RankRefine *RankRefine \`json:"rank_refine,omitempty"\``
- `CouncilType.RefineTopK int` (zero-value defaults to 3)

**Backend implementation** (`internal/council/generaterankrefine.go`):
- `runGenerateRankRefine` (dispatch from `RunFull` switch)
- `runRankStage`, `runRefineStage`, `pickAdvancing`, `clamp` helpers
- `BuildRankPrompt`, `BuildRankRefinePrompt` (in `prompts.go`)

**Config** (`internal/config/config.go`):
- `Config.GenerateRankRefineModels []string`
- `Config.GenerateRankRefineChairmanModel string`
- Two new env vars; whitespace-trim on chairman

**Frontend**:
- `Stage2.jsx` `RankRefineView` — bar chart per criterion (4 mini-bars per row), top-K rows accent-bordered with "↑ advancing" badge, long content truncated with click-to-expand
- `ChatInterface.jsx` threads `rankRefine`, `stage1` props through

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes (**240 tests**, +15 from #209's 225)
- [x] `npm run lint` passes
- [x] `npm run test` passes (**29 tests**, +3 from #209's 26)
- [x] `npm run build` passes within chunk-size budgets

### Backend test cases (11 new in `generaterankrefine_test.go`)
1. Happy path · 2. Quorum failure · 3. Custom RefineTopK · 4. Default RefineTopK · 5. Arbiter parse failure (loud error) · 6. Unknown labels dropped · 7. Refine prompt receives top-K content · 8. Score clamping + missing criterion defaults · 9. Sort stability · 10. **Tie at K boundary (deterministic by Label)** · 11. **Refine-call failure populates Model+DurationMs**

### Wire-format integration (`handler_test.go`)
- Asserts `"kind":"rank_refine"` and `metadata.rank_refine.{rankings, top_k, criteria}` populated; exactly K candidates marked `advancing`

### Config tests (4 new in `config_test.go`)
- Both env vars set · Models-only-set (chairman empty) · Both unset · Chairman whitespace trim

### Frontend dispatcher tests (3 new in `Stage2.test.jsx`)
- Multi-candidate with top-K badges · Single advancing (k=1) · Long content truncation

## Docs

- `docs/strategies.md` — `GenerateRankRefine` row → shipped (#210); `rank_refine` row → shipped with the actual `RankRefine`/`RankedCandidate` schema; **new "LLM-call cost" table** comparing all 4 shipped strategies
- `docs/architecture-v2.md` — new "GenerateRankRefine pipeline" subsection alongside PeerReview/RoleBased/Majority
- `.env.example` — GenerateRankRefine block explicitly noting both env vars must be set

## Out of scope (deferred)

- Other ranking algorithms (cluster-by-embedding, Borda, Tournament/Elo, weighted)
- Per-registration `Criteria []string` field
- Per-request criteria customisation
- Multi-pass refinement (rank → refine → re-rank → refine)
- Separate `RankerModel` / `RefinerModel` fields
- Champion strategy variant (`RefineTopK: 1` with different selection criterion)
- `RankRefine` persistence on `AssistantMessage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)