### PR TITLE
⚖️ feat(council,api,frontend,config): MixtureOfAgents strategy — proposers → aggregators → refiner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,32 @@ DEFAULT_COUNCIL_TEMPERATURE=0.7
 # Invalid values warn and fall back to the runner default.
 # DEBATE_MAX_ROUNDS=2
 
+# ── MixtureOfAgents strategy (proposers → aggregators → refiner) ────────────
+# Three layers, modelled on the Together AI MoA paper. ALL THREE env vars
+# below MUST be set to register the "moa" council type — partial config logs
+# a warning and skips registration. Unlike every other strategy, COUNCIL_MODELS
+# and CHAIRMAN_MODEL are NOT used here; the runner reads the layer-specific
+# fields directly.
+#
+# Best for code generation and complex multi-aspect analysis — tasks where
+# structured layered aggregation beats flat consensus.
+#
+# COST: N + M + 1 LLM calls per request (N proposers + M aggregators + 1
+# refiner). With the defaults below (N=4 M=2): 7 calls per request. Sits
+# between RoleBased (N+1) and Debate (N + N*R + 1).
+#
+# Layer 1 — Proposers. N models generate independent drafts in parallel.
+# MOA_PROPOSER_MODELS=openai/gpt-4o-mini,anthropic/claude-haiku-4-5,google/gemini-flash-1.5,qwen/qwen3.6-plus
+
+# Layer 2 — Aggregators. M models each see ALL Layer 1 outputs (anonymised,
+# all-to-all fan-out per the MoA paper) and produce one improved draft each.
+# MOA_AGGREGATOR_MODELS=anthropic/claude-sonnet-4-5,openai/gpt-4o
+
+# Layer 3 — Refiner. Single model that synthesises the aggregator drafts into
+# the final answer. Sees aggregator outputs WITH model attribution but does
+# NOT see raw proposer outputs (the aggregators have already digested them).
+# MOA_REFINER_MODEL=anthropic/claude-opus-4-7
+
 # ── Storage ─────────────────────────────────────────────────────────────────
 # Directory where conversation JSON files are stored.
 # Created automatically if it does not exist. Default: data/conversations

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -150,6 +150,27 @@ func run() error {
 			}
 		}
 	}
+	// Mirror cmd/server's opt-in MixtureOfAgents registration. Requires all
+	// three MOA_* env vars; partial config is logged and skipped.
+	if len(cfg.MoaProposerModels) > 0 || len(cfg.MoaAggregatorModels) > 0 || cfg.MoaRefinerModel != "" {
+		switch {
+		case len(cfg.MoaProposerModels) == 0:
+			logger.Warn("MOA_AGGREGATOR_MODELS or MOA_REFINER_MODEL set but MOA_PROPOSER_MODELS is empty; skipping registration of \"moa\" council type")
+		case len(cfg.MoaAggregatorModels) == 0:
+			logger.Warn("MOA_PROPOSER_MODELS set but MOA_AGGREGATOR_MODELS is empty; skipping registration of \"moa\" council type")
+		case cfg.MoaRefinerModel == "":
+			logger.Warn("MOA_PROPOSER_MODELS / MOA_AGGREGATOR_MODELS set but MOA_REFINER_MODEL is empty; skipping registration of \"moa\" council type")
+		default:
+			registry["moa"] = council.CouncilType{
+				Name:             "moa",
+				Strategy:         council.MixtureOfAgents,
+				ProposerModels:   cfg.MoaProposerModels,
+				AggregatorModels: cfg.MoaAggregatorModels,
+				RefinerModel:     cfg.MoaRefinerModel,
+				Temperature:      cfg.DefaultCouncilTemperature,
+			}
+		}
+	}
 	if _, ok := registry[*councilType]; !ok {
 		return fmt.Errorf("unknown council type %q (known: %v)", *councilType, knownTypes(registry))
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -101,6 +101,31 @@ func main() {
 		}
 	}
 
+	// MixtureOfAgents registration is opt-in AND requires ALL THREE env vars.
+	// MoA has no no-LLM path: every layer needs models. Models / ChairmanModel
+	// are NOT used — the runner reads ProposerModels / AggregatorModels /
+	// RefinerModel directly. Partial config is logged and skipped (not failed
+	// at request time).
+	if len(cfg.MoaProposerModels) > 0 || len(cfg.MoaAggregatorModels) > 0 || cfg.MoaRefinerModel != "" {
+		switch {
+		case len(cfg.MoaProposerModels) == 0:
+			logger.Warn("MOA_AGGREGATOR_MODELS or MOA_REFINER_MODEL set but MOA_PROPOSER_MODELS is empty; skipping registration of \"moa\" council type")
+		case len(cfg.MoaAggregatorModels) == 0:
+			logger.Warn("MOA_PROPOSER_MODELS set but MOA_AGGREGATOR_MODELS is empty; skipping registration of \"moa\" council type")
+		case cfg.MoaRefinerModel == "":
+			logger.Warn("MOA_PROPOSER_MODELS / MOA_AGGREGATOR_MODELS set but MOA_REFINER_MODEL is empty; skipping registration of \"moa\" council type")
+		default:
+			registry["moa"] = council.CouncilType{
+				Name:             "moa",
+				Strategy:         council.MixtureOfAgents,
+				ProposerModels:   cfg.MoaProposerModels,
+				AggregatorModels: cfg.MoaAggregatorModels,
+				RefinerModel:     cfg.MoaRefinerModel,
+				Temperature:      cfg.DefaultCouncilTemperature,
+			}
+		}
+	}
+
 	client := openrouter.NewClient(cfg.OpenRouterAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger)
 	runner := council.NewCouncil(client, registry, logger)
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -101,7 +101,7 @@ This keeps all dependency injection in one place and makes each package independ
 
 ### Council pipeline (`internal/council`)
 
-The `Strategy` enum carries **7 constants** — 2 are implemented today, 5 are reserved for planned strategies. See [`strategies.md`](./strategies.md) for the full roadmap.
+The `Strategy` enum carries **7 constants** — 6 are implemented today, 1 is reserved for a planned strategy. See [`strategies.md`](./strategies.md) for the full roadmap.
 
 ```go
 type Strategy int
@@ -109,31 +109,44 @@ type Strategy int
 const (
     PeerReview         Strategy = iota // implemented (runner.go:runPeerReview)
     RoleBased                          // implemented (rolebased.go:runRoleBased)
-    Majority                           // not implemented
-    GenerateRankRefine                 // not implemented
-    MultiAgentDebate                   // not implemented
-    MixtureOfAgents                    // not implemented
+    Majority                           // implemented (majority.go:runMajority)
+    GenerateRankRefine                 // implemented (generaterankrefine.go:runGenerateRankRefine)
+    MultiAgentDebate                   // implemented (debate.go:runMultiAgentDebate)
+    MixtureOfAgents                    // implemented (moa.go:runMixtureOfAgents)
     Delphi                             // not implemented
 )
 
 type CouncilType struct {
     Name          string
     Strategy      Strategy
-    Models        []string    // Council members. RoleBased assigns by index mod len.
+    Models        []string    // Council members. RoleBased assigns by index mod len. UNUSED for MixtureOfAgents.
     Roles         []Role      // RoleBased only.
-    ChairmanModel string      // Synthesiser (PeerReview, RoleBased) / arbiter / facilitator.
+    ChairmanModel string      // Synthesiser / arbiter / facilitator. UNUSED for MixtureOfAgents.
     Temperature   float64
-    QuorumMin     int         // 0 = strategy-specific default formula.
+    QuorumMin       int       // 0 = strategy-specific default formula.
+    RefineTopK      int       // GenerateRankRefine only.
+    MaxDebateRounds int       // MultiAgentDebate only.
+
+    // MixtureOfAgents-only model fields. Models / ChairmanModel are UNUSED for MoA.
+    ProposerModels   []string // MoA Layer 1
+    AggregatorModels []string // MoA Layer 2 (parallel, all-to-all over Layer 1)
+    RefinerModel     string   // MoA Layer 3 (single refiner)
 }
 ```
 
-`RunFull()` is a strategy-dispatch switch:
+`MixtureOfAgents` is the first strategy to skip both `Models` and `ChairmanModel`. The runner reads the layer-specific fields directly. The full field-usage matrix (which fields each strategy reads) lives in `CouncilType`'s doc-comment in `internal/council/types.go`.
+
+`RunFull()` is a strategy-dispatch switch — every shipped strategy has its own `case`:
 
 ```go
 switch ct.Strategy {
-case PeerReview: return c.runPeerReview(...)
-case RoleBased:  return c.runRoleBased(...)
-default:         return fmt.Errorf("council: strategy %d not implemented", ct.Strategy)
+case PeerReview:         return c.runPeerReview(...)
+case RoleBased:          return c.runRoleBased(...)
+case Majority:           return c.runMajority(...)
+case GenerateRankRefine: return c.runGenerateRankRefine(...)
+case MultiAgentDebate:   return c.runMultiAgentDebate(...)
+case MixtureOfAgents:    return c.runMixtureOfAgents(...)
+default:                 return fmt.Errorf("council: strategy %d not implemented", ct.Strategy)
 }
 ```
 
@@ -210,6 +223,27 @@ Implemented in `internal/council/debate.go`. Best for reasoning, ethics, and str
 **Round 0 is not in `Debate.Rounds`.** It lives on `AssistantMessage.Stage1` (backend) and `msg.stage1` (frontend). Single source of truth per layer; the schema doesn't lie about what a "debate round" is.
 
 Registration is opt-in AND requires both `DEBATE_MODELS` and `DEBATE_CHAIRMAN_MODEL`. `DEBATE_MAX_ROUNDS` is optional (default 2; invalid values warn and fall back to default).
+
+#### `MixtureOfAgents` pipeline (3 layers)
+
+Implemented in `internal/council/moa.go`. Modelled on the Together AI MoA paper. Best for code generation and complex multi-aspect analysis — tasks where structured layered aggregation beats flat consensus. **First strategy to require new `CouncilType` fields beyond `Models`/`ChairmanModel`** — the field-usage matrix in `internal/council/types.go` documents which strategies read which fields.
+
+1. **Layer 1 (Stage 1)** — `runStage1` reused with `ct.ProposerModels`. Anonymous `Response A`/`B`/… labels assigned via `assignLabels`. Emits `stage1_complete`.
+2. **Layer 1 quorum** — `max(2, ⌈N_proposers/2⌉+1)` when `QuorumMin == 0`. Standard `*QuorumError` if Layer 1 fails.
+3. **Layer 2 (Stage 2)** — `runMoaLayer2`: parallel call per aggregator (`ct.AggregatorModels`), all-to-all fan-out (every aggregator sees every proposer). Aggregators get distinct labels via `assignAggregatorLabels` — `Aggregator A`/`B`/… — so they don't collide with proposer labels in `Metadata.LabelToModel` (a single flat map containing both prefix families). Output is free-form text — no JSON parsing required (the aggregator's job is to write a better draft, not to score).
+4. **Layer 2 quorum** — at least 1 successful aggregator. If all aggregators fail, `runMixtureOfAgents` returns `fmt.Errorf("mixture-of-agents: all aggregators failed (%d configured); refiner has no input", ...)` — loud failure, no `stage2_complete` emitted, no Layer 3 run. Matches the loud-error ethos from #204 / #206 / #212.
+5. **Stage 2 SSE event** — `stage2_complete` with `kind: "moa_aggregator"`, `Metadata.MoaAggregator` populated with `Aggregators[]` (sorted by `Label` asc). Each `AggregatorOutput` carries `{Label, Model, Content, Sources, DurationMs}`; `Sources` lists the Layer 1 proposer labels fed in (today: all-to-all, so every aggregator's `Sources` lists every successful proposer). **No `stage2_round_complete` events** — MoA is single-pass per layer.
+6. **Layer 3 (Stage 3)** — `runMoaRefine`: single LLM call to `ct.RefinerModel` via `BuildMoaRefinerPrompt`. The refiner sees aggregator outputs WITH model attribution (label + model name, mirroring how PeerReview/Debate chairmen receive `LabelToModel`) but does NOT see raw proposer outputs — the aggregators have already digested them. Failure path matches `runStage3` (returns `StageThreeResult{Model, DurationMs, Error}` even on error).
+
+**Cost:** `N + M + 1` LLM calls per request (N proposers + M aggregators + 1 refiner). With defaults N=4 M=2: **7 calls**. Sits between RoleBased (N+1) and the more expensive Debate / PeerReview strategies.
+
+**Anonymisation contract:** the aggregator prompt MUST NOT contain proposer model names — only labels (`Response A`/…). The refiner prompt does include aggregator labels with model attribution.
+
+**Single source of truth on the frontend:** `msg.metadata.moa_aggregator`. The terminal `stage2_complete` is authoritative; `MoaView` reads `msg.metadata?.moa_aggregator?.aggregators` for Layer 2 and `msg.stage1` for Layer 1.
+
+**Out of scope (future variants):** round-robin aggregator fan-out (today is all-to-all per the MoA paper), aggregator role specialisation, refiner-as-pass-through, iterative MoA depth ≥ 2 aggregator layers.
+
+Registration is opt-in AND requires **all three** `MOA_PROPOSER_MODELS` / `MOA_AGGREGATOR_MODELS` / `MOA_REFINER_MODEL` env vars. Partial config logs a warning and skips registration — there's no no-LLM path for MoA.
 
 #### Per-registration model configuration
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,6 +1,6 @@
 # Deliberation Strategies
 
-The `Strategy` enum (`internal/council/types.go`) declares **7 constants**. Two are implemented today; five are reserved for planned strategies. The runner returns `"strategy %d not implemented"` for unimplemented constants.
+The `Strategy` enum (`internal/council/types.go`) declares **7 constants**. Six are implemented today; one is reserved for a planned strategy. The runner returns `"strategy %d not implemented"` for unimplemented constants.
 
 For architecture context (package layout, layer boundaries, dispatch switch) see [`architecture-v2.md`](./architecture-v2.md). For the academic background of each strategy see [`council-research-synthesis.md`](./council-research-synthesis.md).
 
@@ -17,7 +17,7 @@ Stage 0 (clarification) runs **before** strategy dispatch and is strategy-indepe
 | `Majority` | shipped | `majority.go:runMajority` | #205 |
 | `GenerateRankRefine` | shipped | `generaterankrefine.go:runGenerateRankRefine` | #210 |
 | `MultiAgentDebate` | shipped | `debate.go:runMultiAgentDebate` | #212 |
-| `MixtureOfAgents` | planned | — | TBD |
+| `MixtureOfAgents` | shipped | `moa.go:runMixtureOfAgents` | #214 |
 | `Delphi` | planned | — | TBD |
 
 ### LLM-call cost (per request, ignoring Stage 0)
@@ -31,8 +31,9 @@ Operators pick strategies on cost as much as on output quality. For a council of
 | `Majority` | **N + (0 or 1)** | N generation; 0 chairman calls when there's a clear plurality and no chairman is configured; 1 for tiebreak or polish |
 | `GenerateRankRefine` | **N + 2** | N generation + 1 ranking + 1 refinement (both go to the chairman) |
 | `MultiAgentDebate` | **N + N×R + 1** | N generation + R rounds × N debaters revising + 1 chairman synthesis. With defaults N=4, R=2 → 13 calls. The most expensive shipped strategy; cost note in `.env.example`. |
+| `MixtureOfAgents` | **N + M + 1** | N proposers (Layer 1) + M aggregators (Layer 2, all-to-all over proposers) + 1 refiner (Layer 3). With defaults N=4, M=2 → 7 calls. |
 
-`MixtureOfAgents` and `Delphi` are still planned; their costs will be added when each ships.
+`Delphi` is still planned; its cost will be added when it ships.
 
 ---
 
@@ -47,10 +48,10 @@ Each registration in `cmd/server/main.go` and `cmd/eval/main.go` carries its own
 | `Majority` | Voters | Tiebreaker / polish (optional; `""` = no tiebreak, ties error) | `MAJORITY_MODELS` (required to register) / `MAJORITY_CHAIRMAN_MODEL` (optional) | none — registration is opt-in via `MAJORITY_MODELS`; chairman stays empty when unset (so the no-chairman path is reachable) |
 | `GenerateRankRefine` | Generators | Ranker + refiner (single model today) | `GENERATE_RANK_REFINE_MODELS` / `GENERATE_RANK_REFINE_CHAIRMAN_MODEL` | `COUNCIL_MODELS` / `CHAIRMAN_MODEL` |
 | `MultiAgentDebate` | Debaters | Synthesiser | `DEBATE_MODELS` / `DEBATE_CHAIRMAN_MODEL` | `COUNCIL_MODELS` / `CHAIRMAN_MODEL` |
-| `MixtureOfAgents` | (see below — 3 layers) | Refiner (or `""` to use `RefinerModel` field) | `MOA_PROPOSER_MODELS` / `MOA_AGGREGATOR_MODELS` / `MOA_REFINER_MODEL` | `COUNCIL_MODELS` for proposers; `CHAIRMAN_MODEL` for refiner |
+| `MixtureOfAgents` | (UNUSED — MoA reads `ProposerModels`/`AggregatorModels`/`RefinerModel` directly) | (UNUSED — see above) | `MOA_PROPOSER_MODELS` / `MOA_AGGREGATOR_MODELS` / `MOA_REFINER_MODEL` (ALL THREE required to register; partial config logs a warning and skips) | none — registration is opt-in via all three MoA env vars |
 | `Delphi` | Raters | Facilitator (optional) | `DELPHI_MODELS` / `DELPHI_CHAIRMAN_MODEL` | `COUNCIL_MODELS` / `CHAIRMAN_MODEL` |
 
-`MixtureOfAgents` is the only strategy that does not fit the `Models` + `ChairmanModel` shape. When MoA ships, `CouncilType` gains:
+`MixtureOfAgents` is the only shipped strategy that does not fit the `Models` + `ChairmanModel` shape. `CouncilType` carries three MoA-only fields:
 
 ```go
 ProposerModels   []string  // Layer 1
@@ -58,7 +59,7 @@ AggregatorModels []string  // Layer 2
 RefinerModel     string    // Layer 3 (final)
 ```
 
-These fields are zero-valued for every other strategy. Adding optional fields is non-breaking; defer the decision between explicit fields and a generic `Layers map[string][]string` until MoA's implementation PR.
+These fields are zero-valued for every other strategy. The `Models` and `ChairmanModel` fields are unused for MoA registrations — the runner reads the layer-specific fields directly. See the field-usage matrix in `CouncilType`'s doc-comment in `internal/council/types.go`.
 
 ---
 
@@ -116,7 +117,7 @@ PeerReview's existing payload corresponds to `kind: "peer_ranking"`; RoleBased's
 | `vote_tally` | `Majority` | **shipped** | `metadata.vote_tally` is a `VoteTally` (`{clusters: VoteCluster[], winner_label: string}`); `data` is `[]` (Majority does not produce per-reviewer Stage 2 results). `VoteCluster` is `{members: string[], representative: string, votes: int}`. Clusters are sorted by votes desc, then representative asc. | always `0` |
 | `rank_refine` | `GenerateRankRefine` | **shipped** | `metadata.rank_refine` is a `RankRefine` (`{rankings: RankedCandidate[], top_k: int, criteria: string[]}`); `data` is `[]` (the ranking lives in metadata, not per-reviewer). `RankedCandidate` is `{label: string, scores: map<string, float64>, total_score: float64, advancing: bool}`. Rankings are sorted by `total_score` desc, then `label` asc. Exactly `top_k` candidates have `advancing: true`. Per-criterion scores clamped to `[0.0, 1.0]`; `total_score` to `[0.0, len(criteria)]`. | always `0` |
 | `debate_round` | `MultiAgentDebate` | **shipped** | `metadata.debate` is a `Debate` (`{rounds: DebateRound[], final_round: int, dropouts?: DebaterDropout[]}`); `data` is `[]` (the transcript lives in metadata, not per-reviewer). Round events fire as `stage2_round_complete` per round (carrying just that round); the terminal `stage2_complete` carries the full transcript including dropouts. `DebaterDropout` is `{label, last_round, reason: "error"\|"json_parse"\|"empty_revision"}`. | `1..R`; one `stage2_round_complete` per round, then a terminal `stage2_complete` |
-| `moa_aggregator` | `MixtureOfAgents` | **reserved** | Layer-2 aggregator outputs; references to which Layer-1 proposers fed each aggregator | always `0` (single aggregator pass) |
+| `moa_aggregator` | `MixtureOfAgents` | **shipped** | `metadata.moa_aggregator` is a `MoaAggregator` (`{aggregators: AggregatorOutput[]}`); `data` is `[]` (the aggregator drafts live in metadata, not per-reviewer). `AggregatorOutput` is `{label, model, content, sources: string[], duration_ms}`. `sources` lists the Layer-1 proposer labels fed into that aggregator (today: all-to-all, so every aggregator's `sources` lists every successful proposer). Aggregators are sorted by `label` asc. `metadata.label_to_model` is a single flat map containing both proposer (`Response A → …`) and aggregator (`Aggregator A → …`) entries. | always `0` (single aggregator pass; no `stage2_round_complete` events) |
 | `delphi_round` | `Delphi` | **reserved** | per-rater rating list for the current round; running averages and convergence indicator | `1..N`; one event per round |
 
 Reserved kinds are not yet emitted by the runtime. The frontend `Stage2.jsx` dispatcher renders any unknown kind via a fallback view (`Stage 2 — kind: <X> (view not implemented yet)`) so a strategy in flight does not crash the UI.

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -137,6 +137,7 @@ export default function ChatInterface({
                     voteTally={msg.metadata?.vote_tally}
                     rankRefine={msg.metadata?.rank_refine}
                     debate={msg.metadata?.debate}
+                    moaAggregator={msg.metadata?.moa_aggregator}
                     isLoading={msg.loading?.stage2}
                   />
 

--- a/frontend/src/components/Stage2.css
+++ b/frontend/src/components/Stage2.css
@@ -434,3 +434,74 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+/* Mixture-of-Agents view (MixtureOfAgents strategy) */
+
+.moa-layer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: var(--bg-stage);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+  margin-top: 8px;
+}
+
+.moa-layer-header {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+}
+
+.moa-layer-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.moa-row {
+  padding: 10px 12px;
+  background: var(--bg-base);
+  border-radius: var(--radius-sm);
+  border-left: 3px solid var(--accent);
+}
+
+.moa-row-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+
+.moa-row-label {
+  font-family: monospace;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.moa-sources {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: monospace;
+}
+
+.moa-row-content {
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.moa-row-content.collapsed {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/frontend/src/components/Stage2.jsx
+++ b/frontend/src/components/Stage2.jsx
@@ -409,6 +409,120 @@ function DebateView({ debate, isLoading }) {
   );
 }
 
+// MoaView renders the MixtureOfAgents strategy's Stage 2 payload as two
+// stacked layer panels: Layer 1 (proposer drafts from msg.stage1) and
+// Layer 2 (aggregator outputs from metadata.moa_aggregator.aggregators with
+// the source-proposer labels visible per aggregator). Long content is
+// truncated with click-to-expand (same pattern as the other Stage 2 views).
+function MoaProposerRow({ result }) {
+  const [expanded, setExpanded] = useState(false);
+  const longText = (result?.content ?? '').length > REPRESENTATIVE_TRUNCATE_THRESHOLD;
+  return (
+    <div className="moa-row">
+      <div className="moa-row-header">
+        <span className="moa-row-label">{result.label}</span>
+      </div>
+      <div className={`moa-row-content${longText && !expanded ? ' collapsed' : ''}`}>
+        {result.content}
+      </div>
+      {longText && (
+        <button
+          type="button"
+          className="vote-expand-btn"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+        >
+          {expanded ? 'Show less' : 'Show full answer'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function MoaAggregatorRow({ aggregator }) {
+  const [expanded, setExpanded] = useState(false);
+  const longText = (aggregator?.content ?? '').length > REPRESENTATIVE_TRUNCATE_THRESHOLD;
+  const sources = Array.isArray(aggregator.sources) ? aggregator.sources : [];
+  return (
+    <div className="moa-row">
+      <div className="moa-row-header">
+        <span className="moa-row-label">{aggregator.label}</span>
+        {sources.length > 0 && (
+          <span className="moa-sources">Sources: {sources.join(', ')}</span>
+        )}
+      </div>
+      <div className={`moa-row-content${longText && !expanded ? ' collapsed' : ''}`}>
+        {aggregator.content}
+      </div>
+      {longText && (
+        <button
+          type="button"
+          className="vote-expand-btn"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+        >
+          {expanded ? 'Show less' : 'Show full answer'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function MoaView({ moaAggregator, stage1, isLoading }) {
+  if (isLoading && (!moaAggregator || !moaAggregator.aggregators || moaAggregator.aggregators.length === 0)) {
+    return (
+      <div className="stage stage2">
+        <div className="stage-accordion" aria-disabled="true">
+          <span className="stage-accordion-label">
+            <span className="spinner-sm" />
+            Aggregating proposer drafts…
+          </span>
+        </div>
+      </div>
+    );
+  }
+  if (!moaAggregator || !moaAggregator.aggregators || moaAggregator.aggregators.length === 0) {
+    return null;
+  }
+
+  // Filter aggregators that have content (skip failed ones — they are surfaced
+  // by the partial-failure shape but renderable rows need content).
+  const successfulAggregators = moaAggregator.aggregators.filter(
+    (a) => a && (a.content ?? '').length > 0,
+  );
+  const proposerDrafts = Array.isArray(stage1) ? stage1 : [];
+
+  return (
+    <div className="stage stage2">
+      <div className="stage-accordion" aria-disabled="true">
+        <span className="stage-accordion-label">
+          Stage 2: Mixture of Agents ({proposerDrafts.length} proposers → {successfulAggregators.length} aggregators)
+        </span>
+      </div>
+      <div className="stage-body">
+        {proposerDrafts.length > 0 && (
+          <div className="moa-layer">
+            <div className="moa-layer-header">Layer 1 — Proposers</div>
+            <div className="moa-layer-list">
+              {proposerDrafts.map((p, i) => (
+                <MoaProposerRow key={`prop-${p?.label ?? i}-${i}`} result={p} />
+              ))}
+            </div>
+          </div>
+        )}
+        <div className="moa-layer">
+          <div className="moa-layer-header">Layer 2 — Aggregators</div>
+          <div className="moa-layer-list">
+            {successfulAggregators.map((a, i) => (
+              <MoaAggregatorRow key={`agg-${a?.label ?? i}-${i}`} aggregator={a} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // RoleStubView renders a minimal placeholder for the RoleBased strategy,
 // where Stage 2 has no peer-ranking content (roles are complementary).
 function RoleStubView({ isLoading }) {
@@ -467,6 +581,7 @@ export default function Stage2({
   voteTally,
   rankRefine,
   debate,
+  moaAggregator,
   stage1,
   isLoading,
 }) {
@@ -492,6 +607,8 @@ export default function Stage2({
       return <RankRefineView rankRefine={rankRefine} rankings={stage1} isLoading={isLoading} />;
     case 'debate_round':
       return <DebateView debate={debate} isLoading={isLoading} />;
+    case 'moa_aggregator':
+      return <MoaView moaAggregator={moaAggregator} stage1={stage1} isLoading={isLoading} />;
     default:
       return <UnknownKindView kind={effectiveKind} />;
   }

--- a/frontend/src/components/Stage2.test.jsx
+++ b/frontend/src/components/Stage2.test.jsx
@@ -36,12 +36,11 @@ describe('Stage2 dispatcher', () => {
   });
 
   it('routes an unknown kind to the unknown-kind view, surfacing the kind name', () => {
-    // Use one of the still-unimplemented reserved kinds. moa_aggregator and
-    // delphi_round are reserved as of this PR; debate_round and vote_tally
-    // are shipped, so they'd route to their proper views.
-    render(<Stage2 kind="moa_aggregator" isLoading={false} />);
+    // Use the only still-reserved kind. moa_aggregator now routes to MoaView;
+    // delphi_round is reserved as of this PR (Delphi strategy not yet shipped).
+    render(<Stage2 kind="delphi_round" isLoading={false} />);
     expect(screen.getByText(/view not implemented yet/i)).toBeInTheDocument();
-    expect(screen.getByText('moa_aggregator')).toBeInTheDocument();
+    expect(screen.getByText('delphi_round')).toBeInTheDocument();
   });
 
   it('defaults to peer_ranking when kind is undefined (old-backend safety net)', () => {
@@ -313,6 +312,111 @@ describe('Stage2 dispatcher', () => {
         ],
       };
       render(<Stage2 kind="debate_round" debate={debate} isLoading={false} />);
+      expect(screen.getByRole('button', { name: /Show full answer/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('MoaView (kind="moa_aggregator")', () => {
+    const fourProposers = [
+      { label: 'Response A', content: 'proposer a draft' },
+      { label: 'Response B', content: 'proposer b draft' },
+      { label: 'Response C', content: 'proposer c draft' },
+      { label: 'Response D', content: 'proposer d draft' },
+    ];
+    const twoAggregators = {
+      aggregators: [
+        {
+          label: 'Aggregator A',
+          model: 'anthropic/claude-sonnet-4-5',
+          content: 'aggregator a improved draft',
+          sources: ['Response A', 'Response B', 'Response C', 'Response D'],
+        },
+        {
+          label: 'Aggregator B',
+          model: 'openai/gpt-4o',
+          content: 'aggregator b improved draft',
+          sources: ['Response A', 'Response B', 'Response C', 'Response D'],
+        },
+      ],
+    };
+
+    it('renders two layer panels with all proposer drafts and aggregator drafts plus source labels', () => {
+      render(
+        <Stage2
+          kind="moa_aggregator"
+          moaAggregator={twoAggregators}
+          stage1={fourProposers}
+          isLoading={false}
+        />,
+      );
+      // Header reports proposer + aggregator counts.
+      expect(screen.getByText(/Stage 2: Mixture of Agents/i)).toBeInTheDocument();
+      expect(screen.getByText(/4 proposers → 2 aggregators/i)).toBeInTheDocument();
+      // Both layer headers visible.
+      expect(screen.getByText(/Layer 1 — Proposers/i)).toBeInTheDocument();
+      expect(screen.getByText(/Layer 2 — Aggregators/i)).toBeInTheDocument();
+      // 4 proposer rows + 2 aggregator rows = 6 rows total. Verify by content.
+      for (const draft of [
+        'proposer a draft',
+        'proposer b draft',
+        'proposer c draft',
+        'proposer d draft',
+        'aggregator a improved draft',
+        'aggregator b improved draft',
+      ]) {
+        expect(screen.getByText(draft)).toBeInTheDocument();
+      }
+      // Source labels rendered per aggregator (twice — once per aggregator row).
+      const sourceLines = screen.getAllByText(/Sources: Response A, Response B, Response C, Response D/i);
+      expect(sourceLines).toHaveLength(2);
+    });
+
+    it('renders a single aggregator row when only one aggregator survived', () => {
+      const oneAggregator = {
+        aggregators: [
+          {
+            label: 'Aggregator A',
+            model: 'anthropic/claude-sonnet-4-5',
+            content: 'sole aggregator draft',
+            sources: ['Response A', 'Response B'],
+          },
+        ],
+      };
+      render(
+        <Stage2
+          kind="moa_aggregator"
+          moaAggregator={oneAggregator}
+          stage1={fourProposers.slice(0, 2)}
+          isLoading={false}
+        />,
+      );
+      expect(screen.getByText(/2 proposers → 1 aggregators/i)).toBeInTheDocument();
+      expect(screen.getByText('sole aggregator draft')).toBeInTheDocument();
+      expect(screen.getByText('Aggregator A')).toBeInTheDocument();
+      expect(screen.getByText(/Sources: Response A, Response B/i)).toBeInTheDocument();
+    });
+
+    it('truncates long aggregator content with a Show full answer button', () => {
+      const longText =
+        'A long aggregator draft that exceeds the truncation threshold so the dispatcher exposes a Show full answer button — '.repeat(2);
+      const aggregator = {
+        aggregators: [
+          {
+            label: 'Aggregator A',
+            model: 'anthropic/claude-sonnet-4-5',
+            content: longText,
+            sources: ['Response A'],
+          },
+        ],
+      };
+      render(
+        <Stage2
+          kind="moa_aggregator"
+          moaAggregator={aggregator}
+          stage1={[{ label: 'Response A', content: 'short' }]}
+          isLoading={false}
+        />,
+      );
       expect(screen.getByRole('button', { name: /Show full answer/i })).toBeInTheDocument();
     });
   });

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -905,6 +905,90 @@ func TestSendMessageStream(t *testing.T) {
 			},
 		},
 		{
+			name:   "MixtureOfAgents emits kind=moa_aggregator with sources, no stage2_round_complete",
+			body:   `{"content":"q","council_type":"moa"}`,
+			storer: okStorer(),
+			runner: &mockRunner{
+				runFull: func(ctx context.Context, query, ct string, onEvent council.EventFunc) error {
+					onEvent("stage1_complete", []council.StageOneResult{
+						{Label: "Response A", Content: "draft a", Model: "openai/gpt-4o-mini"},
+						{Label: "Response B", Content: "draft b", Model: "anthropic/claude-haiku-4-5"},
+						{Label: "Response C", Content: "draft c", Model: "google/gemini-flash-1.5"},
+						{Label: "Response D", Content: "draft d", Model: "qwen/qwen3.6-plus"},
+					})
+					moa := &council.MoaAggregator{
+						Aggregators: []council.AggregatorOutput{
+							{Label: "Aggregator A", Model: "anthropic/claude-sonnet-4-5", Content: "improved 1", Sources: []string{"Response A", "Response B", "Response C", "Response D"}, DurationMs: 100},
+							{Label: "Aggregator B", Model: "openai/gpt-4o", Content: "improved 2", Sources: []string{"Response A", "Response B", "Response C", "Response D"}, DurationMs: 110},
+						},
+					}
+					onEvent("stage2_complete", council.Stage2CompleteData{
+						Kind:    "moa_aggregator",
+						Results: []council.StageTwoResult{},
+						Metadata: council.Metadata{
+							CouncilType: "moa",
+							LabelToModel: map[string]string{
+								"Response A":   "openai/gpt-4o-mini",
+								"Aggregator A": "anthropic/claude-sonnet-4-5",
+							},
+							AggregateRankings: []council.RankedModel{},
+							MoaAggregator:     moa,
+						},
+					})
+					onEvent("stage3_complete", council.StageThreeResult{Content: "final", Model: "anthropic/claude-opus-4-7", DurationMs: 120})
+					return nil
+				},
+			},
+			wantCode: http.StatusOK,
+			checkSSE: func(t *testing.T, body string) {
+				// 1. stage2_round_complete must NOT appear (MoA is single-pass per layer).
+				// 2. The terminal stage2_complete event MUST carry kind="moa_aggregator"
+				//    and metadata.moa_aggregator with per-aggregator sources populated.
+				var sawTerminalMoa bool
+				for _, line := range strings.Split(body, "\n") {
+					if !strings.HasPrefix(line, "data: ") {
+						continue
+					}
+					raw := []byte(line[6:])
+					var keys map[string]json.RawMessage
+					if err := json.Unmarshal(raw, &keys); err != nil {
+						continue
+					}
+					var typ string
+					if err := json.Unmarshal(keys["type"], &typ); err == nil && typ == "stage2_round_complete" {
+						t.Errorf("MoA must NOT emit stage2_round_complete (single-pass per layer); raw: %s", string(raw))
+					}
+					if err := json.Unmarshal(keys["type"], &typ); err == nil && typ == "stage2_complete" {
+						var env struct {
+							Kind     string           `json:"kind"`
+							Metadata council.Metadata `json:"metadata"`
+						}
+						if err := json.Unmarshal(raw, &env); err != nil {
+							continue
+						}
+						if env.Kind != "moa_aggregator" {
+							t.Errorf("kind: got %q, want %q", env.Kind, "moa_aggregator")
+						}
+						if env.Metadata.MoaAggregator == nil {
+							t.Fatalf("metadata.moa_aggregator: nil; expected populated")
+						}
+						if len(env.Metadata.MoaAggregator.Aggregators) != 2 {
+							t.Errorf("aggregators: got %d, want 2", len(env.Metadata.MoaAggregator.Aggregators))
+						}
+						for _, a := range env.Metadata.MoaAggregator.Aggregators {
+							if len(a.Sources) != 4 {
+								t.Errorf("aggregator %q sources: got %d, want 4 (all-to-all)", a.Label, len(a.Sources))
+							}
+						}
+						sawTerminalMoa = true
+					}
+				}
+				if !sawTerminalMoa {
+					t.Errorf("terminal stage2_complete with moa_aggregator not seen on the wire:\n%s", body)
+				}
+			},
+		},
+		{
 			name:   "QuorumError emits error event",
 			body:   `{"content":"test","council_type":"standard"}`,
 			storer: okStorer(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,15 @@ type Config struct {
 	DebateChairmanModel string
 	DebateMaxRounds     int
 
+	// MixtureOfAgents strategy registration. ALL THREE fields must be set for
+	// the council type to be registered — no no-LLM path. Each layer needs at
+	// least one model. Cost: N_proposers + N_aggregators + 1 LLM calls per
+	// request (default 4 + 2 + 1 = 7 calls). Layer-specific fields, not the
+	// generic Models / ChairmanModel — see CouncilType's field-usage matrix.
+	MoaProposerModels   []string
+	MoaAggregatorModels []string
+	MoaRefinerModel     string
+
 	// LLMAPIMaxRetries is the number of retries the OpenRouter client attempts
 	// on transient failures (HTTP 429/502/503/504, network timeouts, EOFs).
 	// 0 disables retries. Default: 2 (3 total attempts including the initial).
@@ -238,6 +247,31 @@ func Load() (*Config, error) {
 		}
 	}
 
+	// MixtureOfAgents proposer pool. Empty slice when unset — registration
+	// requires all three MoA env vars (no no-LLM path; every layer needs models).
+	var moaProposerModels []string
+	if raw := os.Getenv("MOA_PROPOSER_MODELS"); raw != "" {
+		for _, m := range strings.Split(raw, ",") {
+			if m = strings.TrimSpace(m); m != "" {
+				moaProposerModels = append(moaProposerModels, m)
+			}
+		}
+	}
+
+	// MixtureOfAgents aggregator pool. Same opt-in semantics as proposers.
+	var moaAggregatorModels []string
+	if raw := os.Getenv("MOA_AGGREGATOR_MODELS"); raw != "" {
+		for _, m := range strings.Split(raw, ",") {
+			if m = strings.TrimSpace(m); m != "" {
+				moaAggregatorModels = append(moaAggregatorModels, m)
+			}
+		}
+	}
+
+	// MixtureOfAgents refiner (Layer 3, single model). Whitespace-trimmed so an
+	// accidentally-spaced value doesn't bypass the registration gate.
+	moaRefinerModel := strings.TrimSpace(os.Getenv("MOA_REFINER_MODEL"))
+
 	llmAPIMaxRetries := 2
 	if raw := os.Getenv("LLM_API_MAX_RETRIES"); raw != "" {
 		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
@@ -273,6 +307,10 @@ func Load() (*Config, error) {
 		DebateModels:        debateModels,
 		DebateChairmanModel: debateChairmanModel,
 		DebateMaxRounds:     debateMaxRounds,
+
+		MoaProposerModels:   moaProposerModels,
+		MoaAggregatorModels: moaAggregatorModels,
+		MoaRefinerModel:     moaRefinerModel,
 
 		LLMAPIMaxRetries: llmAPIMaxRetries,
 	}, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -462,3 +462,106 @@ func TestLoad_DebateMaxRounds_Invalid_DefaultsToZero(t *testing.T) {
 		t.Errorf("DebateMaxRounds: got %d, want 0 (invalid input → runner default)", cfg.DebateMaxRounds)
 	}
 }
+
+// ── TestLoad_MoaModels ────────────────────────────────────────────────────
+//
+// All three MOA_* env vars must be set for the council type to register
+// (no no-LLM path; every layer requires at least one model). Loader leaves
+// fields empty when unset — the wiring in cmd/server/main.go decides whether
+// to register.
+
+func TestLoad_MoaModels_AllSet(t *testing.T) {
+	baseEnv(t)
+	setenv(t, "MOA_PROPOSER_MODELS", "openai/gpt-4o-mini, anthropic/claude-haiku-4-5, google/gemini-flash-1.5, qwen/qwen3.6-plus")
+	setenv(t, "MOA_AGGREGATOR_MODELS", "anthropic/claude-sonnet-4-5, openai/gpt-4o")
+	setenv(t, "MOA_REFINER_MODEL", "anthropic/claude-opus-4-7")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantProposers := []string{"openai/gpt-4o-mini", "anthropic/claude-haiku-4-5", "google/gemini-flash-1.5", "qwen/qwen3.6-plus"}
+	if len(cfg.MoaProposerModels) != len(wantProposers) {
+		t.Fatalf("MoaProposerModels: got %v, want %v", cfg.MoaProposerModels, wantProposers)
+	}
+	for i, m := range wantProposers {
+		if cfg.MoaProposerModels[i] != m {
+			t.Errorf("MoaProposerModels[%d]: got %q, want %q", i, cfg.MoaProposerModels[i], m)
+		}
+	}
+	wantAggregators := []string{"anthropic/claude-sonnet-4-5", "openai/gpt-4o"}
+	if len(cfg.MoaAggregatorModels) != len(wantAggregators) {
+		t.Fatalf("MoaAggregatorModels: got %v, want %v", cfg.MoaAggregatorModels, wantAggregators)
+	}
+	for i, m := range wantAggregators {
+		if cfg.MoaAggregatorModels[i] != m {
+			t.Errorf("MoaAggregatorModels[%d]: got %q, want %q", i, cfg.MoaAggregatorModels[i], m)
+		}
+	}
+	if cfg.MoaRefinerModel != "anthropic/claude-opus-4-7" {
+		t.Errorf("MoaRefinerModel: got %q, want %q", cfg.MoaRefinerModel, "anthropic/claude-opus-4-7")
+	}
+}
+
+func TestLoad_MoaModels_PartialConfig_FieldsPopulatedAsParsed(t *testing.T) {
+	// Loader must NOT enforce all-or-nothing; the registration site at
+	// cmd/server/main.go decides whether the partial config is enough.
+	// Loader returns whatever was set, with empty fields for the unset vars.
+	baseEnv(t)
+	setenv(t, "MOA_PROPOSER_MODELS", "openai/gpt-4o-mini")
+	setenv(t, "MOA_AGGREGATOR_MODELS", "anthropic/claude-sonnet-4-5")
+	unsetenv(t, "MOA_REFINER_MODEL")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.MoaProposerModels) != 1 || cfg.MoaProposerModels[0] != "openai/gpt-4o-mini" {
+		t.Errorf("MoaProposerModels: got %v, want [openai/gpt-4o-mini]", cfg.MoaProposerModels)
+	}
+	if len(cfg.MoaAggregatorModels) != 1 || cfg.MoaAggregatorModels[0] != "anthropic/claude-sonnet-4-5" {
+		t.Errorf("MoaAggregatorModels: got %v, want [anthropic/claude-sonnet-4-5]", cfg.MoaAggregatorModels)
+	}
+	if cfg.MoaRefinerModel != "" {
+		t.Errorf("MoaRefinerModel: got %q, want empty", cfg.MoaRefinerModel)
+	}
+}
+
+func TestLoad_MoaModels_AllUnset(t *testing.T) {
+	baseEnv(t)
+	unsetenv(t, "MOA_PROPOSER_MODELS")
+	unsetenv(t, "MOA_AGGREGATOR_MODELS")
+	unsetenv(t, "MOA_REFINER_MODEL")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.MoaProposerModels) != 0 {
+		t.Errorf("MoaProposerModels: got %v, want empty", cfg.MoaProposerModels)
+	}
+	if len(cfg.MoaAggregatorModels) != 0 {
+		t.Errorf("MoaAggregatorModels: got %v, want empty", cfg.MoaAggregatorModels)
+	}
+	if cfg.MoaRefinerModel != "" {
+		t.Errorf("MoaRefinerModel: got %q, want empty", cfg.MoaRefinerModel)
+	}
+}
+
+func TestLoad_MoaRefiner_Whitespace_TreatedAsUnset(t *testing.T) {
+	// Mirror the trim-to-empty pattern shared with CLARIFICATION_ARBITER_MODEL,
+	// MAJORITY_CHAIRMAN_MODEL, GENERATE_RANK_REFINE_CHAIRMAN_MODEL,
+	// DEBATE_CHAIRMAN_MODEL — so the registration gate fires correctly.
+	baseEnv(t)
+	setenv(t, "MOA_PROPOSER_MODELS", "m-a")
+	setenv(t, "MOA_AGGREGATOR_MODELS", "m-b")
+	setenv(t, "MOA_REFINER_MODEL", "   ")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MoaRefinerModel != "" {
+		t.Errorf("MoaRefinerModel: got %q, want empty (whitespace trim)", cfg.MoaRefinerModel)
+	}
+}

--- a/internal/council/council.go
+++ b/internal/council/council.go
@@ -50,3 +50,19 @@ func assignLabels(models []string) (labelToModel, modelToLabel map[string]string
 	}
 	return
 }
+
+// assignAggregatorLabels mirrors assignLabels but uses the "Aggregator " prefix
+// so MixtureOfAgents Layer 2 labels stay visually distinct from Layer 1
+// proposer labels. Both label families end up flat in Metadata.LabelToModel —
+// key collisions are impossible because the prefixes differ.
+func assignAggregatorLabels(models []string) (labelToModel, modelToLabel map[string]string) {
+	perm := rand.Perm(len(models))
+	labelToModel = make(map[string]string, len(models))
+	modelToLabel = make(map[string]string, len(models))
+	for i, idx := range perm {
+		label := fmt.Sprintf("Aggregator %c", rune('A'+i))
+		labelToModel[label] = models[idx]
+		modelToLabel[models[idx]] = label
+	}
+	return
+}

--- a/internal/council/moa.go
+++ b/internal/council/moa.go
@@ -1,0 +1,218 @@
+package council
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"sort"
+	"sync"
+	"time"
+)
+
+// runMixtureOfAgents executes the 3-layer Mixture-of-Agents pipeline:
+//
+//   - Layer 1 (Stage 1): parallel generation across ct.ProposerModels. Anonymous
+//     "Response A/B/…" labels assigned via assignLabels. Emits stage1_complete.
+//   - Layer 2 (Stage 2): parallel call per aggregator (ct.AggregatorModels) with
+//     all-to-all fan-out — every aggregator sees every Layer 1 proposer draft.
+//     Aggregators get distinct "Aggregator A/B/…" labels (assignAggregatorLabels)
+//     so they don't collide with proposer labels in Metadata.LabelToModel. Emits
+//     stage2_complete with kind="moa_aggregator".
+//   - Layer 3 (Stage 3): single refiner call (ct.RefinerModel) that synthesises
+//     the aggregator drafts into the final answer. The refiner sees aggregator
+//     outputs WITH model attribution but does NOT see raw proposer outputs.
+//
+// Two-tier quorum:
+//   - Layer 1: max(2, ⌈N_proposers/2⌉+1) when ct.QuorumMin == 0; standard
+//     *QuorumError if Layer 1 fails.
+//   - Layer 2: at least 1 successful aggregator; loud error otherwise (no
+//     stage2_complete emitted, no Stage 3 run).
+//
+// Models and ChairmanModel are UNUSED for MoA registrations — the runner reads
+// ProposerModels / AggregatorModels / RefinerModel directly. See CouncilType's
+// field-usage matrix in types.go.
+func (c *Council) runMixtureOfAgents(ctx context.Context, query string, ct CouncilType, onEvent EventFunc) error {
+	if len(ct.ProposerModels) == 0 {
+		return fmt.Errorf("council type %q has no proposer models configured (set ProposerModels for MixtureOfAgents)", ct.Name)
+	}
+	if len(ct.AggregatorModels) == 0 {
+		return fmt.Errorf("council type %q has no aggregator models configured (set AggregatorModels for MixtureOfAgents)", ct.Name)
+	}
+	if ct.RefinerModel == "" {
+		return fmt.Errorf("council type %q has no refiner model configured (set RefinerModel for MixtureOfAgents)", ct.Name)
+	}
+
+	// Layer 1 — parallel generation across the proposer pool.
+	allStage1 := c.runStage1(ctx, query, ct.ProposerModels, ct.Temperature)
+
+	// Layer 1 quorum check.
+	successful, err := checkQuorum(allStage1, ct.QuorumMin)
+	if err != nil {
+		return err
+	}
+
+	// Anonymous proposer labels.
+	successfulModels := make([]string, len(successful))
+	for i, r := range successful {
+		successfulModels[i] = r.Model
+	}
+	proposerLabelToModel, proposerModelToLabel := assignLabels(successfulModels)
+	for i := range successful {
+		successful[i].Label = proposerModelToLabel[successful[i].Model]
+	}
+
+	if onEvent != nil {
+		onEvent("stage1_complete", successful)
+	}
+
+	// Aggregator labels (distinct prefix family).
+	aggregatorLabelToModel, _ := assignAggregatorLabels(ct.AggregatorModels)
+
+	// Merge proposer + aggregator label maps into one flat LabelToModel — key
+	// collisions are impossible because the prefixes differ.
+	labelToModel := make(map[string]string, len(proposerLabelToModel)+len(aggregatorLabelToModel))
+	maps.Copy(labelToModel, proposerLabelToModel)
+	maps.Copy(labelToModel, aggregatorLabelToModel)
+
+	// Layer 2 — parallel aggregators, all-to-all fan-out over Layer 1 proposers.
+	aggregatorOutputs := c.runMoaLayer2(ctx, query, successful, aggregatorLabelToModel, ct.Temperature)
+
+	// Sort aggregators by Label for stable test output and deterministic prompts.
+	sort.SliceStable(aggregatorOutputs, func(i, j int) bool {
+		return aggregatorOutputs[i].Label < aggregatorOutputs[j].Label
+	})
+
+	// Layer 2 quorum: at least one successful aggregator.
+	successfulAggregators := make([]AggregatorOutput, 0, len(aggregatorOutputs))
+	for _, a := range aggregatorOutputs {
+		if a.Error == nil && a.Content != "" {
+			successfulAggregators = append(successfulAggregators, a)
+		}
+	}
+	if len(successfulAggregators) == 0 {
+		return fmt.Errorf("mixture-of-agents: all aggregators failed (%d configured); refiner has no input", len(ct.AggregatorModels))
+	}
+
+	moa := &MoaAggregator{Aggregators: aggregatorOutputs}
+
+	metadata := Metadata{
+		CouncilType:       ct.Name,
+		LabelToModel:      labelToModel,
+		AggregateRankings: []RankedModel{},
+		ConsensusW:        0.0,
+		MoaAggregator:     moa,
+	}
+
+	if onEvent != nil {
+		onEvent("stage2_complete", Stage2CompleteData{
+			Kind:     "moa_aggregator",
+			Results:  []StageTwoResult{},
+			Metadata: metadata,
+		})
+	}
+
+	// Layer 3 — single refiner call over the successful aggregators.
+	stage3, err := c.runMoaRefine(ctx, query, successfulAggregators, labelToModel, ct.RefinerModel, ct.Temperature)
+	if err != nil {
+		return err
+	}
+	if onEvent != nil {
+		onEvent("stage3_complete", stage3)
+	}
+	return nil
+}
+
+// runMoaLayer2 runs the aggregator layer in parallel. Each aggregator receives
+// the SAME prompt — all proposer drafts (with labels only) — so the prompt is
+// built once and reused.
+//
+// The Sources slice on every emitted AggregatorOutput is the labels of all
+// successful Layer 1 proposers fed into the prompt — deterministic (sorted by
+// Label) so transcript-agreement tests can verify Sources matches the prompt
+// body byte-for-byte.
+func (c *Council) runMoaLayer2(ctx context.Context, query string, proposers []StageOneResult, aggregatorLabelToModel map[string]string, temperature float64) []AggregatorOutput {
+	// Stable order of sources mirrors the prompt builder's internal sort.
+	sources := make([]string, len(proposers))
+	for i, p := range proposers {
+		sources[i] = p.Label
+	}
+	sort.Strings(sources)
+
+	prompt := BuildMoaAggregatorPrompt(query, proposers)
+
+	// Iterate aggregator labels in a deterministic order.
+	labels := make([]string, 0, len(aggregatorLabelToModel))
+	for l := range aggregatorLabelToModel {
+		labels = append(labels, l)
+	}
+	sort.Strings(labels)
+
+	results := make([]AggregatorOutput, len(labels))
+	var wg sync.WaitGroup
+	for i, lbl := range labels {
+		wg.Add(1)
+		go func(idx int, label string) {
+			defer wg.Done()
+			model := aggregatorLabelToModel[label]
+			start := time.Now()
+			resp, err := c.client.Complete(ctx, CompletionRequest{
+				Model:       model,
+				Messages:    prompt,
+				Temperature: temperature,
+			})
+			elapsed := time.Since(start).Milliseconds()
+			out := AggregatorOutput{
+				Label:      label,
+				Model:      model,
+				Sources:    append([]string(nil), sources...),
+				DurationMs: elapsed,
+			}
+			if err != nil {
+				out.Error = err
+				if c.logger != nil {
+					c.logger.Warn("moa: aggregator errored", slog.String("label", label), slog.String("model", model), slog.Any("error", err))
+				}
+				results[idx] = out
+				return
+			}
+			if len(resp.Choices) == 0 {
+				out.Error = errNoChoices
+				if c.logger != nil {
+					c.logger.Warn("moa: aggregator returned no choices", slog.String("label", label), slog.String("model", model))
+				}
+				results[idx] = out
+				return
+			}
+			out.Content = resp.Choices[0].Message.Content
+			results[idx] = out
+		}(i, lbl)
+	}
+	wg.Wait()
+	return results
+}
+
+// runMoaRefine calls the Layer 3 refiner once with the successful aggregator
+// outputs and returns the synthesised final answer. Failure path matches
+// runStage3 — Model + DurationMs are populated even on error.
+func (c *Council) runMoaRefine(ctx context.Context, query string, aggregators []AggregatorOutput, labelToModel map[string]string, refinerModel string, temperature float64) (StageThreeResult, error) {
+	start := time.Now()
+	msgs := BuildMoaRefinerPrompt(query, aggregators, labelToModel)
+	resp, err := c.client.Complete(ctx, CompletionRequest{
+		Model:       refinerModel,
+		Messages:    msgs,
+		Temperature: temperature,
+	})
+	elapsed := time.Since(start).Milliseconds()
+	result := StageThreeResult{Model: refinerModel, DurationMs: elapsed}
+	if err != nil {
+		result.Error = err
+		return result, fmt.Errorf("moa refiner (%s): %w", refinerModel, err)
+	}
+	if len(resp.Choices) == 0 {
+		result.Error = fmt.Errorf("empty response from refiner %s", refinerModel)
+		return result, result.Error
+	}
+	result.Content = resp.Choices[0].Message.Content
+	return result, nil
+}

--- a/internal/council/moa_test.go
+++ b/internal/council/moa_test.go
@@ -1,0 +1,713 @@
+package council
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// moaRecorder is a thread-safe collector that classifies each completion
+// request as a Stage 1 proposer call, a Layer 2 aggregator call, or a Layer 3
+// refiner call by inspecting the prompt prefix produced by the prompt builders.
+type moaRecorder struct {
+	mu sync.Mutex
+	// proposerOut maps model → answer to return for Stage 1 calls.
+	proposerOut map[string]string
+	// proposerErr maps model → error to return for Stage 1 calls (overrides proposerOut when set).
+	proposerErr map[string]error
+	// aggregatorOut maps model → answer to return for Layer 2 calls.
+	aggregatorOut map[string]string
+	// aggregatorErr maps model → error to return for Layer 2 calls.
+	aggregatorErr map[string]error
+	// refinerOut / refinerErr drive Layer 3.
+	refinerOut string
+	refinerErr error
+
+	// Captured per-call data.
+	calls            []string // labels: "stage1:<model>", "agg:<model>", "refiner:<model>"
+	aggregatorPrompt string   // shared aggregator prompt body (one per call, same content)
+	aggregatorPromptByModel map[string]string // model → captured prompt (all aggregators get the same one, but per-call captured)
+	refinerPrompt    string   // captured refiner prompt body
+}
+
+func (r *moaRecorder) record(req CompletionRequest) (CompletionResponse, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	body := ""
+	if len(req.Messages) > 0 {
+		body = req.Messages[0].Content
+	}
+	switch {
+	case strings.Contains(body, "You aggregate council proposals"):
+		r.calls = append(r.calls, "agg:"+req.Model)
+		r.aggregatorPrompt = body
+		if r.aggregatorPromptByModel == nil {
+			r.aggregatorPromptByModel = map[string]string{}
+		}
+		r.aggregatorPromptByModel[req.Model] = body
+		if e, ok := r.aggregatorErr[req.Model]; ok {
+			return CompletionResponse{}, e
+		}
+		out, ok := r.aggregatorOut[req.Model]
+		if !ok {
+			out = "default aggregator draft from " + req.Model
+		}
+		return makeResponse(out), nil
+	case strings.Contains(body, "You synthesise the final answer from MoA aggregator drafts"):
+		r.calls = append(r.calls, "refiner:"+req.Model)
+		r.refinerPrompt = body
+		if r.refinerErr != nil {
+			return CompletionResponse{}, r.refinerErr
+		}
+		return makeResponse(r.refinerOut), nil
+	default:
+		r.calls = append(r.calls, "stage1:"+req.Model)
+		if e, ok := r.proposerErr[req.Model]; ok {
+			return CompletionResponse{}, e
+		}
+		ans, ok := r.proposerOut[req.Model]
+		if !ok {
+			return CompletionResponse{}, errors.New("no answer scripted for " + req.Model)
+		}
+		return makeResponse(ans), nil
+	}
+}
+
+func moaCouncil(t *testing.T, proposers, aggregators []string, refiner string, rec *moaRecorder) *Council {
+	t.Helper()
+	registry := map[string]CouncilType{
+		"test": {
+			Name:             "test",
+			Strategy:         MixtureOfAgents,
+			ProposerModels:   proposers,
+			AggregatorModels: aggregators,
+			RefinerModel:     refiner,
+			Temperature:      0.7,
+		},
+	}
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			return rec.record(req)
+		},
+	}
+	return NewCouncil(client, registry, nil)
+}
+
+// ── 1. Happy path ─────────────────────────────────────────────────────────
+
+func TestRunMixtureOfAgents_HappyPath(t *testing.T) {
+	rec := &moaRecorder{
+		proposerOut: map[string]string{
+			"prop-a": "draft-a", "prop-b": "draft-b", "prop-c": "draft-c", "prop-d": "draft-d",
+		},
+		aggregatorOut: map[string]string{
+			"agg-1": "improved draft from agg-1",
+			"agg-2": "improved draft from agg-2",
+		},
+		refinerOut: "FINAL ANSWER",
+	}
+	c := moaCouncil(t, []string{"prop-a", "prop-b", "prop-c", "prop-d"}, []string{"agg-1", "agg-2"}, "refiner-z", rec)
+
+	var events []string
+	var seenKind string
+	var moa *MoaAggregator
+	var stage3 StageThreeResult
+
+	err := c.RunFull(context.Background(), "the question?", "test", func(eventType string, data any) {
+		events = append(events, eventType)
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				seenKind = d.Kind
+				moa = d.Metadata.MoaAggregator
+			}
+		}
+		if eventType == "stage3_complete" {
+			stage3 = data.(StageThreeResult)
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantSeq := []string{"stage1_complete", "stage2_complete", "stage3_complete"}
+	if !equalStringSlice(events, wantSeq) {
+		t.Errorf("event sequence: got %v, want %v", events, wantSeq)
+	}
+	if seenKind != "moa_aggregator" {
+		t.Errorf("Stage 2 Kind: got %q, want %q", seenKind, "moa_aggregator")
+	}
+	if moa == nil {
+		t.Fatal("Metadata.MoaAggregator: nil")
+	}
+	if len(moa.Aggregators) != 2 {
+		t.Fatalf("Aggregators: got %d, want 2", len(moa.Aggregators))
+	}
+	for _, a := range moa.Aggregators {
+		if len(a.Sources) != 4 {
+			t.Errorf("aggregator %q sources: got %d, want 4 (all-to-all)", a.Label, len(a.Sources))
+		}
+	}
+	if stage3.Content != "FINAL ANSWER" {
+		t.Errorf("stage3 content: got %q", stage3.Content)
+	}
+	if stage3.Model != "refiner-z" {
+		t.Errorf("stage3 model: got %q, want %q", stage3.Model, "refiner-z")
+	}
+}
+
+// ── 2. Layer 1 quorum failure ─────────────────────────────────────────────
+
+func TestRunMixtureOfAgents_Layer1QuorumFailure(t *testing.T) {
+	// All proposers fail → quorum not met. No Stage 2 / 3 events.
+	rec := &moaRecorder{
+		proposerErr: map[string]error{
+			"prop-a": errors.New("upstream"), "prop-b": errors.New("upstream"),
+			"prop-c": errors.New("upstream"), "prop-d": errors.New("upstream"),
+		},
+	}
+	c := moaCouncil(t, []string{"prop-a", "prop-b", "prop-c", "prop-d"}, []string{"agg-1", "agg-2"}, "refiner-z", rec)
+
+	var events []string
+	err := c.RunFull(context.Background(), "q", "test", func(eventType string, _ any) {
+		events = append(events, eventType)
+	})
+
+	var qe *QuorumError
+	if !errors.As(err, &qe) {
+		t.Fatalf("expected *QuorumError, got %T: %v", err, err)
+	}
+	for _, e := range events {
+		if e == "stage2_complete" || e == "stage3_complete" {
+			t.Errorf("must NOT emit %q after Layer 1 quorum failure (events: %v)", e, events)
+		}
+	}
+}
+
+// ── 3. All aggregators fail (Layer 2 loud failure) ────────────────────────
+
+func TestRunMixtureOfAgents_AllAggregatorsFail(t *testing.T) {
+	rec := &moaRecorder{
+		proposerOut: map[string]string{
+			"prop-a": "draft-a", "prop-b": "draft-b", "prop-c": "draft-c", "prop-d": "draft-d",
+		},
+		aggregatorErr: map[string]error{
+			"agg-1": errors.New("upstream"),
+			"agg-2": errors.New("upstream"),
+		},
+	}
+	c := moaCouncil(t, []string{"prop-a", "prop-b", "prop-c", "prop-d"}, []string{"agg-1", "agg-2"}, "refiner-z", rec)
+
+	var events []string
+	err := c.RunFull(context.Background(), "q", "test", func(eventType string, _ any) {
+		events = append(events, eventType)
+	})
+
+	if err == nil {
+		t.Fatal("expected loud error when all aggregators fail")
+	}
+	if !strings.Contains(err.Error(), "all aggregators failed") {
+		t.Errorf("error message: got %q, want mention of 'all aggregators failed'", err.Error())
+	}
+	for _, e := range events {
+		if e == "stage2_complete" {
+			t.Errorf("must NOT emit stage2_complete when all aggregators failed (events: %v)", events)
+		}
+		if e == "stage3_complete" {
+			t.Errorf("must NOT emit stage3_complete when all aggregators failed (events: %v)", events)
+		}
+	}
+}
+
+// ── 4. Partial aggregator failure ─────────────────────────────────────────
+
+func TestRunMixtureOfAgents_PartialAggregatorFailure(t *testing.T) {
+	// One aggregator fails, the other succeeds → refiner runs with the survivor.
+	// Stage 2 metadata still lists BOTH aggregators (the failed one with Error
+	// surfaced via the `Error` field, omitted from the wire JSON).
+	rec := &moaRecorder{
+		proposerOut: map[string]string{
+			"prop-a": "draft-a", "prop-b": "draft-b", "prop-c": "draft-c", "prop-d": "draft-d",
+		},
+		aggregatorOut: map[string]string{
+			"agg-good": "good draft",
+		},
+		aggregatorErr: map[string]error{
+			"agg-bad": errors.New("upstream"),
+		},
+		refinerOut: "synthesis",
+	}
+	c := moaCouncil(t, []string{"prop-a", "prop-b", "prop-c", "prop-d"}, []string{"agg-good", "agg-bad"}, "refiner-z", rec)
+
+	var moa *MoaAggregator
+	var stage3 StageThreeResult
+	err := c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				moa = d.Metadata.MoaAggregator
+			}
+		}
+		if eventType == "stage3_complete" {
+			stage3 = data.(StageThreeResult)
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if moa == nil || len(moa.Aggregators) != 2 {
+		t.Fatalf("expected 2 aggregator entries (incl. failed), got %v", moa)
+	}
+	successCount := 0
+	for _, a := range moa.Aggregators {
+		if a.Error == nil && a.Content != "" {
+			successCount++
+		}
+	}
+	if successCount != 1 {
+		t.Errorf("successful aggregator count: got %d, want 1", successCount)
+	}
+	if stage3.Content != "synthesis" {
+		t.Errorf("stage3 content: got %q, want %q", stage3.Content, "synthesis")
+	}
+}
+
+// ── 5. Anonymisation (proposer model names not in aggregator prompts) ───
+
+func TestRunMixtureOfAgents_AnonymisationInAggregatorPrompts(t *testing.T) {
+	rec := &moaRecorder{
+		proposerOut: map[string]string{
+			"my-secret-model-a": "draft a",
+			"my-secret-model-b": "draft b",
+			"my-secret-model-c": "draft c",
+			"my-secret-model-d": "draft d",
+		},
+		aggregatorOut: map[string]string{
+			"agg-1": "draft", "agg-2": "draft",
+		},
+		refinerOut: "ok",
+	}
+	c := moaCouncil(t,
+		[]string{"my-secret-model-a", "my-secret-model-b", "my-secret-model-c", "my-secret-model-d"},
+		[]string{"agg-1", "agg-2"}, "refiner-z", rec)
+
+	if err := c.RunFull(context.Background(), "q", "test", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for model, prompt := range rec.aggregatorPromptByModel {
+		// Proposer model names MUST NOT appear in aggregator prompts.
+		for _, secret := range []string{"my-secret-model-a", "my-secret-model-b", "my-secret-model-c", "my-secret-model-d"} {
+			if strings.Contains(prompt, secret) {
+				t.Errorf("aggregator %q prompt leaks proposer model %q:\n%s", model, secret, prompt)
+			}
+		}
+		// At least one proposer label MUST appear.
+		hasAny := false
+		for _, lbl := range []string{"Response A", "Response B", "Response C", "Response D"} {
+			if strings.Contains(prompt, lbl) {
+				hasAny = true
+				break
+			}
+		}
+		if !hasAny {
+			t.Errorf("aggregator %q prompt has no proposer labels:\n%s", model, prompt)
+		}
+	}
+}
+
+// ── 6. Source provenance (Sources lists ALL proposers, all-to-all) ────────
+
+func TestRunMixtureOfAgents_SourceProvenance(t *testing.T) {
+	rec := &moaRecorder{
+		proposerOut: map[string]string{
+			"prop-a": "draft-a", "prop-b": "draft-b", "prop-c": "draft-c", "prop-d": "draft-d",
+		},
+		aggregatorOut: map[string]string{
+			"agg-1": "draft", "agg-2": "draft",
+		},
+		refinerOut: "ok",
+	}
+	c := moaCouncil(t, []string{"prop-a", "prop-b", "prop-c", "prop-d"}, []string{"agg-1", "agg-2"}, "refiner-z", rec)
+
+	var moa *MoaAggregator
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				moa = d.Metadata.MoaAggregator
+			}
+		}
+	})
+	if moa == nil {
+		t.Fatal("moa nil")
+	}
+	for _, a := range moa.Aggregators {
+		if len(a.Sources) != 4 {
+			t.Errorf("aggregator %q sources: got %d (%v), want 4 (all-to-all)", a.Label, len(a.Sources), a.Sources)
+		}
+		// Sources must be sorted ascending for determinism.
+		sorted := append([]string(nil), a.Sources...)
+		sort.Strings(sorted)
+		if !equalStringSlice(a.Sources, sorted) {
+			t.Errorf("aggregator %q sources not sorted ascending: %v", a.Label, a.Sources)
+		}
+	}
+}
+
+// ── 7. Refiner input contract (aggregators only, no raw proposers) ────────
+
+func TestRunMixtureOfAgents_RefinerInputContract(t *testing.T) {
+	rec := &moaRecorder{
+		proposerOut: map[string]string{
+			"prop-a": "PROPOSER-A-CONTENT",
+			"prop-b": "PROPOSER-B-CONTENT",
+			"prop-c": "PROPOSER-C-CONTENT",
+			"prop-d": "PROPOSER-D-CONTENT",
+		},
+		aggregatorOut: map[string]string{
+			"agg-1": "AGGREGATOR-1-DRAFT",
+			"agg-2": "AGGREGATOR-2-DRAFT",
+		},
+		refinerOut: "ok",
+	}
+	c := moaCouncil(t, []string{"prop-a", "prop-b", "prop-c", "prop-d"}, []string{"agg-1", "agg-2"}, "refiner-z", rec)
+
+	if err := c.RunFull(context.Background(), "q", "test", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Refiner prompt MUST contain aggregator drafts.
+	for _, want := range []string{"AGGREGATOR-1-DRAFT", "AGGREGATOR-2-DRAFT"} {
+		if !strings.Contains(rec.refinerPrompt, want) {
+			t.Errorf("refiner prompt missing aggregator content %q", want)
+		}
+	}
+	// Refiner prompt MUST contain aggregator model attribution.
+	for _, want := range []string{"agg-1", "agg-2"} {
+		if !strings.Contains(rec.refinerPrompt, want) {
+			t.Errorf("refiner prompt missing aggregator model %q", want)
+		}
+	}
+	// Refiner prompt MUST NOT contain raw proposer content.
+	for _, raw := range []string{"PROPOSER-A-CONTENT", "PROPOSER-B-CONTENT", "PROPOSER-C-CONTENT", "PROPOSER-D-CONTENT"} {
+		if strings.Contains(rec.refinerPrompt, raw) {
+			t.Errorf("refiner prompt leaks raw proposer content %q (refiner should only see aggregator drafts):\n%s", raw, rec.refinerPrompt)
+		}
+	}
+}
+
+// ── 8. Stage 2 kind ─────────────────────────────────────────────────────
+
+func TestRunMixtureOfAgents_Stage2Kind(t *testing.T) {
+	rec := &moaRecorder{
+		proposerOut: map[string]string{
+			"prop-a": "draft-a", "prop-b": "draft-b", "prop-c": "draft-c", "prop-d": "draft-d",
+		},
+		aggregatorOut: map[string]string{
+			"agg-1": "draft", "agg-2": "draft",
+		},
+		refinerOut: "ok",
+	}
+	c := moaCouncil(t, []string{"prop-a", "prop-b", "prop-c", "prop-d"}, []string{"agg-1", "agg-2"}, "refiner-z", rec)
+
+	var seenKind string
+	var sawRoundEvent bool
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				seenKind = d.Kind
+			}
+		}
+		if eventType == "stage2_round_complete" {
+			sawRoundEvent = true
+		}
+	})
+	if seenKind != "moa_aggregator" {
+		t.Errorf("kind: got %q, want %q", seenKind, "moa_aggregator")
+	}
+	if sawRoundEvent {
+		t.Error("MoA must not emit stage2_round_complete (single-pass per layer)")
+	}
+}
+
+// ── 9. Missing model fields error early ────────────────────────────────
+
+func TestRunMixtureOfAgents_MissingFieldsErrorsEarly(t *testing.T) {
+	tests := []struct {
+		name string
+		ct   CouncilType
+		want string
+	}{
+		{
+			name: "missing proposers",
+			ct: CouncilType{
+				Name:             "test",
+				Strategy:         MixtureOfAgents,
+				AggregatorModels: []string{"agg-1"},
+				RefinerModel:     "refiner-z",
+			},
+			want: "no proposer models",
+		},
+		{
+			name: "missing aggregators",
+			ct: CouncilType{
+				Name:           "test",
+				Strategy:       MixtureOfAgents,
+				ProposerModels: []string{"prop-a"},
+				RefinerModel:   "refiner-z",
+			},
+			want: "no aggregator models",
+		},
+		{
+			name: "missing refiner",
+			ct: CouncilType{
+				Name:             "test",
+				Strategy:         MixtureOfAgents,
+				ProposerModels:   []string{"prop-a"},
+				AggregatorModels: []string{"agg-1"},
+			},
+			want: "no refiner model",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int
+			client := &mockLLMClient{
+				complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+					calls++
+					return makeResponse("should not be called"), nil
+				},
+			}
+			c := NewCouncil(client, map[string]CouncilType{"test": tc.ct}, nil)
+			err := c.RunFull(context.Background(), "q", "test", nil)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error message: got %q, want mention of %q", err.Error(), tc.want)
+			}
+			if calls != 0 {
+				t.Errorf("expected 0 LLM calls before missing-field error, got %d", calls)
+			}
+		})
+	}
+}
+
+// ── 10. Aggregator labels distinct from proposer labels ────────────────
+
+func TestRunMixtureOfAgents_DistinctLabelFamilies(t *testing.T) {
+	rec := &moaRecorder{
+		proposerOut: map[string]string{
+			"prop-a": "draft-a", "prop-b": "draft-b", "prop-c": "draft-c", "prop-d": "draft-d",
+		},
+		aggregatorOut: map[string]string{
+			"agg-1": "draft", "agg-2": "draft",
+		},
+		refinerOut: "ok",
+	}
+	c := moaCouncil(t, []string{"prop-a", "prop-b", "prop-c", "prop-d"}, []string{"agg-1", "agg-2"}, "refiner-z", rec)
+
+	var labelToModel map[string]string
+	var moa *MoaAggregator
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				labelToModel = d.Metadata.LabelToModel
+				moa = d.Metadata.MoaAggregator
+			}
+		}
+	})
+
+	// LabelToModel must contain BOTH proposer- and aggregator-prefixed entries.
+	var proposerCount, aggregatorCount int
+	for label := range labelToModel {
+		switch {
+		case strings.HasPrefix(label, "Response "):
+			proposerCount++
+		case strings.HasPrefix(label, "Aggregator "):
+			aggregatorCount++
+		default:
+			t.Errorf("unexpected label prefix in LabelToModel: %q", label)
+		}
+	}
+	if proposerCount != 4 {
+		t.Errorf("proposer-prefixed entries: got %d, want 4", proposerCount)
+	}
+	if aggregatorCount != 2 {
+		t.Errorf("aggregator-prefixed entries: got %d, want 2", aggregatorCount)
+	}
+	// Aggregator labels in MoaAggregator MUST use the "Aggregator " prefix.
+	for _, a := range moa.Aggregators {
+		if !strings.HasPrefix(a.Label, "Aggregator ") {
+			t.Errorf("aggregator label %q missing 'Aggregator ' prefix", a.Label)
+		}
+	}
+}
+
+// ── 11. Refiner failure populates Model + DurationMs ───────────────────
+
+func TestRunMixtureOfAgents_RefinerFailurePopulatesModel(t *testing.T) {
+	errBoom := errors.New("refiner upstream")
+	rec := &moaRecorder{
+		proposerOut: map[string]string{
+			"prop-a": "draft-a", "prop-b": "draft-b", "prop-c": "draft-c", "prop-d": "draft-d",
+		},
+		aggregatorOut: map[string]string{
+			"agg-1": "draft", "agg-2": "draft",
+		},
+		refinerErr: errBoom,
+	}
+	c := moaCouncil(t, []string{"prop-a", "prop-b", "prop-c", "prop-d"}, []string{"agg-1", "agg-2"}, "refiner-z", rec)
+
+	err := c.RunFull(context.Background(), "q", "test", nil)
+	if err == nil {
+		t.Fatal("expected refiner error")
+	}
+	if !errors.Is(err, errBoom) {
+		t.Errorf("error chain: want errBoom, got %v", err)
+	}
+	// runMoaRefine returns StageThreeResult{Model, DurationMs, Error} on the
+	// error path. The package-level test surface for that is via runMoaRefine
+	// directly (RunFull discards the result on error).
+	stage3, refineErr := c.runMoaRefine(context.Background(), "q",
+		[]AggregatorOutput{{Label: "Aggregator A", Model: "agg-1", Content: "draft", Sources: []string{"Response A"}}},
+		map[string]string{"Aggregator A": "agg-1"},
+		"refiner-z", 0.7,
+	)
+	if refineErr == nil {
+		t.Fatal("expected error from runMoaRefine")
+	}
+	if stage3.Model != "refiner-z" {
+		t.Errorf("Model: got %q, want %q on error", stage3.Model, "refiner-z")
+	}
+	if stage3.DurationMs < 0 {
+		t.Errorf("DurationMs: negative %d", stage3.DurationMs)
+	}
+	if stage3.Error == nil {
+		t.Error("Error: nil; want populated on failure path")
+	}
+}
+
+// ── 12. Sort stability ────────────────────────────────────────────────
+
+func TestRunMixtureOfAgents_SortStability(t *testing.T) {
+	rec := &moaRecorder{
+		proposerOut: map[string]string{
+			"prop-a": "draft-a", "prop-b": "draft-b", "prop-c": "draft-c", "prop-d": "draft-d",
+		},
+		aggregatorOut: map[string]string{
+			"agg-1": "draft 1", "agg-2": "draft 2", "agg-3": "draft 3",
+		},
+		refinerOut: "ok",
+	}
+	c := moaCouncil(t, []string{"prop-a", "prop-b", "prop-c", "prop-d"}, []string{"agg-1", "agg-2", "agg-3"}, "refiner-z", rec)
+
+	var moa *MoaAggregator
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				moa = d.Metadata.MoaAggregator
+			}
+		}
+	})
+	if moa == nil {
+		t.Fatal("moa nil")
+	}
+	for i := 1; i < len(moa.Aggregators); i++ {
+		if moa.Aggregators[i-1].Label > moa.Aggregators[i].Label {
+			t.Errorf("aggregators not sorted ascending by Label: %+v", labelsOf(moa.Aggregators))
+			break
+		}
+	}
+}
+
+// ── 13. Transcript-agreement contract ────────────────────────────────
+
+func TestRunMixtureOfAgents_TranscriptAgreement(t *testing.T) {
+	// For every emitted AggregatorOutput, every label in Sources MUST appear in
+	// the captured prompt body, and the prompt body MUST contain no extras
+	// (i.e., the prompt's set of Layer 1 labels equals Sources). Catches
+	// runner/prompt bookkeeping divergence.
+	rec := &moaRecorder{
+		proposerOut: map[string]string{
+			"prop-a": "draft-a", "prop-b": "draft-b", "prop-c": "draft-c", "prop-d": "draft-d",
+		},
+		aggregatorOut: map[string]string{
+			"agg-1": "draft 1", "agg-2": "draft 2",
+		},
+		refinerOut: "ok",
+	}
+	c := moaCouncil(t, []string{"prop-a", "prop-b", "prop-c", "prop-d"}, []string{"agg-1", "agg-2"}, "refiner-z", rec)
+
+	var moa *MoaAggregator
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				moa = d.Metadata.MoaAggregator
+			}
+		}
+	})
+	if moa == nil {
+		t.Fatal("moa nil")
+	}
+	for _, a := range moa.Aggregators {
+		prompt, ok := rec.aggregatorPromptByModel[a.Model]
+		if !ok {
+			t.Errorf("no captured prompt for aggregator %q (model %q)", a.Label, a.Model)
+			continue
+		}
+		// 1. Every label in Sources MUST appear in the prompt body.
+		for _, lbl := range a.Sources {
+			needle := fmt.Sprintf("[%s]", lbl)
+			if !strings.Contains(prompt, needle) {
+				t.Errorf("aggregator %q: source %q not present in prompt body", a.Label, lbl)
+			}
+		}
+		// 2. No extra proposer-prefixed labels beyond Sources.
+		labelsInPrompt := extractProposerLabelsFromPrompt(prompt)
+		got := append([]string(nil), labelsInPrompt...)
+		want := append([]string(nil), a.Sources...)
+		sort.Strings(got)
+		sort.Strings(want)
+		if !equalStringSlice(got, want) {
+			t.Errorf("aggregator %q: prompt labels ≠ Sources\nprompt has: %v\nSources:    %v", a.Label, got, want)
+		}
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+func labelsOf(aggs []AggregatorOutput) []string {
+	out := make([]string, len(aggs))
+	for i, a := range aggs {
+		out[i] = a.Label
+	}
+	return out
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// extractProposerLabelsFromPrompt returns every "Response X" label that
+// appears in the prompt body inside `[...]` brackets — the format used by
+// BuildMoaAggregatorPrompt for proposer drafts.
+func extractProposerLabelsFromPrompt(prompt string) []string {
+	var out []string
+	for _, line := range strings.Split(prompt, "\n") {
+		if strings.HasPrefix(line, "[Response ") && strings.HasSuffix(line, "]") {
+			out = append(out, strings.Trim(line, "[]"))
+		}
+	}
+	return out
+}

--- a/internal/council/prompts.go
+++ b/internal/council/prompts.go
@@ -489,6 +489,82 @@ func BuildDebateChairmanPrompt(query string, stage1 []StageOneResult, debate *De
 	}
 }
 
+// BuildMoaAggregatorPrompt asks a single MixtureOfAgents Layer 2 aggregator to
+// digest the Layer 1 proposer drafts and produce one improved draft.
+//
+// Anonymisation contract: proposer outputs are shown with labels only —
+// model names MUST NOT appear in the body (the aggregator should not weight
+// drafts by source identity).
+//
+// Output is free-form text — no JSON-mode constraint. The aggregator's draft
+// flows directly into the Layer 3 refiner prompt; nothing parses it. Proposers
+// are sorted by Label so the prompt is deterministic across runs.
+//
+// Discriminator prefix: "You aggregate council proposals." — used by tests to
+// classify the call as a Layer 2 aggregator call (vs Layer 3 refiner).
+func BuildMoaAggregatorPrompt(query string, proposers []StageOneResult) []ChatMessage {
+	sorted := make([]StageOneResult, len(proposers))
+	copy(sorted, proposers)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Label < sorted[j].Label })
+
+	var sb strings.Builder
+	sb.WriteString("You aggregate council proposals. ")
+	fmt.Fprintf(&sb, "%d proposers wrote independent drafts for the question below; ", len(sorted))
+	sb.WriteString("read all drafts carefully and write ONE improved draft that integrates the strongest ideas from each. ")
+	sb.WriteString("Do not just pick a favourite — synthesise. Do not list the proposers' weaknesses; produce the better answer directly.\n\n")
+	sb.WriteString("Question: ")
+	sb.WriteString(query)
+	sb.WriteString("\n\nProposer drafts (anonymous; you do not know which model wrote which):\n")
+	for _, p := range sorted {
+		fmt.Fprintf(&sb, "\n[%s]\n%s\n", p.Label, p.Content)
+	}
+	sb.WriteString("\nWrite your improved draft. Reply with the draft only — no preamble, no commentary on the proposers.")
+
+	return []ChatMessage{
+		{Role: "user", Content: sb.String()},
+	}
+}
+
+// BuildMoaRefinerPrompt asks the MixtureOfAgents Layer 3 refiner to synthesise
+// a final answer from the Layer 2 aggregator drafts. The refiner does NOT see
+// raw proposer outputs — the aggregators have already digested them; passing
+// proposers again would defeat the layered-aggregation premise.
+//
+// The refiner receives aggregator outputs WITH model attribution (label +
+// model name), mirroring how PeerReview / MultiAgentDebate chairmen receive
+// LabelToModel — Layer 3 is the strategy's "chairman" equivalent and model
+// attribution is allowed at this stage.
+//
+// Discriminator prefix: "You synthesise the final answer from MoA aggregator
+// drafts." — used by tests to classify the call as the Layer 3 refiner call.
+func BuildMoaRefinerPrompt(query string, aggregators []AggregatorOutput, labelToModel map[string]string) []ChatMessage {
+	sorted := make([]AggregatorOutput, len(aggregators))
+	copy(sorted, aggregators)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Label < sorted[j].Label })
+
+	var sb strings.Builder
+	sb.WriteString("You synthesise the final answer from MoA aggregator drafts. ")
+	fmt.Fprintf(&sb, "%d aggregators each digested the council's proposer drafts and produced an improved draft for the question below. ", len(sorted))
+	sb.WriteString("Combine the strongest threads from these aggregator drafts into one final answer.\n\n")
+	sb.WriteString("Question: ")
+	sb.WriteString(query)
+	sb.WriteString("\n\nAggregator drafts:\n")
+	for _, a := range sorted {
+		modelName := labelToModel[a.Label]
+		if modelName == "" {
+			modelName = a.Model
+		}
+		fmt.Fprintf(&sb, "\n[%s — %s]\n%s\n", a.Label, modelName, a.Content)
+	}
+	sb.WriteString("\nProduce the final answer. Pick the strongest threads from each aggregator draft and weave them into one answer that is more accurate, clearer, and more complete than any individual draft. ")
+	sb.WriteString("If one aggregator is clearly best, prefer it over an unnecessary synthesis. ")
+	sb.WriteString("Reply with the final answer only — no preamble, no commentary on the aggregation process.")
+
+	return []ChatMessage{
+		{Role: "user", Content: sb.String()},
+	}
+}
+
 // BuildRankRefinePrompt asks the GenerateRankRefine refiner (the chairman) to
 // produce a final answer from the top-K advancing candidates. The instruction
 // emphasises picking strong threads over averaging — bland blends are the

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -72,6 +72,8 @@ func (c *Council) RunFull(ctx context.Context, query string, councilTypeName str
 		return c.runGenerateRankRefine(ctx, query, ct, onEvent)
 	case MultiAgentDebate:
 		return c.runMultiAgentDebate(ctx, query, ct, onEvent)
+	case MixtureOfAgents:
+		return c.runMixtureOfAgents(ctx, query, ct, onEvent)
 	default:
 		return fmt.Errorf("council: strategy %d not implemented", ct.Strategy)
 	}

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -555,7 +555,7 @@ func TestRunFull_Stage2CompletePayload_IsStage2CompleteData(t *testing.T) {
 
 func TestRunFull_UnimplementedStrategy_ReturnsError(t *testing.T) {
 	unimplemented := []Strategy{
-		MixtureOfAgents, Delphi,
+		Delphi,
 	}
 	for _, s := range unimplemented {
 		s := s

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -42,6 +42,21 @@ type Role struct {
 
 // CouncilType describes a named council configuration.
 // QuorumMin of 0 means use the formula: max(2, ⌈N/2⌉+1).
+//
+// Field-usage matrix (which fields each strategy reads):
+//
+//	PeerReview         : Models, ChairmanModel, Temperature, QuorumMin
+//	RoleBased          : Models, Roles, ChairmanModel, Temperature, QuorumMin
+//	Majority           : Models, ChairmanModel (optional), Temperature, QuorumMin
+//	GenerateRankRefine : Models, ChairmanModel, Temperature, QuorumMin, RefineTopK
+//	MultiAgentDebate   : Models, ChairmanModel, Temperature, QuorumMin, MaxDebateRounds
+//	MixtureOfAgents    : ProposerModels, AggregatorModels, RefinerModel, Temperature, QuorumMin
+//	                     (Models and ChairmanModel are UNUSED for this strategy)
+//
+// MixtureOfAgents is the first strategy to skip both Models and ChairmanModel —
+// the runner reads the layer-specific ProposerModels / AggregatorModels /
+// RefinerModel fields directly. The Models/ChairmanModel fields stay zero-valued
+// for MoA registrations and are non-breaking for every other strategy.
 type CouncilType struct {
 	Name          string
 	Strategy      Strategy
@@ -52,6 +67,12 @@ type CouncilType struct {
 	QuorumMin       int // 0 = strategy-specific default formula
 	RefineTopK      int // GenerateRankRefine only: how many ranked candidates advance to refinement; 0 = default (3)
 	MaxDebateRounds int // MultiAgentDebate only: number of debate rounds after Stage 1; 0 = default (2)
+
+	// MixtureOfAgents-only model fields. The runner reads these directly;
+	// Models and ChairmanModel are UNUSED for MoA registrations.
+	ProposerModels   []string // MoA: Layer 1 model pool (parallel proposer drafts)
+	AggregatorModels []string // MoA: Layer 2 model pool (parallel aggregators, all-to-all over Layer 1)
+	RefinerModel     string   // MoA: Layer 3 single refiner that synthesises the final answer
 }
 
 // ChatMessage is a single turn in a conversation history.
@@ -202,11 +223,36 @@ type Debate struct {
 	Dropouts   []DebaterDropout `json:"dropouts,omitempty"`
 }
 
+// AggregatorOutput is a single Layer 2 aggregator's improved draft in the
+// MixtureOfAgents strategy. Sources lists the labels of the Layer 1 proposers
+// whose drafts were fed into this aggregator (today: all-to-all fan-out, so
+// every aggregator sees every proposer).
+type AggregatorOutput struct {
+	Label      string   `json:"label"`        // anonymised, e.g. "Aggregator A"
+	Model      string   `json:"model"`        // OpenRouter ID, for transparency
+	Content    string   `json:"content"`      // aggregator's improved draft
+	Sources    []string `json:"sources"`      // proposer labels fed in (e.g. ["Response A", "Response B"])
+	DurationMs int64    `json:"duration_ms"`
+	Error      error    `json:"-"`
+}
+
+// MoaAggregator is the Stage 2 payload for the MixtureOfAgents strategy.
+// Aggregators are sorted by Label ascending for stable output across runs.
+type MoaAggregator struct {
+	Aggregators []AggregatorOutput `json:"aggregators"`
+}
+
 // Metadata is persisted with every assistant message.
 //
 // VoteTally is populated only by the Majority strategy; RankRefine only by
-// GenerateRankRefine; Debate only by MultiAgentDebate. omitempty keeps each
-// absent on the wire and at rest for every other strategy.
+// GenerateRankRefine; Debate only by MultiAgentDebate; MoaAggregator only by
+// MixtureOfAgents. omitempty keeps each absent on the wire and at rest for
+// every other strategy.
+//
+// LabelToModel is a single flat map containing both proposer labels
+// ("Response A" → model-x) and aggregator labels ("Aggregator A" → model-y)
+// for MixtureOfAgents — key collisions are impossible because the prefixes
+// differ. The same field is reused; no parallel aggregator_label_to_model.
 type Metadata struct {
 	CouncilType       string            `json:"council_type"`
 	LabelToModel      map[string]string `json:"label_to_model"`
@@ -215,6 +261,7 @@ type Metadata struct {
 	VoteTally         *VoteTally        `json:"vote_tally,omitempty"`
 	RankRefine        *RankRefine       `json:"rank_refine,omitempty"`
 	Debate            *Debate           `json:"debate,omitempty"`
+	MoaAggregator     *MoaAggregator    `json:"moa_aggregator,omitempty"`
 }
 
 // Stage2CompleteData is the payload emitted by Runner for the "stage2_complete" event.


### PR DESCRIPTION
## Summary

Sixth deliberation strategy (Together AI MoA paper). Three layers — proposers (Layer 1) → aggregators (Layer 2, all-to-all over Layer 1) → refiner (Layer 3). Best for code generation and complex multi-aspect analysis.

- **First strategy to require new `CouncilType` fields beyond `Models`/`ChairmanModel`**: `ProposerModels`, `AggregatorModels`, `RefinerModel`. Existing fields are unused for MoA registrations. Field-usage matrix documented in `CouncilType`'s doc-comment in `internal/council/types.go`.
- **Anonymisation:** proposer labels (`Response A/B/…`) and aggregator labels (`Aggregator A/B/…`) coexist as a single flat `Metadata.LabelToModel` map (no key collisions, distinct prefix families).
- **Two-tier quorum:** Layer 1 standard `max(2, ⌈N/2⌉+1)`; Layer 2 needs ≥1 successful aggregator else loud error (no `stage2_complete` emitted, no Stage 3 run).
- **Three required env vars** `MOA_PROPOSER_MODELS` / `MOA_AGGREGATOR_MODELS` / `MOA_REFINER_MODEL` — partial config logs a warning and skips registration. Mirrored across `cmd/server` and `cmd/eval`.
- **Cost:** N+M+1 LLM calls per request (default N=4 M=2 → 7 calls).

Stage 2 emits `kind: "moa_aggregator"` with per-aggregator outputs and `Sources` provenance. **No `stage2_round_complete` events** — MoA is single-pass per layer; wire-format test asserts the round event is absent.

Frontend `MoaView` shows two stacked layer panels with source-proposer labels per aggregator. Unknown-kind dispatcher test moved to `delphi_round` (the only kind still reserved post-merge).

Closes #214

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./internal/... ./cmd/...` passes (all packages)
- [x] 13 backend cases in `internal/council/moa_test.go` pass — including a transcript-agreement contract test (each `AggregatorOutput.Sources` matches exactly the proposer labels in the captured aggregator prompt)
- [x] 1 wire-format integration test in `internal/api/handler_test.go` — asserts `kind="moa_aggregator"` on the wire AND `stage2_round_complete` is NOT emitted
- [x] 4 config tests in `internal/config/config_test.go` (all-set, partial, all-unset, refiner whitespace)
- [x] 3 frontend tests in `frontend/src/components/Stage2.test.jsx` (4-proposer/2-aggregator panels, single survivor, long-content truncation)
- [x] `npm run lint` passes
- [x] `npm test -- --run` passes (35 tests across 3 files)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)