### PR TITLE
⚖️ feat(council,api,frontend,config): Delphi strategy — multi-round anonymous blind rating with convergence detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,6 +187,45 @@ DEFAULT_COUNCIL_TEMPERATURE=0.7
 # NOT see raw proposer outputs (the aggregators have already digested them).
 # MOA_REFINER_MODEL=anthropic/claude-opus-4-7
 
+# ── Delphi strategy (multi-round anonymous blind rating with convergence) ───
+# Setting BOTH DELPHI_MODELS and DELPHI_CHAIRMAN_MODEL registers the "delphi"
+# council type. Like MultiAgentDebate / GenerateRankRefine / MoA, this
+# strategy has no no-LLM path — every round is an LLM call per surviving
+# rater plus one Stage 3 chairman synthesis. If models are set without the
+# chairman, the server logs a warning and skips registration.
+#
+# Best for evaluation tasks, expert consensus problems, and forecasting —
+# domains where rating-based feedback drives convergence faster than free-
+# form critique.
+#
+# COST WARNING. Worst case (no convergence): N + N×R + 1 LLM calls per
+# request. With the defaults below (N=4 raters × R=3 rounds + chairman)
+# that's 17 calls per request. Convergence at round 2 reduces this to
+# 9 calls. Bump DELPHI_MAX_ROUNDS only when you've measured cost is
+# acceptable.
+#
+# DELPHI_MODELS=openai/gpt-4o-mini,anthropic/claude-haiku-4-5,google/gemini-flash-1.5,qwen/qwen3.6-plus
+
+# Required when DELPHI_MODELS is set. The chairman synthesises the final
+# answer from the final-round per-rater ratings + summaries + converged
+# stats. Synthesis guidance scales with whether the panel converged.
+# DELPHI_CHAIRMAN_MODEL=anthropic/claude-sonnet-4-5
+
+# Optional. Maximum number of rating rounds before forced exit. Default: 3.
+# Each round, every surviving rater scores ALL Stage 1 candidates against
+# the criteria (correctness, clarity, completeness) and produces a 1–2
+# sentence summary of its current view. Invalid values warn and fall back
+# to the runner default.
+# DELPHI_MAX_ROUNDS=3
+
+# Optional. Convergence threshold for max(DeltaMean) across criteria.
+# Strategy exits early when, after any round R≥2, the absolute change in
+# mean rating per criterion is below this threshold for ALL criteria
+# present in the round. Valid range: (0.0, 1.0). Default: 0.1.
+# Conservative — the `max` comparison means every criterion must converge.
+# Invalid values (≤ 0, ≥ 1.0, non-numeric) warn and fall back to default.
+# DELPHI_CONVERGENCE_THRESHOLD=0.1
+
 # ── Storage ─────────────────────────────────────────────────────────────────
 # Directory where conversation JSON files are stored.
 # Created automatically if it does not exist. Default: data/conversations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,14 @@ codebase; the rewrite is well past the research phase.
 
 See `docs/` for the current source of truth:
 - `docs/architecture-v2.md` — package layout, layer boundaries, composition root, pipeline behaviour
-- `docs/strategies.md` — the 7 deliberation strategies (2 implemented, 5 planned), per-registration model config, quorum defaults, SSE protocol
+- `docs/strategies.md` — the 7 deliberation strategies (all implemented), per-registration model config, quorum defaults, SSE protocol
 - `docs/api.md` — REST + SSE event reference
 - `docs/pipeline.md` — Stage 0/1/2/3 internals
 - `docs/council-research-synthesis.md` — aggregated design research
 
-Two strategies (`PeerReview`, `RoleBased`) are implemented; five are reserved for planned
-work. Stage 0 (clarification) runs before strategy dispatch and is strategy-independent.
+All seven strategies are implemented (`PeerReview`, `RoleBased`, `Majority`,
+`GenerateRankRefine`, `MultiAgentDebate`, `MixtureOfAgents`, `Delphi`). Stage 0
+(clarification) runs before strategy dispatch and is strategy-independent.
 See [`docs/strategies.md`](docs/strategies.md) for the full enum, status, and per-strategy
 configuration.
 

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -171,6 +171,22 @@ func run() error {
 			}
 		}
 	}
+	// Mirror cmd/server's opt-in Delphi registration.
+	if len(cfg.DelphiModels) > 0 {
+		if cfg.DelphiChairmanModel == "" {
+			logger.Warn("DELPHI_MODELS set but DELPHI_CHAIRMAN_MODEL is empty; skipping registration of \"delphi\" council type")
+		} else {
+			registry["delphi"] = council.CouncilType{
+				Name:                       "delphi",
+				Strategy:                   council.Delphi,
+				Models:                     cfg.DelphiModels,
+				ChairmanModel:              cfg.DelphiChairmanModel,
+				Temperature:                cfg.DefaultCouncilTemperature,
+				MaxDelphiRounds:            cfg.DelphiMaxRounds,
+				DelphiConvergenceThreshold: cfg.DelphiConvergenceThreshold,
+			}
+		}
+	}
 	if _, ok := registry[*councilType]; !ok {
 		return fmt.Errorf("unknown council type %q (known: %v)", *councilType, knownTypes(registry))
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -126,6 +126,26 @@ func main() {
 		}
 	}
 
+	// Delphi registration is opt-in AND requires both env vars. Stage 3
+	// chairman always runs; no no-LLM path. DelphiMaxRounds=0 and
+	// DelphiConvergenceThreshold=0 are sentinels for "use runner defaults"
+	// (3 rounds, 0.1 threshold).
+	if len(cfg.DelphiModels) > 0 {
+		if cfg.DelphiChairmanModel == "" {
+			logger.Warn("DELPHI_MODELS set but DELPHI_CHAIRMAN_MODEL is empty; skipping registration of \"delphi\" council type")
+		} else {
+			registry["delphi"] = council.CouncilType{
+				Name:                       "delphi",
+				Strategy:                   council.Delphi,
+				Models:                     cfg.DelphiModels,
+				ChairmanModel:              cfg.DelphiChairmanModel,
+				Temperature:                cfg.DefaultCouncilTemperature,
+				MaxDelphiRounds:            cfg.DelphiMaxRounds,
+				DelphiConvergenceThreshold: cfg.DelphiConvergenceThreshold,
+			}
+		}
+	}
+
 	client := openrouter.NewClient(cfg.OpenRouterAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger)
 	runner := council.NewCouncil(client, registry, logger)
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -101,7 +101,7 @@ This keeps all dependency injection in one place and makes each package independ
 
 ### Council pipeline (`internal/council`)
 
-The `Strategy` enum carries **7 constants** — 6 are implemented today, 1 is reserved for a planned strategy. See [`strategies.md`](./strategies.md) for the full roadmap.
+The `Strategy` enum carries **7 constants — all implemented**. The strategy roadmap is complete. See [`strategies.md`](./strategies.md) for the full per-strategy reference.
 
 ```go
 type Strategy int
@@ -113,7 +113,7 @@ const (
     GenerateRankRefine                 // implemented (generaterankrefine.go:runGenerateRankRefine)
     MultiAgentDebate                   // implemented (debate.go:runMultiAgentDebate)
     MixtureOfAgents                    // implemented (moa.go:runMixtureOfAgents)
-    Delphi                             // not implemented
+    Delphi                             // implemented (delphi.go:runDelphi)
 )
 
 type CouncilType struct {
@@ -134,7 +134,7 @@ type CouncilType struct {
 }
 ```
 
-`MixtureOfAgents` is the first strategy to skip both `Models` and `ChairmanModel`. The runner reads the layer-specific fields directly. The full field-usage matrix (which fields each strategy reads) lives in `CouncilType`'s doc-comment in `internal/council/types.go`.
+`CouncilType` carries strategy-specific scalars too — `RefineTopK` for GenerateRankRefine, `MaxDebateRounds` for MultiAgentDebate, `MaxDelphiRounds` and `DelphiConvergenceThreshold` for Delphi. `MixtureOfAgents` is the only strategy to skip both `Models` and `ChairmanModel` — the runner reads the layer-specific fields directly. The full field-usage matrix (which fields each strategy reads) lives in `CouncilType`'s doc-comment in `internal/council/types.go`.
 
 `RunFull()` is a strategy-dispatch switch — every shipped strategy has its own `case`:
 
@@ -146,9 +146,12 @@ case Majority:           return c.runMajority(...)
 case GenerateRankRefine: return c.runGenerateRankRefine(...)
 case MultiAgentDebate:   return c.runMultiAgentDebate(...)
 case MixtureOfAgents:    return c.runMixtureOfAgents(...)
+case Delphi:             return c.runDelphi(...)
 default:                 return fmt.Errorf("council: strategy %d not implemented", ct.Strategy)
 }
 ```
+
+The `default` arm is unreachable today (every strategy has a case), but is retained for forward compatibility — adding a new `Strategy` constant without a corresponding case fails loudly at runtime.
 
 #### `PeerReview` pipeline (3 stages)
 
@@ -244,6 +247,26 @@ Implemented in `internal/council/moa.go`. Modelled on the Together AI MoA paper.
 **Out of scope (future variants):** round-robin aggregator fan-out (today is all-to-all per the MoA paper), aggregator role specialisation, refiner-as-pass-through, iterative MoA depth ≥ 2 aggregator layers.
 
 Registration is opt-in AND requires **all three** `MOA_PROPOSER_MODELS` / `MOA_AGGREGATOR_MODELS` / `MOA_REFINER_MODEL` env vars. Partial config logs a warning and skips registration — there's no no-LLM path for MoA.
+
+#### `Delphi` pipeline (multi-round, second to use `stage2_round_complete`)
+
+Implemented in `internal/council/delphi.go`. Modelled on the Delphi method. Best for evaluation tasks, expert consensus problems, and forecasting — domains where rating-based feedback drives convergence faster than free-form critique. **Last unimplemented strategy in the roadmap;** post-merge no `Strategy` constants are reserved.
+
+1. **Stage 1** — `runStage1` reused with `ct.Models`. Anonymous `Response A`/`B`/… labels via `assignLabels`. Quorum: `max(3, ⌈N/2⌉+1)` when `QuorumMin == 0` — higher floor than PeerReview/Debate (3 vs 2) because statistical averaging needs ≥3 raters.
+2. **Rounds 1..R** — for each round, all surviving raters concurrently rate ALL Stage 1 candidates against `defaultDelphiCriteria` (`correctness`, `clarity`, `completeness`) via `runDelphiRound`. Output is JSON `{ratings: {<criterion>: <0.0..1.0>, ...}, summary: "<1–2 sentences>"}`. Per-rater LLM/parse/empty-scores failure drops that rater for the rest of the run; per-round event: `stage2_round_complete` with `kind: "delphi_round"` and `round: r`.
+3. **Round-1 vs round R≥2 prompt asymmetry.** Round 1 prompts contain only the question + criteria + Stage 1 candidates (with anonymous labels). Round R≥2 prompts add (a) the full prior-round aggregate stats history (mean/stddev per criterion, and DeltaMean from round 2 onwards) and (b) the rater's OWN previous-round ratings + summary so it can revise rather than start from scratch. **Other raters' raw ratings are NEVER exposed to a rater** — the aggregate is the entire feedback signal. Cross-rater leakage would defeat the anonymous-blind property of the method.
+4. **Per-round quorum re-check.** After every round, if `len(survivors) < need`, `runDelphi` returns `fmt.Errorf("delphi: quorum failed after round %d (%d survivors, need %d)")` — loud failure, no `stage2_complete` emitted, no Stage 3 run. Mirror Debate's pattern (#213).
+5. **Convergence detection** (`computeDelphiStats`): pure function. Mean/StdDev populated only for criteria with ≥1 rating in the round; DeltaMean populated only for criteria present in BOTH the current and prior round (and absent on round 1). After round R≥2, if `max(DeltaMean) < ct.DelphiConvergenceThreshold` for ALL criteria in DeltaMean, exit early with `Converged: true`. Conservative — every criterion must converge; `mean` would let one stable criterion paper over a divergent one.
+6. **Stage 2 terminal event** — `stage2_complete` with `kind: "delphi_round"`, `Metadata.DelphiPanel` populated with `Rounds[]`, `FinalRound`, `Converged`, and `Criteria`.
+7. **Stage 3** — `runDelphiStage3`: chairman synthesises across the final-round per-rater ratings + summaries + converged stats via `BuildDelphiChairmanPrompt`. The chairman receives the LabelToModel map for candidate provenance attribution. Synthesis guidance scales with the `Converged` flag — converged → confident synthesis from the highest-rated candidate; not-converged → balanced presentation. Failure path matches `runStage3` (returns `StageThreeResult{Model, DurationMs, Error}` even on error).
+
+**Cost:** `N + N×R + 1` worst case (no convergence). With defaults N=4 R=3: **17 calls**. Convergence at round 2 → 9 calls; at round 1 the strategy can't yet detect convergence.
+
+**No `DelphiDropout` type.** Dropped raters are simply absent from subsequent rounds' `Ratings` slices; chairman and frontend infer dropout by label-set diff between rounds. Delphi's transcript is a sample (smaller `n`), not a narrative — typed dropout markers would invite the chairman prompt to over-explain.
+
+**Single source of truth on the frontend:** `msg.metadata.delphi`. The `stage2_round_complete` handler (factored into `mergeRoundIntoMessage` in `App.jsx`) appends to `metadata.delphi.rounds` for `kind: "delphi_round"` events, mirroring how it handles `kind: "debate_round"` for Debate.
+
+Registration is opt-in AND requires both `DELPHI_MODELS` and `DELPHI_CHAIRMAN_MODEL`. `DELPHI_MAX_ROUNDS` (default 3) and `DELPHI_CONVERGENCE_THRESHOLD` (default 0.1; valid range `(0.0, 1.0)`) are optional; invalid values warn and fall back to defaults.
 
 #### Per-registration model configuration
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,6 +1,6 @@
 # Deliberation Strategies
 
-The `Strategy` enum (`internal/council/types.go`) declares **7 constants**. Six are implemented today; one is reserved for a planned strategy. The runner returns `"strategy %d not implemented"` for unimplemented constants.
+The `Strategy` enum (`internal/council/types.go`) declares **7 constants — all implemented**. The strategy roadmap is complete.
 
 For architecture context (package layout, layer boundaries, dispatch switch) see [`architecture-v2.md`](./architecture-v2.md). For the academic background of each strategy see [`council-research-synthesis.md`](./council-research-synthesis.md).
 
@@ -18,7 +18,7 @@ Stage 0 (clarification) runs **before** strategy dispatch and is strategy-indepe
 | `GenerateRankRefine` | shipped | `generaterankrefine.go:runGenerateRankRefine` | #210 |
 | `MultiAgentDebate` | shipped | `debate.go:runMultiAgentDebate` | #212 |
 | `MixtureOfAgents` | shipped | `moa.go:runMixtureOfAgents` | #214 |
-| `Delphi` | planned | — | TBD |
+| `Delphi` | shipped | `delphi.go:runDelphi` | #216 |
 
 ### LLM-call cost (per request, ignoring Stage 0)
 
@@ -32,8 +32,7 @@ Operators pick strategies on cost as much as on output quality. For a council of
 | `GenerateRankRefine` | **N + 2** | N generation + 1 ranking + 1 refinement (both go to the chairman) |
 | `MultiAgentDebate` | **N + N×R + 1** | N generation + R rounds × N debaters revising + 1 chairman synthesis. With defaults N=4, R=2 → 13 calls. The most expensive shipped strategy; cost note in `.env.example`. |
 | `MixtureOfAgents` | **N + M + 1** | N proposers (Layer 1) + M aggregators (Layer 2, all-to-all over proposers) + 1 refiner (Layer 3). With defaults N=4, M=2 → 7 calls. |
-
-`Delphi` is still planned; its cost will be added when it ships.
+| `Delphi` | **N + N×R + 1** (worst case) | N generation (Stage 1) + R rounds × N raters + 1 chairman synthesis. Strategy may exit early on convergence (max(DeltaMean) < threshold across all criteria after any round R≥2), so effective cost = N + N×R_eff + 1 where R_eff = FinalRound. With defaults N=4, R=3: **17 calls** worst case (no convergence); **9 calls** on early convergence at round 2. |
 
 ---
 
@@ -49,7 +48,7 @@ Each registration in `cmd/server/main.go` and `cmd/eval/main.go` carries its own
 | `GenerateRankRefine` | Generators | Ranker + refiner (single model today) | `GENERATE_RANK_REFINE_MODELS` / `GENERATE_RANK_REFINE_CHAIRMAN_MODEL` | `COUNCIL_MODELS` / `CHAIRMAN_MODEL` |
 | `MultiAgentDebate` | Debaters | Synthesiser | `DEBATE_MODELS` / `DEBATE_CHAIRMAN_MODEL` | `COUNCIL_MODELS` / `CHAIRMAN_MODEL` |
 | `MixtureOfAgents` | (UNUSED — MoA reads `ProposerModels`/`AggregatorModels`/`RefinerModel` directly) | (UNUSED — see above) | `MOA_PROPOSER_MODELS` / `MOA_AGGREGATOR_MODELS` / `MOA_REFINER_MODEL` (ALL THREE required to register; partial config logs a warning and skips) | none — registration is opt-in via all three MoA env vars |
-| `Delphi` | Raters | Facilitator (optional) | `DELPHI_MODELS` / `DELPHI_CHAIRMAN_MODEL` | `COUNCIL_MODELS` / `CHAIRMAN_MODEL` |
+| `Delphi` | Raters (also Stage 1 proposers — same pool serves both roles) | Synthesiser (required) | `DELPHI_MODELS` / `DELPHI_CHAIRMAN_MODEL` (both required); `DELPHI_MAX_ROUNDS` (optional, default 3) and `DELPHI_CONVERGENCE_THRESHOLD` (optional, default 0.1) tune the rating loop | none — registration is opt-in via both DELPHI_* env vars |
 
 `MixtureOfAgents` is the only shipped strategy that does not fit the `Models` + `ChairmanModel` shape. `CouncilType` carries three MoA-only fields:
 
@@ -118,9 +117,9 @@ PeerReview's existing payload corresponds to `kind: "peer_ranking"`; RoleBased's
 | `rank_refine` | `GenerateRankRefine` | **shipped** | `metadata.rank_refine` is a `RankRefine` (`{rankings: RankedCandidate[], top_k: int, criteria: string[]}`); `data` is `[]` (the ranking lives in metadata, not per-reviewer). `RankedCandidate` is `{label: string, scores: map<string, float64>, total_score: float64, advancing: bool}`. Rankings are sorted by `total_score` desc, then `label` asc. Exactly `top_k` candidates have `advancing: true`. Per-criterion scores clamped to `[0.0, 1.0]`; `total_score` to `[0.0, len(criteria)]`. | always `0` |
 | `debate_round` | `MultiAgentDebate` | **shipped** | `metadata.debate` is a `Debate` (`{rounds: DebateRound[], final_round: int, dropouts?: DebaterDropout[]}`); `data` is `[]` (the transcript lives in metadata, not per-reviewer). Round events fire as `stage2_round_complete` per round (carrying just that round); the terminal `stage2_complete` carries the full transcript including dropouts. `DebaterDropout` is `{label, last_round, reason: "error"\|"json_parse"\|"empty_revision"}`. | `1..R`; one `stage2_round_complete` per round, then a terminal `stage2_complete` |
 | `moa_aggregator` | `MixtureOfAgents` | **shipped** | `metadata.moa_aggregator` is a `MoaAggregator` (`{aggregators: AggregatorOutput[]}`); `data` is `[]` (the aggregator drafts live in metadata, not per-reviewer). `AggregatorOutput` is `{label, model, content, sources: string[], duration_ms}`. `sources` lists the Layer-1 proposer labels fed into that aggregator (today: all-to-all, so every aggregator's `sources` lists every successful proposer). Aggregators are sorted by `label` asc. `metadata.label_to_model` is a single flat map containing both proposer (`Response A → …`) and aggregator (`Aggregator A → …`) entries. | always `0` (single aggregator pass; no `stage2_round_complete` events) |
-| `delphi_round` | `Delphi` | **reserved** | per-rater rating list for the current round; running averages and convergence indicator | `1..N`; one event per round |
+| `delphi_round` | `Delphi` | **shipped** | `metadata.delphi` is a `DelphiPanel` (`{rounds: DelphiRound[], final_round: int, converged: bool, criteria: string[]}`); `data` is `[]` (the rating transcript lives in metadata, not per-reviewer). `DelphiRound` is `{round, ratings: DelphiRating[], stats: DelphiStats}`. `DelphiRating` is `{label, model, scores: map<string, float64>, summary, duration_ms}` — scores clamped to `[0.0, 1.0]` per criterion. `DelphiStats` is `{mean, std_dev, delta_mean (omitempty)}` — `delta_mean` absent on round 1; on round R≥2, present only for criteria in BOTH the current and prior round. Round events fire as `stage2_round_complete` per round (carrying just that round's `DelphiRound`); the terminal `stage2_complete` carries the full transcript. NO `DelphiDropout` type — dropped raters are simply absent from subsequent `ratings` slices. | `1..R`; one `stage2_round_complete` per round, then a terminal `stage2_complete`. Strategy may exit early when `max(delta_mean) < threshold` across all criteria. |
 
-Reserved kinds are not yet emitted by the runtime. The frontend `Stage2.jsx` dispatcher renders any unknown kind via a fallback view (`Stage 2 — kind: <X> (view not implemented yet)`) so a strategy in flight does not crash the UI.
+All seven kinds are now shipped. The frontend `Stage2.jsx` dispatcher renders any unknown kind via a fallback view (`Stage 2 — kind: <X> (view not implemented yet)`) so a future strategy in flight does not crash the UI; the dispatcher's unknown-kind test uses a synthetic sentinel (`__bogus_kind__`) since no real reserved kind remains.
 
 ---
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,6 +29,35 @@ function normaliseStage2Kind(raw) {
   return trimmed || 'peer_ranking';
 }
 
+// mergeRoundIntoMessage appends a per-round event's transcript subset into the
+// message's canonical metadata pointer for that strategy. Single source of
+// truth: msg.metadata.<ptr>.rounds — the terminal stage2_complete overwrites
+// with the canonical state, so this just keeps the live view in sync during
+// streaming.
+//
+// Kind → metadata pointer name:
+//   debate_round → metadata.debate
+//   delphi_round → metadata.delphi
+//
+// A new pointer is created if missing; an unknown kind defaults to "debate"
+// for backward compatibility (the only multi-round kind before this helper
+// existed).
+function mergeRoundIntoMessage(msg, event) {
+  if (!msg.metadata) {
+    msg.metadata = event.metadata ? { ...event.metadata } : {};
+  }
+  const ptrKey = event.kind === 'delphi_round' ? 'delphi' : 'debate';
+  if (!msg.metadata[ptrKey]) {
+    msg.metadata[ptrKey] = { rounds: [], final_round: 0 };
+  }
+  const incoming = event.metadata?.[ptrKey]?.rounds ?? [];
+  msg.metadata[ptrKey].rounds.push(...incoming);
+  msg.metadata[ptrKey].final_round = event.round ?? msg.metadata[ptrKey].rounds.length;
+  // Surface the kind so the dispatcher renders the right view during streaming
+  // (otherwise the view stays at peer_ranking until the terminal event).
+  msg.stage2Kind = normaliseStage2Kind(event.kind);
+}
+
 function App() {
   const [conversations, setConversations] = useState([]);
   const [currentConversationId, setCurrentConversationId] = useState(null);
@@ -164,25 +193,12 @@ function App() {
       msg.loading.stage1 = false;
     }),
     stage2_start: () => updateLast((msg) => { msg.loading.stage2 = true; }),
-    // Per-round events (currently only from MultiAgentDebate). Single source
-    // of truth: msg.metadata.debate.rounds. Each event APPENDS its round's
-    // revisions to the existing transcript; the terminal stage2_complete
-    // overwrites with the canonical state. No separate `debateRounds` field —
-    // dual state is a drift hazard.
-    stage2_round_complete: (event) => updateLast((msg) => {
-      if (!msg.metadata) {
-        msg.metadata = event.metadata ? { ...event.metadata } : {};
-      }
-      if (!msg.metadata.debate) {
-        msg.metadata.debate = { rounds: [], final_round: 0 };
-      }
-      const incoming = event.metadata?.debate?.rounds ?? [];
-      msg.metadata.debate.rounds.push(...incoming);
-      msg.metadata.debate.final_round = event.round ?? msg.metadata.debate.rounds.length;
-      // Surface the kind so the dispatcher renders DebateView during streaming
-      // (otherwise the view stays at peer_ranking until the terminal event).
-      msg.stage2Kind = normaliseStage2Kind(event.kind);
-    }),
+    // Per-round events from multi-round strategies (MultiAgentDebate, Delphi).
+    // Single source of truth per strategy: msg.metadata.<kind-pointer>.rounds.
+    // Each event APPENDS its round's transcript subset to the running list;
+    // the terminal stage2_complete overwrites with the canonical state. No
+    // separate `debateRounds` field — dual state is a drift hazard.
+    stage2_round_complete: (event) => updateLast((msg) => mergeRoundIntoMessage(msg, event)),
     stage2_complete: (event) => updateLast((msg) => {
       msg.stage2 = event.data;
       // Treat null / undefined / empty / whitespace-only as missing and

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -138,6 +138,7 @@ export default function ChatInterface({
                     rankRefine={msg.metadata?.rank_refine}
                     debate={msg.metadata?.debate}
                     moaAggregator={msg.metadata?.moa_aggregator}
+                    delphi={msg.metadata?.delphi}
                     isLoading={msg.loading?.stage2}
                   />
 

--- a/frontend/src/components/Stage2.css
+++ b/frontend/src/components/Stage2.css
@@ -505,3 +505,102 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+/* Delphi view (Delphi strategy) — per-round rating timeline */
+
+.delphi-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.delphi-round {
+  padding: 12px;
+  background: var(--bg-stage);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+}
+
+.delphi-round-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.delphi-converged-badge {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.delphi-criteria-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.delphi-criterion-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.delphi-criterion-name {
+  flex: 0 0 100px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  text-transform: capitalize;
+}
+
+.delphi-criterion-track {
+  flex: 1;
+  height: 4px;
+  background: var(--border-color);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.delphi-criterion-fill {
+  height: 100%;
+  background: var(--text-muted);
+  transition: width 200ms ease-out;
+}
+
+.delphi-criterion-stat {
+  flex: 0 0 80px;
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-family: monospace;
+}
+
+.delphi-delta-chip {
+  flex: 0 0 56px;
+  background: color-mix(in srgb, var(--text-muted) 15%, transparent);
+  color: var(--text-muted);
+  border: 1px solid color-mix(in srgb, var(--text-muted) 25%, transparent);
+  font-size: 10px;
+  font-family: monospace;
+  padding: 1px 6px;
+  border-radius: 9999px;
+  text-align: center;
+}
+
+.delphi-delta-chip.converged {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+}

--- a/frontend/src/components/Stage2.jsx
+++ b/frontend/src/components/Stage2.jsx
@@ -523,6 +523,110 @@ function MoaView({ moaAggregator, stage1, isLoading }) {
   );
 }
 
+// DelphiView renders the Delphi strategy's Stage 2 payload as a per-round
+// timeline. Each round section shows per-criterion mean ± stddev rows, and
+// from round 2 onwards a Δ chip per criterion (success-coloured below
+// threshold, muted above). The converged round carries a `(converged ✓)`
+// badge in the section header.
+function DelphiCriterionRow({ name, mean, stdDev, delta, converged }) {
+  const widthPct = Math.max(2, Math.round((mean ?? 0) * 100));
+  const hasDelta = typeof delta === 'number';
+  return (
+    <div className="delphi-criterion-row">
+      <span className="delphi-criterion-name">{name}</span>
+      <div className="delphi-criterion-track" aria-hidden="true">
+        <div className="delphi-criterion-fill" style={{ width: `${widthPct}%` }} />
+      </div>
+      <span className="delphi-criterion-stat">
+        {mean.toFixed(2)} ± {stdDev.toFixed(2)}
+      </span>
+      {hasDelta && (
+        <span className={`delphi-delta-chip${converged ? ' converged' : ''}`}>
+          Δ {delta.toFixed(2)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function DelphiRoundSection({ round, criteria, isConvergedRound }) {
+  const stats = round.stats ?? {};
+  const meanMap = stats.mean ?? {};
+  const stdDevMap = stats.std_dev ?? {};
+  const deltaMap = stats.delta_mean; // may be undefined on round 1
+  return (
+    <div className="delphi-round">
+      <div className="delphi-round-header">
+        <span>Round {round.round}</span>
+        {isConvergedRound && (
+          <span className="delphi-converged-badge" aria-label="converged">✓ converged</span>
+        )}
+      </div>
+      <div className="delphi-criteria-list">
+        {criteria.map((name) => {
+          const mean = meanMap[name];
+          if (typeof mean !== 'number') return null; // criterion absent this round
+          return (
+            <DelphiCriterionRow
+              key={name}
+              name={name}
+              mean={mean}
+              stdDev={stdDevMap[name] ?? 0}
+              delta={deltaMap?.[name]}
+              converged={isConvergedRound}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function DelphiView({ delphi, isLoading }) {
+  if (isLoading && (!delphi || !delphi.rounds || delphi.rounds.length === 0)) {
+    return (
+      <div className="stage stage2">
+        <div className="stage-accordion" aria-disabled="true">
+          <span className="stage-accordion-label">
+            <span className="spinner-sm" />
+            Rating panel in progress…
+          </span>
+        </div>
+      </div>
+    );
+  }
+  if (!delphi || !delphi.rounds || delphi.rounds.length === 0) {
+    return null;
+  }
+
+  const criteria = Array.isArray(delphi.criteria) ? delphi.criteria : [];
+  const finalRound = delphi.final_round ?? delphi.rounds.length;
+  const converged = !!delphi.converged;
+
+  return (
+    <div className="stage stage2">
+      <div className="stage-accordion" aria-disabled="true">
+        <span className="stage-accordion-label">
+          Stage 2: Delphi Panel ({finalRound} {finalRound === 1 ? 'round' : 'rounds'}
+          {converged ? ', converged' : ''})
+        </span>
+      </div>
+      <div className="stage-body">
+        <div className="delphi-timeline">
+          {delphi.rounds.map((round) => (
+            <DelphiRoundSection
+              key={round.round}
+              round={round}
+              criteria={criteria}
+              isConvergedRound={converged && round.round === finalRound}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // RoleStubView renders a minimal placeholder for the RoleBased strategy,
 // where Stage 2 has no peer-ranking content (roles are complementary).
 function RoleStubView({ isLoading }) {
@@ -582,6 +686,7 @@ export default function Stage2({
   rankRefine,
   debate,
   moaAggregator,
+  delphi,
   stage1,
   isLoading,
 }) {
@@ -609,6 +714,8 @@ export default function Stage2({
       return <DebateView debate={debate} isLoading={isLoading} />;
     case 'moa_aggregator':
       return <MoaView moaAggregator={moaAggregator} stage1={stage1} isLoading={isLoading} />;
+    case 'delphi_round':
+      return <DelphiView delphi={delphi} isLoading={isLoading} />;
     default:
       return <UnknownKindView kind={effectiveKind} />;
   }

--- a/frontend/src/components/Stage2.test.jsx
+++ b/frontend/src/components/Stage2.test.jsx
@@ -36,11 +36,13 @@ describe('Stage2 dispatcher', () => {
   });
 
   it('routes an unknown kind to the unknown-kind view, surfacing the kind name', () => {
-    // Use the only still-reserved kind. moa_aggregator now routes to MoaView;
-    // delphi_round is reserved as of this PR (Delphi strategy not yet shipped).
-    render(<Stage2 kind="delphi_round" isLoading={false} />);
+    // Synthetic sentinel: starts with "__", contains "kind", and never collides
+    // with any real kind value. Delphi was the last reserved kind (it ships in
+    // this PR), so no real reserved kind remains — using a synthetic value
+    // guarantees this test stays valid as future kind-table changes happen.
+    render(<Stage2 kind="__bogus_kind__" isLoading={false} />);
     expect(screen.getByText(/view not implemented yet/i)).toBeInTheDocument();
-    expect(screen.getByText('delphi_round')).toBeInTheDocument();
+    expect(screen.getByText('__bogus_kind__')).toBeInTheDocument();
   });
 
   it('defaults to peer_ranking when kind is undefined (old-backend safety net)', () => {
@@ -418,6 +420,109 @@ describe('Stage2 dispatcher', () => {
         />,
       );
       expect(screen.getByRole('button', { name: /Show full answer/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('DelphiView (kind="delphi_round")', () => {
+    const threeRoundDelphi = {
+      final_round: 3,
+      converged: true,
+      criteria: ['correctness', 'clarity', 'completeness'],
+      rounds: [
+        {
+          round: 1,
+          ratings: [],
+          stats: {
+            mean: { correctness: 0.5, clarity: 0.5, completeness: 0.5 },
+            std_dev: { correctness: 0.1, clarity: 0.1, completeness: 0.1 },
+            // round 1 has no delta_mean
+          },
+        },
+        {
+          round: 2,
+          ratings: [],
+          stats: {
+            mean: { correctness: 0.55, clarity: 0.55, completeness: 0.55 },
+            std_dev: { correctness: 0.08, clarity: 0.08, completeness: 0.08 },
+            delta_mean: { correctness: 0.05, clarity: 0.05, completeness: 0.05 },
+          },
+        },
+        {
+          round: 3,
+          ratings: [],
+          stats: {
+            mean: { correctness: 0.57, clarity: 0.57, completeness: 0.57 },
+            std_dev: { correctness: 0.06, clarity: 0.06, completeness: 0.06 },
+            delta_mean: { correctness: 0.02, clarity: 0.02, completeness: 0.02 },
+          },
+        },
+      ],
+    };
+
+    it('renders 3 round sections with per-criterion mean ± stddev rows and Δ chips on rounds 2+', () => {
+      render(<Stage2 kind="delphi_round" delphi={threeRoundDelphi} isLoading={false} />);
+      // Header.
+      expect(screen.getByText(/Stage 2: Delphi Panel/i)).toBeInTheDocument();
+      expect(screen.getByText(/3 rounds/i)).toBeInTheDocument();
+      // Round headers.
+      expect(screen.getByText(/Round 1/i)).toBeInTheDocument();
+      expect(screen.getByText(/Round 2/i)).toBeInTheDocument();
+      expect(screen.getByText(/Round 3/i)).toBeInTheDocument();
+      // 3 rounds × 3 criteria = 9 criterion names visible.
+      expect(screen.getAllByText('correctness').length).toBe(3);
+      expect(screen.getAllByText('clarity').length).toBe(3);
+      expect(screen.getAllByText('completeness').length).toBe(3);
+      // Δ chips: 2 rounds × 3 criteria = 6 chips (round 1 has none).
+      const deltaChips = screen.getAllByText(/^Δ /);
+      expect(deltaChips).toHaveLength(6);
+    });
+
+    it('renders the converged badge ONLY on the converged round', () => {
+      render(<Stage2 kind="delphi_round" delphi={threeRoundDelphi} isLoading={false} />);
+      // Exactly one converged badge — on the final round (round 3).
+      const badges = screen.getAllByLabelText(/converged/i);
+      expect(badges).toHaveLength(1);
+    });
+
+    it('appends a new round when state updates (live progressive UI)', () => {
+      const oneRound = {
+        final_round: 1,
+        converged: false,
+        criteria: ['correctness'],
+        rounds: [
+          {
+            round: 1,
+            ratings: [],
+            stats: {
+              mean: { correctness: 0.5 },
+              std_dev: { correctness: 0.1 },
+            },
+          },
+        ],
+      };
+      const { rerender } = render(<Stage2 kind="delphi_round" delphi={oneRound} isLoading={false} />);
+      expect(screen.getByText(/Round 1/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Round 2/i)).not.toBeInTheDocument();
+
+      const twoRounds = {
+        ...oneRound,
+        final_round: 2,
+        rounds: [
+          ...oneRound.rounds,
+          {
+            round: 2,
+            ratings: [],
+            stats: {
+              mean: { correctness: 0.55 },
+              std_dev: { correctness: 0.08 },
+              delta_mean: { correctness: 0.05 },
+            },
+          },
+        ],
+      };
+      rerender(<Stage2 kind="delphi_round" delphi={twoRounds} isLoading={false} />);
+      expect(screen.getByText(/Round 1/i)).toBeInTheDocument();
+      expect(screen.getByText(/Round 2/i)).toBeInTheDocument();
     });
   });
 });

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -905,6 +905,132 @@ func TestSendMessageStream(t *testing.T) {
 			},
 		},
 		{
+			name:   "Delphi emits stage2_round_complete events with required round + terminal stage2_complete with metadata.delphi",
+			body:   `{"content":"q","council_type":"delphi"}`,
+			storer: okStorer(),
+			runner: &mockRunner{
+				runFull: func(ctx context.Context, query, ct string, onEvent council.EventFunc) error {
+					onEvent("stage1_complete", []council.StageOneResult{
+						{Label: "Response A", Content: "ans-a", Model: "openai/gpt-4o-mini"},
+						{Label: "Response B", Content: "ans-b", Model: "anthropic/claude-haiku-4-5"},
+						{Label: "Response C", Content: "ans-c", Model: "google/gemini-flash-1.5"},
+					})
+					// Round 1
+					onEvent("stage2_round_complete", council.Stage2CompleteData{
+						Kind:    "delphi_round",
+						Round:   1,
+						Results: []council.StageTwoResult{},
+						Metadata: council.Metadata{
+							CouncilType:       "delphi",
+							LabelToModel:      map[string]string{"Response A": "openai/gpt-4o-mini"},
+							AggregateRankings: []council.RankedModel{},
+							DelphiPanel: &council.DelphiPanel{
+								Rounds: []council.DelphiRound{{
+									Round: 1,
+									Ratings: []council.DelphiRating{{
+										Label:  "Response A",
+										Model:  "openai/gpt-4o-mini",
+										Scores: map[string]float64{"correctness": 0.5, "clarity": 0.5, "completeness": 0.5},
+									}},
+									Stats: council.DelphiStats{
+										Mean:   map[string]float64{"correctness": 0.5},
+										StdDev: map[string]float64{"correctness": 0.0},
+									},
+								}},
+								FinalRound: 1,
+								Criteria:   []string{"correctness", "clarity", "completeness"},
+							},
+						},
+					})
+					// Terminal event with full transcript.
+					onEvent("stage2_complete", council.Stage2CompleteData{
+						Kind:    "delphi_round",
+						Results: []council.StageTwoResult{},
+						Metadata: council.Metadata{
+							CouncilType:       "delphi",
+							LabelToModel:      map[string]string{"Response A": "openai/gpt-4o-mini"},
+							AggregateRankings: []council.RankedModel{},
+							DelphiPanel: &council.DelphiPanel{
+								Rounds: []council.DelphiRound{
+									{Round: 1, Ratings: []council.DelphiRating{{Label: "Response A", Model: "openai/gpt-4o-mini", Scores: map[string]float64{"correctness": 0.5}}}},
+									{Round: 2, Ratings: []council.DelphiRating{{Label: "Response A", Model: "openai/gpt-4o-mini", Scores: map[string]float64{"correctness": 0.55}}}},
+								},
+								FinalRound: 2,
+								Converged:  true,
+								Criteria:   []string{"correctness", "clarity", "completeness"},
+							},
+						},
+					})
+					onEvent("stage3_complete", council.StageThreeResult{Content: "synthesis", Model: "chairman-z", DurationMs: 100})
+					return nil
+				},
+			},
+			wantCode: http.StatusOK,
+			checkSSE: func(t *testing.T, body string) {
+				var sawRoundEvent bool
+				var sawTerminalDelphi bool
+				for _, line := range strings.Split(body, "\n") {
+					if !strings.HasPrefix(line, "data: ") {
+						continue
+					}
+					raw := []byte(line[6:])
+					var keys map[string]json.RawMessage
+					if err := json.Unmarshal(raw, &keys); err != nil {
+						continue
+					}
+					var typ string
+					if err := json.Unmarshal(keys["type"], &typ); err == nil && typ == "stage2_round_complete" {
+						sawRoundEvent = true
+						roundRaw, present := keys["round"]
+						if !present {
+							t.Errorf("delphi stage2_round_complete: 'round' key missing on the wire (must be required, not omitempty)")
+						}
+						var roundVal int
+						if err := json.Unmarshal(roundRaw, &roundVal); err != nil || roundVal != 1 {
+							t.Errorf("delphi stage2_round_complete round: got %s, want 1", string(roundRaw))
+						}
+						var kind string
+						_ = json.Unmarshal(keys["kind"], &kind)
+						if kind != "delphi_round" {
+							t.Errorf("delphi stage2_round_complete kind: got %q, want %q", kind, "delphi_round")
+						}
+					}
+					if err := json.Unmarshal(keys["type"], &typ); err == nil && typ == "stage2_complete" {
+						var env struct {
+							Kind     string           `json:"kind"`
+							Metadata council.Metadata `json:"metadata"`
+						}
+						if err := json.Unmarshal(raw, &env); err != nil {
+							continue
+						}
+						if env.Kind != "delphi_round" {
+							t.Errorf("terminal kind: got %q, want %q", env.Kind, "delphi_round")
+						}
+						if env.Metadata.DelphiPanel == nil {
+							t.Errorf("terminal stage2_complete: metadata.delphi is nil")
+							continue
+						}
+						if env.Metadata.DelphiPanel.FinalRound != 2 {
+							t.Errorf("FinalRound: got %d, want 2", env.Metadata.DelphiPanel.FinalRound)
+						}
+						if !env.Metadata.DelphiPanel.Converged {
+							t.Error("Converged: got false, want true")
+						}
+						if len(env.Metadata.DelphiPanel.Rounds) != 2 {
+							t.Errorf("transcript rounds: got %d, want 2", len(env.Metadata.DelphiPanel.Rounds))
+						}
+						sawTerminalDelphi = true
+					}
+				}
+				if !sawRoundEvent {
+					t.Error("delphi stage2_round_complete event not seen on the wire")
+				}
+				if !sawTerminalDelphi {
+					t.Error("terminal stage2_complete with delphi panel not seen on the wire")
+				}
+			},
+		},
+		{
 			name:   "MixtureOfAgents emits kind=moa_aggregator with sources, no stage2_round_complete",
 			body:   `{"content":"q","council_type":"moa"}`,
 			storer: okStorer(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,19 @@ type Config struct {
 	MoaAggregatorModels []string
 	MoaRefinerModel     string
 
+	// Delphi strategy registration. BOTH DelphiModels AND DelphiChairmanModel
+	// must be set for the council type to be registered (Stage 3 chairman
+	// always runs; no no-LLM path). DelphiMaxRounds and
+	// DelphiConvergenceThreshold are optional; 0 = use the runner's defaults
+	// (3 rounds, 0.1 threshold).
+	// Cost note: this strategy fires N + N×R + 1 LLM calls in the worst
+	// case (no convergence); with the default 4 raters × 3 rounds + chairman
+	// that's 17 calls. Convergence at round 2 → 9 calls.
+	DelphiModels               []string
+	DelphiChairmanModel        string
+	DelphiMaxRounds            int
+	DelphiConvergenceThreshold float64
+
 	// LLMAPIMaxRetries is the number of retries the OpenRouter client attempts
 	// on transient failures (HTTP 429/502/503/504, network timeouts, EOFs).
 	// 0 disables retries. Default: 2 (3 total attempts including the initial).
@@ -272,6 +285,44 @@ func Load() (*Config, error) {
 	// accidentally-spaced value doesn't bypass the registration gate.
 	moaRefinerModel := strings.TrimSpace(os.Getenv("MOA_REFINER_MODEL"))
 
+	// Delphi rater pool. Empty when unset — registration requires both this
+	// AND the chairman var (Stage 3 chairman always runs).
+	var delphiModels []string
+	if raw := os.Getenv("DELPHI_MODELS"); raw != "" {
+		for _, m := range strings.Split(raw, ",") {
+			if m = strings.TrimSpace(m); m != "" {
+				delphiModels = append(delphiModels, m)
+			}
+		}
+	}
+
+	// Delphi chairman (required when models are set; whitespace-trim).
+	delphiChairmanModel := strings.TrimSpace(os.Getenv("DELPHI_CHAIRMAN_MODEL"))
+
+	// Delphi round budget. 0 = let the runner use its default of 3.
+	// Invalid values warn + use 0 sentinel. Must be ≥1 to be valid.
+	delphiMaxRounds := 0
+	if raw := os.Getenv("DELPHI_MAX_ROUNDS"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			delphiMaxRounds = v
+		} else {
+			slog.Warn("DELPHI_MAX_ROUNDS is invalid; using runner default",
+				"value", raw, "error", err)
+		}
+	}
+
+	// Delphi convergence threshold. 0 = let the runner use its default of 0.1.
+	// Valid range is (0.0, 1.0). Outside that range or non-numeric → warn + 0.
+	delphiConvergenceThreshold := 0.0
+	if raw := strings.TrimSpace(os.Getenv("DELPHI_CONVERGENCE_THRESHOLD")); raw != "" {
+		if v, err := strconv.ParseFloat(raw, 64); err == nil && v > 0.0 && v < 1.0 {
+			delphiConvergenceThreshold = v
+		} else {
+			slog.Warn("DELPHI_CONVERGENCE_THRESHOLD is invalid (must be in (0.0, 1.0)); using runner default",
+				"value", raw, "error", err)
+		}
+	}
+
 	llmAPIMaxRetries := 2
 	if raw := os.Getenv("LLM_API_MAX_RETRIES"); raw != "" {
 		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
@@ -311,6 +362,11 @@ func Load() (*Config, error) {
 		MoaProposerModels:   moaProposerModels,
 		MoaAggregatorModels: moaAggregatorModels,
 		MoaRefinerModel:     moaRefinerModel,
+
+		DelphiModels:               delphiModels,
+		DelphiChairmanModel:        delphiChairmanModel,
+		DelphiMaxRounds:            delphiMaxRounds,
+		DelphiConvergenceThreshold: delphiConvergenceThreshold,
 
 		LLMAPIMaxRetries: llmAPIMaxRetries,
 	}, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -565,3 +565,141 @@ func TestLoad_MoaRefiner_Whitespace_TreatedAsUnset(t *testing.T) {
 		t.Errorf("MoaRefinerModel: got %q, want empty (whitespace trim)", cfg.MoaRefinerModel)
 	}
 }
+
+// ── TestLoad_DelphiModels ─────────────────────────────────────────────────
+//
+// Both DELPHI_MODELS and DELPHI_CHAIRMAN_MODEL must be set for the council
+// type to register (Stage 3 chairman always runs; no no-LLM path).
+// DELPHI_MAX_ROUNDS and DELPHI_CONVERGENCE_THRESHOLD are optional; 0 = use
+// the runner's defaults (3 rounds, 0.1 threshold).
+
+func TestLoad_DelphiModels_AllSet(t *testing.T) {
+	baseEnv(t)
+	setenv(t, "DELPHI_MODELS", "openai/gpt-4o-mini, anthropic/claude-haiku-4-5, google/gemini-flash-1.5, qwen/qwen3.6-plus")
+	setenv(t, "DELPHI_CHAIRMAN_MODEL", "anthropic/claude-sonnet-4-5")
+	setenv(t, "DELPHI_MAX_ROUNDS", "5")
+	setenv(t, "DELPHI_CONVERGENCE_THRESHOLD", "0.05")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"openai/gpt-4o-mini", "anthropic/claude-haiku-4-5", "google/gemini-flash-1.5", "qwen/qwen3.6-plus"}
+	if len(cfg.DelphiModels) != len(want) {
+		t.Fatalf("DelphiModels: got %v, want %v", cfg.DelphiModels, want)
+	}
+	for i, m := range want {
+		if cfg.DelphiModels[i] != m {
+			t.Errorf("DelphiModels[%d]: got %q, want %q", i, cfg.DelphiModels[i], m)
+		}
+	}
+	if cfg.DelphiChairmanModel != "anthropic/claude-sonnet-4-5" {
+		t.Errorf("DelphiChairmanModel: got %q, want %q", cfg.DelphiChairmanModel, "anthropic/claude-sonnet-4-5")
+	}
+	if cfg.DelphiMaxRounds != 5 {
+		t.Errorf("DelphiMaxRounds: got %d, want 5", cfg.DelphiMaxRounds)
+	}
+	if cfg.DelphiConvergenceThreshold != 0.05 {
+		t.Errorf("DelphiConvergenceThreshold: got %f, want 0.05", cfg.DelphiConvergenceThreshold)
+	}
+}
+
+func TestLoad_DelphiModels_OptionalsUnset(t *testing.T) {
+	baseEnv(t)
+	setenv(t, "DELPHI_MODELS", "openai/gpt-4o-mini")
+	setenv(t, "DELPHI_CHAIRMAN_MODEL", "anthropic/claude-sonnet-4-5")
+	unsetenv(t, "DELPHI_MAX_ROUNDS")
+	unsetenv(t, "DELPHI_CONVERGENCE_THRESHOLD")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.DelphiModels) != 1 || cfg.DelphiModels[0] != "openai/gpt-4o-mini" {
+		t.Errorf("DelphiModels: got %v, want [openai/gpt-4o-mini]", cfg.DelphiModels)
+	}
+	if cfg.DelphiChairmanModel != "anthropic/claude-sonnet-4-5" {
+		t.Errorf("DelphiChairmanModel: got %q", cfg.DelphiChairmanModel)
+	}
+	if cfg.DelphiMaxRounds != 0 {
+		t.Errorf("DelphiMaxRounds: got %d, want 0 (sentinel for runner default)", cfg.DelphiMaxRounds)
+	}
+	if cfg.DelphiConvergenceThreshold != 0.0 {
+		t.Errorf("DelphiConvergenceThreshold: got %f, want 0.0 (sentinel for runner default)", cfg.DelphiConvergenceThreshold)
+	}
+}
+
+func TestLoad_DelphiModels_ModelsOnly_ChairmanEmpty(t *testing.T) {
+	baseEnv(t)
+	setenv(t, "DELPHI_MODELS", "openai/gpt-4o-mini")
+	unsetenv(t, "DELPHI_CHAIRMAN_MODEL")
+	// Loader does NOT pre-fill from CHAIRMAN_MODEL — registration site decides.
+	setenv(t, "CHAIRMAN_MODEL", "global-chairman")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.DelphiModels) != 1 {
+		t.Errorf("DelphiModels: got %v", cfg.DelphiModels)
+	}
+	if cfg.DelphiChairmanModel != "" {
+		t.Errorf("DelphiChairmanModel: got %q, want empty (loader does not pre-fill from CHAIRMAN_MODEL)", cfg.DelphiChairmanModel)
+	}
+}
+
+func TestLoad_DelphiModels_AllUnset(t *testing.T) {
+	baseEnv(t)
+	unsetenv(t, "DELPHI_MODELS")
+	unsetenv(t, "DELPHI_CHAIRMAN_MODEL")
+	unsetenv(t, "DELPHI_MAX_ROUNDS")
+	unsetenv(t, "DELPHI_CONVERGENCE_THRESHOLD")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.DelphiModels) != 0 {
+		t.Errorf("DelphiModels: got %v, want empty", cfg.DelphiModels)
+	}
+	if cfg.DelphiChairmanModel != "" {
+		t.Errorf("DelphiChairmanModel: got %q, want empty", cfg.DelphiChairmanModel)
+	}
+	if cfg.DelphiMaxRounds != 0 {
+		t.Errorf("DelphiMaxRounds: got %d, want 0", cfg.DelphiMaxRounds)
+	}
+	if cfg.DelphiConvergenceThreshold != 0.0 {
+		t.Errorf("DelphiConvergenceThreshold: got %f, want 0.0", cfg.DelphiConvergenceThreshold)
+	}
+}
+
+func TestLoad_DelphiConvergenceThreshold_Invalid(t *testing.T) {
+	// Negative, ≥ 1.0, and non-numeric all fall back to 0 sentinel (= runner
+	// default). Test each via a sub-table.
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"negative", "-0.1"},
+		{"zero", "0"},
+		{"one", "1.0"},
+		{"greater than one", "1.5"},
+		{"non-numeric", "convergent"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			baseEnv(t)
+			setenv(t, "DELPHI_MODELS", "m-a")
+			setenv(t, "DELPHI_CHAIRMAN_MODEL", "chairman-z")
+			setenv(t, "DELPHI_CONVERGENCE_THRESHOLD", tc.raw)
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.DelphiConvergenceThreshold != 0.0 {
+				t.Errorf("invalid input %q: got %f, want 0.0 (runner default sentinel)", tc.raw, cfg.DelphiConvergenceThreshold)
+			}
+		})
+	}
+}

--- a/internal/council/delphi.go
+++ b/internal/council/delphi.go
@@ -1,0 +1,445 @@
+package council
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"sort"
+	"sync"
+	"time"
+)
+
+// defaultDelphiCriteria is the v1 fixed set of rating dimensions. A subset of
+// GenerateRankRefine's criteria — `originality` is dropped because it's a
+// generation-time concern, not a rating-time one. Per-registration overrides
+// are deferred to a future variant.
+var defaultDelphiCriteria = []string{"correctness", "clarity", "completeness"}
+
+// Delphi defaults used when CouncilType fields are zero-valued.
+const (
+	defaultDelphiMaxRounds            = 3
+	defaultDelphiConvergenceThreshold = 0.1
+)
+
+// runDelphi executes the Delphi method's multi-round anonymous blind rating
+// pipeline:
+//
+//   - Stage 1: parallel generation across ct.Models (reuses runStage1).
+//     Anonymous "Response A/B/…" labels assigned via assignLabels. Quorum:
+//     max(3, ⌈N/2⌉+1) — higher floor than PeerReview/Debate because
+//     statistical averaging needs ≥3 raters.
+//   - Rounds 1..R: each surviving rater concurrently rates ALL Stage 1
+//     candidates against defaultDelphiCriteria and produces a 1–2 sentence
+//     summary. Per-rater LLM/parse/missing-criteria failure drops that rater
+//     for the rest of the run; per-round quorum re-check fires loud error
+//     if survivors fall below need. Per-round event:
+//     stage2_round_complete with kind="delphi_round" and round=r.
+//   - Convergence: after every round R≥2, if max(DeltaMean[crit] across
+//     criteria present in both rounds) < ct.DelphiConvergenceThreshold,
+//     exit early with Converged=true. Conservative — every criterion must
+//     converge.
+//   - Stage 2 terminal event: stage2_complete with kind="delphi_round"
+//     carrying the full transcript via Metadata.DelphiPanel.
+//   - Stage 3: chairman synthesises across the final-round ratings + per-
+//     rater summaries + converged stats.
+//
+// NO DelphiDropout type is added. Dropped raters are simply absent from
+// subsequent rounds' Ratings slices; chairman and frontend infer dropout
+// by label-set diff between rounds.
+func (c *Council) runDelphi(ctx context.Context, query string, ct CouncilType, onEvent EventFunc) error {
+	if len(ct.Models) == 0 {
+		return fmt.Errorf("council type %q has no models configured", ct.Name)
+	}
+	if ct.ChairmanModel == "" {
+		return fmt.Errorf("council type %q has no chairman model configured (Delphi Stage 3 always runs)", ct.Name)
+	}
+
+	rounds := ct.MaxDelphiRounds
+	if rounds <= 0 {
+		rounds = defaultDelphiMaxRounds
+	}
+	threshold := ct.DelphiConvergenceThreshold
+	if threshold <= 0 {
+		threshold = defaultDelphiConvergenceThreshold
+	}
+
+	// Stage 1 — parallel generation.
+	allStage1 := c.runStage1(ctx, query, ct.Models, ct.Temperature)
+
+	// Higher quorum floor for Delphi (3 vs 2 for PeerReview/Debate).
+	need := ct.QuorumMin
+	if need == 0 {
+		n := len(allStage1)
+		need = max(3, (n+1)/2+1)
+	}
+	successful, err := checkQuorum(allStage1, need)
+	if err != nil {
+		return err
+	}
+
+	successfulModels := make([]string, len(successful))
+	for i, r := range successful {
+		successfulModels[i] = r.Model
+	}
+	labelToModel, modelToLabel := assignLabels(successfulModels)
+	for i := range successful {
+		successful[i].Label = modelToLabel[successful[i].Model]
+	}
+
+	if onEvent != nil {
+		onEvent("stage1_complete", successful)
+	}
+
+	// previousRatings holds each rater's most recent successful rating, keyed
+	// by Label. Used to feed the rater its OWN previous ratings + summary in
+	// rounds 2+ (so it can revise rather than start from scratch).
+	previousRatings := make(map[string]DelphiRating, len(successful))
+
+	// alive lists labels that are still in the panel. Sorted ascending for
+	// determinism.
+	alive := make([]string, 0, len(successful))
+	for _, s1 := range successful {
+		alive = append(alive, s1.Label)
+	}
+	sort.Strings(alive)
+
+	// labelToS1 indexes Stage 1 successes for fast model lookup per label.
+	labelToS1 := make(map[string]StageOneResult, len(successful))
+	for _, s1 := range successful {
+		labelToS1[s1.Label] = s1
+	}
+
+	transcript := make([]DelphiRound, 0, rounds)
+	priorStats := make([]DelphiStats, 0, rounds)
+	converged := false
+
+	for r := 1; r <= rounds; r++ {
+		ratings := c.runDelphiRound(ctx, query, successful, defaultDelphiCriteria, r, rounds, priorStats, previousRatings, labelToS1, alive, ct.Temperature)
+
+		// Filter to successful ratings; update previousRatings + alive.
+		newAlive := make([]string, 0, len(alive))
+		successfulRatings := make([]DelphiRating, 0, len(ratings))
+		for _, rt := range ratings {
+			if rt.Error != nil || len(rt.Scores) == 0 {
+				continue
+			}
+			successfulRatings = append(successfulRatings, rt)
+			previousRatings[rt.Label] = rt
+			newAlive = append(newAlive, rt.Label)
+		}
+		sort.Strings(newAlive)
+		alive = newAlive
+
+		// Sort ratings by Label for stable output.
+		sort.SliceStable(successfulRatings, func(i, j int) bool {
+			return successfulRatings[i].Label < successfulRatings[j].Label
+		})
+
+		// Compute aggregate stats for this round, keyed off prior-round mean
+		// for DeltaMean (round 1 has no prev → DeltaMean stays nil/empty).
+		var prevMean map[string]float64
+		if len(priorStats) > 0 {
+			prevMean = priorStats[len(priorStats)-1].Mean
+		}
+		stats := computeDelphiStats(successfulRatings, defaultDelphiCriteria, prevMean)
+
+		round := DelphiRound{
+			Round:   r,
+			Ratings: successfulRatings,
+			Stats:   stats,
+		}
+		transcript = append(transcript, round)
+		priorStats = append(priorStats, stats)
+
+		// Per-round event — carries this round's data only.
+		if onEvent != nil {
+			onEvent("stage2_round_complete", Stage2CompleteData{
+				Kind:    "delphi_round",
+				Round:   r,
+				Results: []StageTwoResult{},
+				Metadata: Metadata{
+					CouncilType:       ct.Name,
+					LabelToModel:      labelToModel,
+					AggregateRankings: []RankedModel{},
+					ConsensusW:        0.0,
+					DelphiPanel: &DelphiPanel{
+						Rounds:     []DelphiRound{round},
+						FinalRound: r,
+						Criteria:   defaultDelphiCriteria,
+					},
+				},
+			})
+		}
+
+		// Per-round quorum re-check: survivors must still meet need.
+		if len(alive) < need {
+			return fmt.Errorf("delphi: quorum failed after round %d (%d survivors, need %d)", r, len(alive), need)
+		}
+
+		// Convergence check (round R≥2 only): max(DeltaMean) < threshold for
+		// every criterion present in DeltaMean. If DeltaMean is empty (round 1
+		// or every criterion missing in either round), skip — no convergence
+		// declared.
+		if r >= 2 && len(stats.DeltaMean) > 0 {
+			maxDelta := 0.0
+			for _, d := range stats.DeltaMean {
+				if d > maxDelta {
+					maxDelta = d
+				}
+			}
+			if maxDelta < threshold {
+				converged = true
+				break
+			}
+		}
+	}
+
+	panel := &DelphiPanel{
+		Rounds:     transcript,
+		FinalRound: len(transcript),
+		Converged:  converged,
+		Criteria:   defaultDelphiCriteria,
+	}
+
+	metadata := Metadata{
+		CouncilType:       ct.Name,
+		LabelToModel:      labelToModel,
+		AggregateRankings: []RankedModel{},
+		ConsensusW:        0.0,
+		DelphiPanel:       panel,
+	}
+
+	if onEvent != nil {
+		onEvent("stage2_complete", Stage2CompleteData{
+			Kind:     "delphi_round",
+			Results:  []StageTwoResult{},
+			Metadata: metadata,
+		})
+	}
+
+	// Stage 3 — chairman synthesises across the final-round ratings.
+	finalRatings := transcript[len(transcript)-1].Ratings
+	finalStats := transcript[len(transcript)-1].Stats
+	stage3, err := c.runDelphiStage3(ctx, query, successful, finalRatings, finalStats, converged, defaultDelphiCriteria, labelToModel, ct.ChairmanModel, ct.Temperature)
+	if err != nil {
+		return err
+	}
+	if onEvent != nil {
+		onEvent("stage3_complete", stage3)
+	}
+	return nil
+}
+
+// runDelphiRound runs one round of rating in parallel across all surviving
+// raters. Each rater gets the same prompt template (with its own previous-
+// round ratings injected for rounds 2+) and produces JSON
+// {ratings: {...}, summary: "..."}.
+//
+// Per-rater LLM error / JSON parse failure / empty scores result in a
+// rating with Error set; the caller drops those raters from the run.
+func (c *Council) runDelphiRound(
+	ctx context.Context,
+	query string,
+	candidates []StageOneResult,
+	criteria []string,
+	round, totalRounds int,
+	priorStats []DelphiStats,
+	previousRatings map[string]DelphiRating,
+	labelToS1 map[string]StageOneResult,
+	alive []string,
+	temperature float64,
+) []DelphiRating {
+	results := make([]DelphiRating, len(alive))
+	var wg sync.WaitGroup
+	for i, lbl := range alive {
+		wg.Add(1)
+		go func(idx int, selfLabel string) {
+			defer wg.Done()
+			s1 := labelToS1[selfLabel]
+			model := s1.Model
+
+			var selfPrevPtr *DelphiRating
+			if prev, ok := previousRatings[selfLabel]; ok {
+				selfPrev := prev // copy so we don't alias the map's value
+				selfPrevPtr = &selfPrev
+			}
+
+			prompt := BuildDelphiRoundPrompt(query, candidates, criteria, round, totalRounds, priorStats, selfPrevPtr)
+
+			start := time.Now()
+			resp, err := c.client.Complete(ctx, CompletionRequest{
+				Model:          model,
+				Messages:       prompt,
+				Temperature:    temperature,
+				ResponseFormat: &ResponseFormat{Type: "json_object"},
+			})
+			elapsed := time.Since(start).Milliseconds()
+
+			rating := DelphiRating{
+				Label:      selfLabel,
+				Model:      model,
+				DurationMs: elapsed,
+			}
+
+			if err != nil {
+				rating.Error = err
+				if c.logger != nil {
+					c.logger.Warn("delphi: rater errored", slog.String("label", selfLabel), slog.Int("round", round), slog.Any("error", err))
+				}
+				results[idx] = rating
+				return
+			}
+			if len(resp.Choices) == 0 {
+				rating.Error = errNoChoices
+				results[idx] = rating
+				return
+			}
+
+			body := StripCodeFence(resp.Choices[0].Message.Content)
+			var parsed struct {
+				Ratings map[string]float64 `json:"ratings"`
+				Summary string             `json:"summary"`
+			}
+			if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+				rating.Error = err
+				if c.logger != nil {
+					c.logger.Warn("delphi: parse failure", slog.String("label", selfLabel), slog.Int("round", round), slog.Any("error", err))
+				}
+				results[idx] = rating
+				return
+			}
+			if len(parsed.Ratings) == 0 {
+				rating.Error = fmt.Errorf("empty ratings")
+				if c.logger != nil {
+					c.logger.Warn("delphi: empty ratings", slog.String("label", selfLabel), slog.Int("round", round))
+				}
+				results[idx] = rating
+				return
+			}
+
+			// Per-criterion clamp + missing-criterion default.
+			scores := make(map[string]float64, len(criteria))
+			for _, name := range criteria {
+				v, ok := parsed.Ratings[name]
+				if !ok {
+					if c.logger != nil {
+						c.logger.Warn("delphi: missing criterion", slog.String("label", selfLabel), slog.String("criterion", name))
+					}
+					v = 0.0
+				}
+				scores[name] = clamp(v, 0.0, 1.0)
+			}
+			rating.Scores = scores
+			rating.Summary = parsed.Summary
+			results[idx] = rating
+		}(i, lbl)
+	}
+	wg.Wait()
+	return results
+}
+
+// computeDelphiStats is a pure function that computes per-criterion mean and
+// stddev across all successful ratings in a single round, plus DeltaMean
+// against the prior round's mean.
+//
+// Semantics on missing criteria:
+//   - Mean[crit] and StdDev[crit] are populated only for criteria with ≥1
+//     rating in this round.
+//   - DeltaMean[crit] is populated only for criteria present in BOTH the
+//     current round and the prior round; criteria missing from either side
+//     are excluded from DeltaMean and from the convergence check.
+//   - If prevMean is nil or empty (round 1), DeltaMean is nil (omitempty
+//     keeps it off the wire).
+func computeDelphiStats(ratings []DelphiRating, criteria []string, prevMean map[string]float64) DelphiStats {
+	mean := make(map[string]float64, len(criteria))
+	stdDev := make(map[string]float64, len(criteria))
+
+	// Per-criterion: collect all rating values (each rater contributes one
+	// value per criterion since runDelphiRound clamps + defaults missing
+	// criteria to 0.0; but tests can also surface true absence by omitting
+	// the criterion from rating.Scores).
+	for _, name := range criteria {
+		var values []float64
+		for _, r := range ratings {
+			if v, ok := r.Scores[name]; ok {
+				values = append(values, v)
+			}
+		}
+		if len(values) == 0 {
+			continue // criterion not populated this round
+		}
+		var sum float64
+		for _, v := range values {
+			sum += v
+		}
+		m := sum / float64(len(values))
+		mean[name] = m
+
+		var sqSum float64
+		for _, v := range values {
+			d := v - m
+			sqSum += d * d
+		}
+		stdDev[name] = math.Sqrt(sqSum / float64(len(values))) // population stddev
+	}
+
+	var deltaMean map[string]float64
+	if len(prevMean) > 0 {
+		for _, name := range criteria {
+			curr, hasCurr := mean[name]
+			prev, hasPrev := prevMean[name]
+			if !hasCurr || !hasPrev {
+				continue // criterion missing in either round
+			}
+			if deltaMean == nil {
+				deltaMean = make(map[string]float64)
+			}
+			deltaMean[name] = math.Abs(curr - prev)
+		}
+	}
+
+	return DelphiStats{
+		Mean:      mean,
+		StdDev:    stdDev,
+		DeltaMean: deltaMean,
+	}
+}
+
+// runDelphiStage3 calls the chairman with the Stage 1 candidates + final-
+// round per-rater ratings + summaries + converged stats. Failure path
+// matches runStage3 / runDebateStage3 / runMoaRefine — Model + DurationMs
+// populated even on error.
+func (c *Council) runDelphiStage3(
+	ctx context.Context,
+	query string,
+	candidates []StageOneResult,
+	finalRatings []DelphiRating,
+	finalStats DelphiStats,
+	converged bool,
+	criteria []string,
+	labelToModel map[string]string,
+	chairmanModel string,
+	temperature float64,
+) (StageThreeResult, error) {
+	start := time.Now()
+	msgs := BuildDelphiChairmanPrompt(query, candidates, finalRatings, finalStats, converged, criteria, labelToModel)
+	resp, err := c.client.Complete(ctx, CompletionRequest{
+		Model:       chairmanModel,
+		Messages:    msgs,
+		Temperature: temperature,
+	})
+	elapsed := time.Since(start).Milliseconds()
+	result := StageThreeResult{Model: chairmanModel, DurationMs: elapsed}
+	if err != nil {
+		result.Error = err
+		return result, fmt.Errorf("delphi chairman (%s): %w", chairmanModel, err)
+	}
+	if len(resp.Choices) == 0 {
+		result.Error = fmt.Errorf("empty response from chairman %s", chairmanModel)
+		return result, result.Error
+	}
+	result.Content = resp.Choices[0].Message.Content
+	return result, nil
+}

--- a/internal/council/delphi_test.go
+++ b/internal/council/delphi_test.go
@@ -1,0 +1,718 @@
+package council
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// delphiRecorder is a thread-safe collector that classifies each completion
+// request as a Stage 1 generation, a Delphi rating call, or a Stage 3
+// chairman call by inspecting the prompt prefix.
+type delphiRecorder struct {
+	mu sync.Mutex
+
+	stage1 map[string]string
+
+	// roundOutByModel[round][model] → JSON {"ratings":{...},"summary":"..."}
+	roundOutByModel map[int]map[string]string
+	// roundErrByModel[round][model] → error
+	roundErrByModel map[int]map[string]error
+	// roundDefaults is the default rating JSON if no per-(round,model) entry exists.
+	roundDefaults string
+
+	chairmanOut string
+	chairmanErr error
+
+	calls          []string
+	ratingPrompts  []string
+	ratingPromptsByRound map[int][]string
+	ratingPromptByRoundModel map[int]map[string]string
+	chairmanPrompt string
+}
+
+func (r *delphiRecorder) record(req CompletionRequest) (CompletionResponse, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	body := ""
+	if len(req.Messages) > 0 {
+		body = req.Messages[0].Content
+	}
+	switch {
+	case strings.Contains(body, "You rate council answers"):
+		// Determine round from the prompt header "round N of M".
+		round := 0
+		fmt.Sscanf(strings.SplitN(body[strings.Index(body, "This is round "):], "\n", 2)[0], "This is round %d", &round)
+		r.calls = append(r.calls, fmt.Sprintf("rate:%s:r%d", req.Model, round))
+		r.ratingPrompts = append(r.ratingPrompts, body)
+		if r.ratingPromptsByRound == nil {
+			r.ratingPromptsByRound = map[int][]string{}
+		}
+		r.ratingPromptsByRound[round] = append(r.ratingPromptsByRound[round], body)
+		if r.ratingPromptByRoundModel == nil {
+			r.ratingPromptByRoundModel = map[int]map[string]string{}
+		}
+		if r.ratingPromptByRoundModel[round] == nil {
+			r.ratingPromptByRoundModel[round] = map[string]string{}
+		}
+		r.ratingPromptByRoundModel[round][req.Model] = body
+
+		if errMap, ok := r.roundErrByModel[round]; ok {
+			if e, ok := errMap[req.Model]; ok {
+				return CompletionResponse{}, e
+			}
+		}
+		if outMap, ok := r.roundOutByModel[round]; ok {
+			if out, ok := outMap[req.Model]; ok {
+				return makeResponse(out), nil
+			}
+		}
+		out := r.roundDefaults
+		if out == "" {
+			out = `{"ratings":{"correctness":0.5,"clarity":0.5,"completeness":0.5},"summary":"default"}`
+		}
+		return makeResponse(out), nil
+	case strings.Contains(body, "You synthesise the final answer from a Delphi rating panel"):
+		r.calls = append(r.calls, "chairman:"+req.Model)
+		r.chairmanPrompt = body
+		if r.chairmanErr != nil {
+			return CompletionResponse{}, r.chairmanErr
+		}
+		return makeResponse(r.chairmanOut), nil
+	default:
+		r.calls = append(r.calls, "stage1:"+req.Model)
+		ans, ok := r.stage1[req.Model]
+		if !ok {
+			return CompletionResponse{}, errors.New("no answer scripted for " + req.Model)
+		}
+		return makeResponse(ans), nil
+	}
+}
+
+func delphiCouncil(t *testing.T, models []string, chairman string, maxRounds int, threshold float64, rec *delphiRecorder) *Council {
+	t.Helper()
+	registry := map[string]CouncilType{
+		"test": {
+			Name:                       "test",
+			Strategy:                   Delphi,
+			Models:                     models,
+			ChairmanModel:              chairman,
+			Temperature:                0.7,
+			MaxDelphiRounds:            maxRounds,
+			DelphiConvergenceThreshold: threshold,
+		},
+	}
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			return rec.record(req)
+		},
+	}
+	return NewCouncil(client, registry, nil)
+}
+
+// ratingJSON is a fixture helper for scripting per-round per-model ratings.
+func ratingJSON(correctness, clarity, completeness float64, summary string) string {
+	return fmt.Sprintf(`{"ratings":{"correctness":%.2f,"clarity":%.2f,"completeness":%.2f},"summary":%q}`,
+		correctness, clarity, completeness, summary)
+}
+
+// ── 1. Happy path (no convergence) ────────────────────────────────────────
+
+func TestRunDelphi_HappyPath_NoConvergence(t *testing.T) {
+	// Threshold tight enough that DeltaMean stays above it across all 3 rounds —
+	// strategy runs to MaxRounds and exits with Converged: false.
+	rec := &delphiRecorder{
+		stage1: map[string]string{
+			"m-a": "ans-a", "m-b": "ans-b", "m-c": "ans-c", "m-d": "ans-d",
+		},
+		roundOutByModel: map[int]map[string]string{
+			1: {
+				"m-a": ratingJSON(0.9, 0.9, 0.9, "r1 a"),
+				"m-b": ratingJSON(0.6, 0.6, 0.6, "r1 b"),
+				"m-c": ratingJSON(0.3, 0.3, 0.3, "r1 c"),
+				"m-d": ratingJSON(0.1, 0.1, 0.1, "r1 d"),
+			},
+			2: {
+				"m-a": ratingJSON(0.5, 0.5, 0.5, "r2 a"), // big shift from 0.9
+				"m-b": ratingJSON(0.5, 0.5, 0.5, "r2 b"),
+				"m-c": ratingJSON(0.5, 0.5, 0.5, "r2 c"),
+				"m-d": ratingJSON(0.9, 0.9, 0.9, "r2 d"), // big shift from 0.1
+			},
+			3: {
+				"m-a": ratingJSON(0.0, 0.0, 0.0, "r3 a"), // big shift from 0.5
+				"m-b": ratingJSON(0.0, 0.0, 0.0, "r3 b"),
+				"m-c": ratingJSON(1.0, 1.0, 1.0, "r3 c"), // big shift
+				"m-d": ratingJSON(1.0, 1.0, 1.0, "r3 d"),
+			},
+		},
+		chairmanOut: "FINAL",
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 3, 0.05, rec)
+
+	var events []string
+	var rounds []int
+	var seenKind string
+	var panel *DelphiPanel
+	var stage3 StageThreeResult
+
+	err := c.RunFull(context.Background(), "the question?", "test", func(eventType string, data any) {
+		events = append(events, eventType)
+		if eventType == "stage2_round_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				rounds = append(rounds, d.Round)
+			}
+		}
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				seenKind = d.Kind
+				panel = d.Metadata.DelphiPanel
+			}
+		}
+		if eventType == "stage3_complete" {
+			stage3 = data.(StageThreeResult)
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantSeq := []string{"stage1_complete",
+		"stage2_round_complete", "stage2_round_complete", "stage2_round_complete",
+		"stage2_complete", "stage3_complete"}
+	if !reflect.DeepEqual(events, wantSeq) {
+		t.Errorf("event sequence: got %v, want %v", events, wantSeq)
+	}
+	if !reflect.DeepEqual(rounds, []int{1, 2, 3}) {
+		t.Errorf("round events: got %v, want [1 2 3]", rounds)
+	}
+	if seenKind != "delphi_round" {
+		t.Errorf("Stage 2 Kind: got %q, want %q", seenKind, "delphi_round")
+	}
+	if panel == nil || panel.FinalRound != 3 || panel.Converged {
+		t.Errorf("panel: FinalRound=3 Converged=false expected, got %+v", panel)
+	}
+	if stage3.Content != "FINAL" {
+		t.Errorf("stage3 content: got %q", stage3.Content)
+	}
+}
+
+// ── 2. Early convergence ──────────────────────────────────────────────────
+
+func TestRunDelphi_EarlyConvergence(t *testing.T) {
+	// Round 1 ratings spread; round 2 ratings move close to round 1 means
+	// → DeltaMean < threshold → exit after round 2 with Converged: true.
+	rec := &delphiRecorder{
+		stage1: map[string]string{
+			"m-a": "ans-a", "m-b": "ans-b", "m-c": "ans-c", "m-d": "ans-d",
+		},
+		roundOutByModel: map[int]map[string]string{
+			1: {
+				"m-a": ratingJSON(0.5, 0.5, 0.5, "r1 a"),
+				"m-b": ratingJSON(0.5, 0.5, 0.5, "r1 b"),
+				"m-c": ratingJSON(0.5, 0.5, 0.5, "r1 c"),
+				"m-d": ratingJSON(0.5, 0.5, 0.5, "r1 d"),
+			},
+			2: {
+				// All shift by 0.02 — well below threshold 0.1.
+				"m-a": ratingJSON(0.52, 0.52, 0.52, "r2 a"),
+				"m-b": ratingJSON(0.52, 0.52, 0.52, "r2 b"),
+				"m-c": ratingJSON(0.52, 0.52, 0.52, "r2 c"),
+				"m-d": ratingJSON(0.52, 0.52, 0.52, "r2 d"),
+			},
+		},
+		chairmanOut: "ok",
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 5, 0.1, rec)
+
+	var roundCount int
+	var panel *DelphiPanel
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_round_complete" {
+			roundCount++
+		}
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				panel = d.Metadata.DelphiPanel
+			}
+		}
+	})
+	if roundCount != 2 {
+		t.Errorf("round events: got %d, want 2 (early convergence)", roundCount)
+	}
+	if panel == nil || panel.FinalRound != 2 || !panel.Converged {
+		t.Errorf("panel: FinalRound=2 Converged=true expected, got %+v", panel)
+	}
+}
+
+// ── 3. Stage 1 quorum failure ────────────────────────────────────────────
+
+func TestRunDelphi_Stage1QuorumFailure(t *testing.T) {
+	rec := &delphiRecorder{stage1: map[string]string{}} // no scripted answers
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 3, 0.1, rec)
+
+	err := c.RunFull(context.Background(), "q", "test", nil)
+	var qe *QuorumError
+	if !errors.As(err, &qe) {
+		t.Fatalf("expected *QuorumError, got %T: %v", err, err)
+	}
+}
+
+// ── 4. Per-round quorum failure ──────────────────────────────────────────
+
+func TestRunDelphi_PerRoundQuorumFailure(t *testing.T) {
+	// Need = max(3, ⌈4/2⌉+1) = 3 with 4 raters. Two fail in round 1 → 2
+	// survivors → quorum re-check fires loud error.
+	rec := &delphiRecorder{
+		stage1: map[string]string{"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d"},
+		roundOutByModel: map[int]map[string]string{
+			1: {
+				"m-a": ratingJSON(0.5, 0.5, 0.5, "ok"),
+				"m-b": ratingJSON(0.5, 0.5, 0.5, "ok"),
+			},
+		},
+		roundErrByModel: map[int]map[string]error{
+			1: {
+				"m-c": errors.New("fail c"),
+				"m-d": errors.New("fail d"),
+			},
+		},
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 3, 0.1, rec)
+
+	var stage2CompleteEmitted bool
+	var stage3Emitted bool
+	err := c.RunFull(context.Background(), "q", "test", func(eventType string, _ any) {
+		if eventType == "stage2_complete" {
+			stage2CompleteEmitted = true
+		}
+		if eventType == "stage3_complete" {
+			stage3Emitted = true
+		}
+	})
+	if err == nil {
+		t.Fatal("expected loud error on per-round quorum drop")
+	}
+	if !strings.Contains(err.Error(), "delphi: quorum failed after round 1") {
+		t.Errorf("error: got %q, want mention of 'delphi: quorum failed after round 1'", err.Error())
+	}
+	if stage2CompleteEmitted {
+		t.Error("must NOT emit terminal stage2_complete on quorum failure")
+	}
+	if stage3Emitted {
+		t.Error("must NOT emit stage3_complete on quorum failure")
+	}
+}
+
+// ── 5. Per-rater JSON parse failure (drop) ───────────────────────────────
+
+func TestRunDelphi_PerRaterJSONParseFailureDrops(t *testing.T) {
+	rec := &delphiRecorder{
+		stage1: map[string]string{"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d"},
+		roundOutByModel: map[int]map[string]string{
+			1: {
+				"m-a": ratingJSON(0.5, 0.5, 0.5, "ok"),
+				"m-b": "not valid json {{{",
+				"m-c": ratingJSON(0.5, 0.5, 0.5, "ok"),
+				"m-d": ratingJSON(0.5, 0.5, 0.5, "ok"),
+			},
+		},
+		roundDefaults: ratingJSON(0.5, 0.5, 0.5, "default"),
+		chairmanOut:   "ok",
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 2, 0.1, rec)
+
+	var panel *DelphiPanel
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				panel = d.Metadata.DelphiPanel
+			}
+		}
+	})
+	if panel == nil {
+		t.Fatal("panel nil")
+	}
+	// Round 1 should have 3 successful ratings (m-b dropped).
+	if len(panel.Rounds[0].Ratings) != 3 {
+		t.Errorf("round 1 ratings: got %d, want 3", len(panel.Rounds[0].Ratings))
+	}
+	// Round 2 should also have 3 (m-b stays out).
+	if len(panel.Rounds[1].Ratings) != 3 {
+		t.Errorf("round 2 ratings: got %d, want 3", len(panel.Rounds[1].Ratings))
+	}
+}
+
+// ── 6. Missing-criterion handling ────────────────────────────────────────
+
+func TestRunDelphi_MissingCriterionDefaultsToZero(t *testing.T) {
+	// One rater returns ratings dict missing "completeness" → criterion
+	// defaults to 0.0; rater stays in.
+	rec := &delphiRecorder{
+		stage1: map[string]string{"m-a": "a", "m-b": "b", "m-c": "c"},
+		roundOutByModel: map[int]map[string]string{
+			1: {
+				"m-a": `{"ratings":{"correctness":0.8,"clarity":0.8},"summary":"missing one"}`,
+				"m-b": ratingJSON(0.5, 0.5, 0.5, "ok"),
+				"m-c": ratingJSON(0.5, 0.5, 0.5, "ok"),
+			},
+		},
+		chairmanOut: "ok",
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c"}, "chairman-z", 1, 0.1, rec)
+
+	var panel *DelphiPanel
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				panel = d.Metadata.DelphiPanel
+			}
+		}
+	})
+	if panel == nil || len(panel.Rounds) != 1 {
+		t.Fatalf("panel state unexpected: %+v", panel)
+	}
+	// m-a should still be present with completeness defaulted to 0.0.
+	var aRating *DelphiRating
+	for i := range panel.Rounds[0].Ratings {
+		if panel.Rounds[0].Ratings[i].Model == "m-a" {
+			aRating = &panel.Rounds[0].Ratings[i]
+		}
+	}
+	if aRating == nil {
+		t.Fatal("m-a rating missing — should have stayed in")
+	}
+	if aRating.Scores["completeness"] != 0.0 {
+		t.Errorf("missing 'completeness' should default to 0.0, got %v", aRating.Scores["completeness"])
+	}
+}
+
+// ── 7. Score clamping ────────────────────────────────────────────────────
+
+func TestRunDelphi_ScoreClamping(t *testing.T) {
+	rec := &delphiRecorder{
+		stage1: map[string]string{"m-a": "a", "m-b": "b", "m-c": "c"},
+		roundOutByModel: map[int]map[string]string{
+			1: {
+				"m-a": `{"ratings":{"correctness":1.5,"clarity":-0.3,"completeness":0.5},"summary":"out of range"}`,
+				"m-b": ratingJSON(0.5, 0.5, 0.5, "ok"),
+				"m-c": ratingJSON(0.5, 0.5, 0.5, "ok"),
+			},
+		},
+		chairmanOut: "ok",
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c"}, "chairman-z", 1, 0.1, rec)
+
+	var panel *DelphiPanel
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				panel = d.Metadata.DelphiPanel
+			}
+		}
+	})
+	if panel == nil {
+		t.Fatal("panel nil")
+	}
+	for _, r := range panel.Rounds[0].Ratings {
+		if r.Model == "m-a" {
+			if r.Scores["correctness"] != 1.0 {
+				t.Errorf("correctness=1.5 should clamp to 1.0, got %v", r.Scores["correctness"])
+			}
+			if r.Scores["clarity"] != 0.0 {
+				t.Errorf("clarity=-0.3 should clamp to 0.0, got %v", r.Scores["clarity"])
+			}
+		}
+	}
+}
+
+// ── 8. Anonymisation (no model names in rater prompts) ───────────────────
+
+func TestRunDelphi_AnonymisationInPrompts(t *testing.T) {
+	rec := &delphiRecorder{
+		stage1: map[string]string{
+			"my-secret-model-a": "ans a",
+			"my-secret-model-b": "ans b",
+			"my-secret-model-c": "ans c",
+		},
+		roundDefaults: ratingJSON(0.5, 0.5, 0.5, "ok"),
+		chairmanOut:   "ok",
+	}
+	c := delphiCouncil(t,
+		[]string{"my-secret-model-a", "my-secret-model-b", "my-secret-model-c"},
+		"chairman-z", 1, 0.1, rec)
+
+	if err := c.RunFull(context.Background(), "q", "test", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, prompt := range rec.ratingPrompts {
+		for _, secret := range []string{"my-secret-model-a", "my-secret-model-b", "my-secret-model-c"} {
+			if strings.Contains(prompt, secret) {
+				t.Errorf("rater prompt leaks model name %q:\n%s", secret, prompt)
+			}
+		}
+		// At least one Response label should appear.
+		hasAny := false
+		for _, lbl := range []string{"Response A", "Response B", "Response C"} {
+			if strings.Contains(prompt, lbl) {
+				hasAny = true
+				break
+			}
+		}
+		if !hasAny {
+			t.Errorf("rater prompt has no anonymous labels:\n%s", prompt)
+		}
+	}
+}
+
+// ── 9. Self-prev injection only on round 2+ ──────────────────────────────
+
+func TestRunDelphi_SelfPrevInjection(t *testing.T) {
+	rec := &delphiRecorder{
+		stage1: map[string]string{"m-a": "a", "m-b": "b", "m-c": "c"},
+		roundOutByModel: map[int]map[string]string{
+			1: {
+				"m-a": `{"ratings":{"correctness":0.7,"clarity":0.7,"completeness":0.7},"summary":"UNIQUE-R1-SUMMARY-A"}`,
+				"m-b": ratingJSON(0.5, 0.5, 0.5, "ok"),
+				"m-c": ratingJSON(0.5, 0.5, 0.5, "ok"),
+			},
+		},
+		roundDefaults: ratingJSON(0.5, 0.5, 0.5, "ok"),
+		chairmanOut:   "ok",
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c"}, "chairman-z", 2, 0.001, rec) // tight threshold to force round 2
+
+	if err := c.RunFull(context.Background(), "q", "test", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Round 1 prompts MUST NOT contain a self-prev section ("Your own previous-round").
+	for _, p := range rec.ratingPromptsByRound[1] {
+		if strings.Contains(p, "Your own previous-round ratings") {
+			t.Errorf("round 1 prompt MUST NOT contain self-prev section:\n%s", p)
+		}
+	}
+	// Round 2 prompt for m-a MUST contain its own UNIQUE round-1 summary.
+	r2pa, ok := rec.ratingPromptByRoundModel[2]["m-a"]
+	if !ok {
+		t.Fatal("no round-2 prompt captured for m-a")
+	}
+	if !strings.Contains(r2pa, "Your own previous-round ratings") {
+		t.Error("round-2 m-a prompt missing self-prev section")
+	}
+	if !strings.Contains(r2pa, "UNIQUE-R1-SUMMARY-A") {
+		t.Error("round-2 m-a prompt missing its own round-1 summary")
+	}
+	// Round 2 prompt for m-b MUST NOT contain m-a's UNIQUE summary (no cross-rater leakage).
+	r2pb, ok := rec.ratingPromptByRoundModel[2]["m-b"]
+	if !ok {
+		t.Fatal("no round-2 prompt captured for m-b")
+	}
+	if strings.Contains(r2pb, "UNIQUE-R1-SUMMARY-A") {
+		t.Error("round-2 m-b prompt leaks m-a's round-1 summary (cross-rater leakage forbidden)")
+	}
+}
+
+// ── 10. Other raters' raw ratings NOT exposed (aggregate-only feedback) ──
+
+func TestRunDelphi_AggregateOnlyFeedback(t *testing.T) {
+	// Each rater scripts a UNIQUE rating pattern. Round 2 prompts must NOT
+	// contain other raters' unique fingerprints — only the aggregate stats.
+	rec := &delphiRecorder{
+		stage1: map[string]string{"m-a": "a", "m-b": "b", "m-c": "c"},
+		roundOutByModel: map[int]map[string]string{
+			1: {
+				"m-a": `{"ratings":{"correctness":0.987,"clarity":0.987,"completeness":0.987},"summary":"r1"}`,
+				"m-b": `{"ratings":{"correctness":0.012,"clarity":0.012,"completeness":0.012},"summary":"r1"}`,
+				"m-c": `{"ratings":{"correctness":0.456,"clarity":0.456,"completeness":0.456},"summary":"r1"}`,
+			},
+		},
+		roundDefaults: ratingJSON(0.5, 0.5, 0.5, "ok"),
+		chairmanOut:   "ok",
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c"}, "chairman-z", 2, 0.001, rec)
+
+	if err := c.RunFull(context.Background(), "q", "test", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Round 2 prompts must NOT contain the unique rating fingerprints from round 1.
+	// Each rater's prompt should only include the aggregate mean (~0.485 = (0.987+0.012+0.456)/3)
+	// and the rater's OWN previous ratings — not other raters' raw values.
+	for model, prompt := range rec.ratingPromptByRoundModel[2] {
+		// The prompt does include the rater's own previous ratings, so we
+		// only check OTHER raters' fingerprints.
+		otherFingerprints := map[string][]string{
+			"m-a": {"0.012", "0.456"},
+			"m-b": {"0.987", "0.456"},
+			"m-c": {"0.987", "0.012"},
+		}
+		for _, fp := range otherFingerprints[model] {
+			if strings.Contains(prompt, fp) {
+				t.Errorf("rater %s round-2 prompt leaks other rater's raw rating %q:\n%s", model, fp, prompt)
+			}
+		}
+	}
+}
+
+// ── 11. Stage 2 kind on every event ──────────────────────────────────────
+
+func TestRunDelphi_StageTwoKind(t *testing.T) {
+	rec := &delphiRecorder{
+		stage1: map[string]string{"m-a": "a", "m-b": "b", "m-c": "c"},
+		roundDefaults: ratingJSON(0.5, 0.5, 0.5, "ok"),
+		chairmanOut:   "ok",
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c"}, "chairman-z", 2, 0.001, rec)
+
+	var roundEventKinds []string
+	var terminalKind string
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_round_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				roundEventKinds = append(roundEventKinds, d.Kind)
+			}
+		}
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				terminalKind = d.Kind
+			}
+		}
+	})
+	for _, k := range roundEventKinds {
+		if k != "delphi_round" {
+			t.Errorf("round event kind: got %q, want %q", k, "delphi_round")
+		}
+	}
+	if terminalKind != "delphi_round" {
+		t.Errorf("terminal kind: got %q, want %q", terminalKind, "delphi_round")
+	}
+}
+
+// ── 12. Sort stability ───────────────────────────────────────────────────
+
+func TestRunDelphi_RatingSortStability(t *testing.T) {
+	rec := &delphiRecorder{
+		stage1: map[string]string{"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d"},
+		roundDefaults: ratingJSON(0.5, 0.5, 0.5, "ok"),
+		chairmanOut:   "ok",
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 1, 0.1, rec)
+
+	var panel *DelphiPanel
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				panel = d.Metadata.DelphiPanel
+			}
+		}
+	})
+	if panel == nil || len(panel.Rounds) != 1 {
+		t.Fatalf("panel state unexpected: %+v", panel)
+	}
+	rs := panel.Rounds[0].Ratings
+	for i := 1; i < len(rs); i++ {
+		if rs[i-1].Label > rs[i].Label {
+			t.Errorf("ratings not sorted ascending by Label: %v", labelsOfRatings(rs))
+			break
+		}
+	}
+}
+
+// ── 13. Transcript-agreement contract ────────────────────────────────────
+
+func TestRunDelphi_TranscriptAgreement(t *testing.T) {
+	rec := &delphiRecorder{
+		stage1: map[string]string{"m-a": "a", "m-b": "b", "m-c": "c", "m-d": "d"},
+		roundDefaults: ratingJSON(0.5, 0.5, 0.5, "ok"),
+		chairmanOut:   "ok",
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c", "m-d"}, "chairman-z", 2, 0.001, rec)
+
+	var cumulative []DelphiRound
+	var canonical []DelphiRound
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_round_complete" {
+			if d, ok := data.(Stage2CompleteData); ok && d.Metadata.DelphiPanel != nil {
+				cumulative = append(cumulative, d.Metadata.DelphiPanel.Rounds...)
+			}
+		}
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok && d.Metadata.DelphiPanel != nil {
+				canonical = d.Metadata.DelphiPanel.Rounds
+			}
+		}
+	})
+	if len(cumulative) == 0 || len(canonical) == 0 {
+		t.Fatalf("missing rounds: cumulative=%d, canonical=%d", len(cumulative), len(canonical))
+	}
+	if !reflect.DeepEqual(cumulative, canonical) {
+		t.Errorf("cumulative round events disagree with canonical Metadata.DelphiPanel.Rounds:\ncumulative=%+v\ncanonical=%+v", cumulative, canonical)
+	}
+}
+
+// ── 14. Per-criterion convergence asymmetry ──────────────────────────────
+
+func TestRunDelphi_PerCriterionConvergenceAsymmetry(t *testing.T) {
+	// At round 2: correctness Δ ≈ 0.05 (below threshold 0.1),
+	//             clarity Δ ≈ 0.15 (above threshold).
+	// Strategy MUST NOT exit early at round 2 — max(Δ) = 0.15 > 0.1.
+	// Round 3: both Δs fall below threshold → exits with Converged: true.
+	rec := &delphiRecorder{
+		stage1: map[string]string{"m-a": "a", "m-b": "b", "m-c": "c"},
+		roundOutByModel: map[int]map[string]string{
+			1: {
+				"m-a": ratingJSON(0.5, 0.5, 0.5, "r1"),
+				"m-b": ratingJSON(0.5, 0.5, 0.5, "r1"),
+				"m-c": ratingJSON(0.5, 0.5, 0.5, "r1"),
+			},
+			2: {
+				// correctness mean shifts from 0.5 → 0.55 (Δ=0.05, below).
+				// clarity mean shifts from 0.5 → 0.65 (Δ=0.15, above).
+				// completeness shifts from 0.5 → 0.55 (Δ=0.05, below).
+				"m-a": ratingJSON(0.55, 0.65, 0.55, "r2"),
+				"m-b": ratingJSON(0.55, 0.65, 0.55, "r2"),
+				"m-c": ratingJSON(0.55, 0.65, 0.55, "r2"),
+			},
+			3: {
+				// All shift by 0.02 from round 2 → all below threshold.
+				"m-a": ratingJSON(0.57, 0.67, 0.57, "r3"),
+				"m-b": ratingJSON(0.57, 0.67, 0.57, "r3"),
+				"m-c": ratingJSON(0.57, 0.67, 0.57, "r3"),
+			},
+		},
+		chairmanOut: "ok",
+	}
+	c := delphiCouncil(t, []string{"m-a", "m-b", "m-c"}, "chairman-z", 5, 0.1, rec)
+
+	var roundCount int
+	var panel *DelphiPanel
+	_ = c.RunFull(context.Background(), "q", "test", func(eventType string, data any) {
+		if eventType == "stage2_round_complete" {
+			roundCount++
+		}
+		if eventType == "stage2_complete" {
+			if d, ok := data.(Stage2CompleteData); ok {
+				panel = d.Metadata.DelphiPanel
+			}
+		}
+	})
+	if roundCount != 3 {
+		t.Errorf("round events: got %d, want 3 (round 2 must NOT trigger early exit because clarity Δ > threshold)", roundCount)
+	}
+	if panel == nil || panel.FinalRound != 3 || !panel.Converged {
+		t.Errorf("expected FinalRound=3 Converged=true, got %+v", panel)
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+func labelsOfRatings(rs []DelphiRating) []string {
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.Label
+	}
+	return out
+}

--- a/internal/council/prompts.go
+++ b/internal/council/prompts.go
@@ -489,6 +489,177 @@ func BuildDebateChairmanPrompt(query string, stage1 []StageOneResult, debate *De
 	}
 }
 
+// BuildDelphiRoundPrompt asks a single Delphi rater to score every Stage 1
+// candidate against a fixed set of criteria and produce a 1–2 sentence
+// summary of its current view.
+//
+// Anonymisation contract:
+//   - Stage 1 candidates are shown with labels only — no model names.
+//   - From round 2 onwards, the prompt shows AGGREGATE stats from every
+//     prior round (mean ± stddev per criterion) — never other raters' raw
+//     ratings. The aggregate is the entire feedback signal; raw cross-rater
+//     leakage would defeat the anonymous-blind property of the method.
+//   - From round 2 onwards, the prompt also shows the rater's OWN
+//     previous-round ratings + summary so it can revise rather than start
+//     from scratch.
+//
+// Discriminator prefix: "You rate council answers." — used by tests to
+// classify the call as a Delphi rating call.
+func BuildDelphiRoundPrompt(query string, candidates []StageOneResult, criteria []string, round, totalRounds int, priorStats []DelphiStats, selfPrev *DelphiRating) []ChatMessage {
+	sortedCandidates := make([]StageOneResult, len(candidates))
+	copy(sortedCandidates, candidates)
+	sort.SliceStable(sortedCandidates, func(i, j int) bool { return sortedCandidates[i].Label < sortedCandidates[j].Label })
+
+	var sb strings.Builder
+	sb.WriteString("You rate council answers. ")
+	fmt.Fprintf(&sb, "This is round %d of %d in a Delphi rating panel.\n\n", round, totalRounds)
+	sb.WriteString("Question: ")
+	sb.WriteString(query)
+	sb.WriteString("\n\nCriteria (each scored 0.0–1.0):\n")
+	for _, c := range criteria {
+		fmt.Fprintf(&sb, "- %s\n", c)
+	}
+
+	sb.WriteString("\nCandidate answers (anonymous; you do not know which model wrote which):\n")
+	for _, cand := range sortedCandidates {
+		fmt.Fprintf(&sb, "\n[%s]\n%s\n", cand.Label, cand.Content)
+	}
+
+	if len(priorStats) > 0 {
+		sb.WriteString("\nPrior-round aggregate statistics across the rating panel (you cannot see other raters' raw ratings — only these aggregates):\n")
+		for i, stats := range priorStats {
+			fmt.Fprintf(&sb, "\nRound %d:\n", i+1)
+			// Sort criteria for deterministic output.
+			critNames := make([]string, 0, len(stats.Mean))
+			for k := range stats.Mean {
+				critNames = append(critNames, k)
+			}
+			sort.Strings(critNames)
+			for _, name := range critNames {
+				fmt.Fprintf(&sb, "  %s: mean=%.2f stddev=%.2f", name, stats.Mean[name], stats.StdDev[name])
+				if d, ok := stats.DeltaMean[name]; ok {
+					fmt.Fprintf(&sb, " Δ=%.2f", d)
+				}
+				sb.WriteString("\n")
+			}
+		}
+	}
+
+	if selfPrev != nil {
+		sb.WriteString("\nYour own previous-round ratings (revise them, don't start from scratch):\n")
+		critNames := make([]string, 0, len(selfPrev.Scores))
+		for k := range selfPrev.Scores {
+			critNames = append(critNames, k)
+		}
+		sort.Strings(critNames)
+		for _, name := range critNames {
+			fmt.Fprintf(&sb, "  %s: %.2f\n", name, selfPrev.Scores[name])
+		}
+		if selfPrev.Summary != "" {
+			fmt.Fprintf(&sb, "Your previous summary: %s\n", selfPrev.Summary)
+		}
+	}
+
+	sb.WriteString("\nProduce a JSON object with this shape:\n")
+	sb.WriteString("```json\n")
+	sb.WriteString("{\n  \"ratings\": { ")
+	for i, c := range criteria {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		fmt.Fprintf(&sb, "\"%s\": <0.0..1.0>", c)
+	}
+	sb.WriteString(" },\n  \"summary\": \"<1–2 sentence summary of your current view>\"\n}\n```\n")
+	sb.WriteString("Score every criterion. Be discriminating — spread scores across the range so consensus is informative. ")
+	sb.WriteString("If you change your mind from the previous round, the summary should briefly explain why; if you don't, the summary should still acknowledge the prior-round aggregate.")
+
+	return []ChatMessage{
+		{Role: "user", Content: sb.String()},
+	}
+}
+
+// BuildDelphiChairmanPrompt asks the Delphi chairman to synthesise a final
+// answer from the rating panel. The chairman receives the Stage 1 candidates,
+// the final-round per-rater ratings + summaries, the converged stats, and a
+// Converged flag. Synthesis guidance scales with consensus — analog to
+// PeerReview's Kendall's W guidance.
+//
+// The chairman receives LabelToModel for candidate provenance attribution
+// (mirrors how PeerReview/Debate chairmen attribute provenance).
+//
+// Discriminator prefix: "You synthesise the final answer from a Delphi
+// rating panel." — used by tests to classify the call as the Delphi
+// chairman call.
+func BuildDelphiChairmanPrompt(query string, candidates []StageOneResult, finalRatings []DelphiRating, finalStats DelphiStats, converged bool, criteria []string, labelToModel map[string]string) []ChatMessage {
+	sortedCandidates := make([]StageOneResult, len(candidates))
+	copy(sortedCandidates, candidates)
+	sort.SliceStable(sortedCandidates, func(i, j int) bool { return sortedCandidates[i].Label < sortedCandidates[j].Label })
+
+	sortedRatings := make([]DelphiRating, len(finalRatings))
+	copy(sortedRatings, finalRatings)
+	sort.SliceStable(sortedRatings, func(i, j int) bool { return sortedRatings[i].Label < sortedRatings[j].Label })
+
+	// Synthesis guidance keyed off the converged flag + the spread in the
+	// final-round mean ratings. High consensus + high mean → confident
+	// synthesis from the highest-rated candidate. Low consensus → balanced
+	// presentation of perspectives.
+	var guidance string
+	switch {
+	case converged:
+		guidance = "The rating panel converged — your synthesis can confidently weight the highest-rated candidate(s) heavily."
+	default:
+		guidance = "The rating panel did NOT converge within the round budget — present the strongest perspectives fairly and acknowledge where ratings diverged."
+	}
+
+	var sb strings.Builder
+	sb.WriteString("You synthesise the final answer from a Delphi rating panel. ")
+	fmt.Fprintf(&sb, "%d raters scored %d candidate answers across %d rounds.\n\n", len(sortedRatings), len(sortedCandidates), len(criteria))
+	sb.WriteString("Question: ")
+	sb.WriteString(query)
+	sb.WriteString("\n\nCandidate answers (with model attribution):\n")
+	for _, cand := range sortedCandidates {
+		modelName := labelToModel[cand.Label]
+		if modelName == "" {
+			modelName = cand.Model
+		}
+		fmt.Fprintf(&sb, "\n[%s — %s]\n%s\n", cand.Label, modelName, cand.Content)
+	}
+
+	sb.WriteString("\nFinal-round aggregate statistics across the panel:\n")
+	for _, name := range criteria {
+		mean, ok := finalStats.Mean[name]
+		if !ok {
+			fmt.Fprintf(&sb, "  %s: (no ratings — every rater omitted this criterion)\n", name)
+			continue
+		}
+		fmt.Fprintf(&sb, "  %s: mean=%.2f stddev=%.2f\n", name, mean, finalStats.StdDev[name])
+	}
+
+	sb.WriteString("\nFinal-round per-rater summaries:\n")
+	for _, r := range sortedRatings {
+		modelName := labelToModel[r.Label]
+		if modelName == "" {
+			modelName = r.Model
+		}
+		fmt.Fprintf(&sb, "\n[%s — %s] ", r.Label, modelName)
+		if r.Summary != "" {
+			sb.WriteString(r.Summary)
+		} else {
+			sb.WriteString("(no summary)")
+		}
+		sb.WriteString("\n")
+	}
+
+	fmt.Fprintf(&sb, "\nConverged: %t\n", converged)
+	sb.WriteString("\n")
+	sb.WriteString(guidance)
+	sb.WriteString("\n\nProduce the final answer. Reply with the answer only — no preamble, no commentary on the rating process.")
+
+	return []ChatMessage{
+		{Role: "user", Content: sb.String()},
+	}
+}
+
 // BuildMoaAggregatorPrompt asks a single MixtureOfAgents Layer 2 aggregator to
 // digest the Layer 1 proposer drafts and produce one improved draft.
 //

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -74,6 +74,8 @@ func (c *Council) RunFull(ctx context.Context, query string, councilTypeName str
 		return c.runMultiAgentDebate(ctx, query, ct, onEvent)
 	case MixtureOfAgents:
 		return c.runMixtureOfAgents(ctx, query, ct, onEvent)
+	case Delphi:
+		return c.runDelphi(ctx, query, ct, onEvent)
 	default:
 		return fmt.Errorf("council: strategy %d not implemented", ct.Strategy)
 	}

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -550,25 +549,6 @@ func TestRunFull_Stage2CompletePayload_IsStage2CompleteData(t *testing.T) {
 		if !expectedModels[r.Model] {
 			t.Errorf("AggregateRankings entry %q is not a known model", r.Model)
 		}
-	}
-}
-
-func TestRunFull_UnimplementedStrategy_ReturnsError(t *testing.T) {
-	unimplemented := []Strategy{
-		Delphi,
-	}
-	for _, s := range unimplemented {
-		s := s
-		t.Run(fmt.Sprintf("strategy_%d", s), func(t *testing.T) {
-			registry := map[string]CouncilType{
-				"test": {Name: "test", Strategy: s, Models: []string{"m1"}},
-			}
-			c := NewCouncil(&mockLLMClient{}, registry, nil)
-			err := c.RunFull(context.Background(), "q", "test", nil)
-			if err == nil || !strings.Contains(err.Error(), "not implemented") {
-				t.Fatalf("expected 'not implemented' error, got %v", err)
-			}
-		})
 	}
 }
 

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -14,23 +14,25 @@ const (
 	RoleBased
 
 	// Majority runs independent generation followed by a vote (exact match,
-	// cluster, or weighted). Selects rather than synthesises. Not implemented.
+	// cluster, or weighted). Selects rather than synthesises. Implemented in
+	// majority.go.
 	Majority
 
 	// GenerateRankRefine runs parallel generation, ranks candidates against
-	// structured criteria, then refines the top-K. Not implemented.
+	// structured criteria, then refines the top-K. Implemented in
+	// generaterankrefine.go.
 	GenerateRankRefine
 
 	// MultiAgentDebate runs initial answers followed by N rounds of mutual
-	// critique and revision, then synthesises. Not implemented.
+	// critique and revision, then synthesises. Implemented in debate.go.
 	MultiAgentDebate
 
 	// MixtureOfAgents runs a layered architecture: proposers → aggregators →
-	// refiner. Not implemented.
+	// refiner. Implemented in moa.go.
 	MixtureOfAgents
 
-	// Delphi runs multiple anonymous blind rating rounds with averaged ratings.
-	// Not implemented.
+	// Delphi runs multiple anonymous blind rating rounds with averaged ratings
+	// and convergence detection. Implemented in delphi.go.
 	Delphi
 )
 
@@ -52,6 +54,8 @@ type Role struct {
 //	MultiAgentDebate   : Models, ChairmanModel, Temperature, QuorumMin, MaxDebateRounds
 //	MixtureOfAgents    : ProposerModels, AggregatorModels, RefinerModel, Temperature, QuorumMin
 //	                     (Models and ChairmanModel are UNUSED for this strategy)
+//	Delphi             : Models, ChairmanModel, Temperature, QuorumMin,
+//	                     MaxDelphiRounds, DelphiConvergenceThreshold
 //
 // MixtureOfAgents is the first strategy to skip both Models and ChairmanModel —
 // the runner reads the layer-specific ProposerModels / AggregatorModels /
@@ -73,6 +77,11 @@ type CouncilType struct {
 	ProposerModels   []string // MoA: Layer 1 model pool (parallel proposer drafts)
 	AggregatorModels []string // MoA: Layer 2 model pool (parallel aggregators, all-to-all over Layer 1)
 	RefinerModel     string   // MoA: Layer 3 single refiner that synthesises the final answer
+
+	// Delphi-only scalars. Models and ChairmanModel are reused (Delphi has no
+	// layer-specific model pools), so only the rating-loop knobs live here.
+	MaxDelphiRounds            int     // Delphi: max rating rounds before forced exit; 0 = default (3)
+	DelphiConvergenceThreshold float64 // Delphi: max DeltaMean to declare convergence; 0 = default (0.1)
 }
 
 // ChatMessage is a single turn in a conversation history.
@@ -242,12 +251,65 @@ type MoaAggregator struct {
 	Aggregators []AggregatorOutput `json:"aggregators"`
 }
 
+// DelphiRating is one rater's per-criterion ratings + free-form summary in a
+// single Delphi round. Scores are clamped to [0.0, 1.0] per criterion;
+// missing criterion values default to 0.0 with a warn log (same recovery
+// shape as GenerateRankRefine's BuildRankPrompt parser). Ratings carry the
+// SAME label as the rater's Stage 1 output (raters and proposers are the
+// same model pool in Delphi today; the label persists across rounds).
+type DelphiRating struct {
+	Label      string             `json:"label"`        // anonymised, e.g. "Response A"
+	Model      string             `json:"model"`        // OpenRouter ID
+	Scores     map[string]float64 `json:"scores"`       // criterion → 0.0–1.0
+	Summary    string             `json:"summary,omitempty"`
+	DurationMs int64              `json:"duration_ms"`
+	Error      error              `json:"-"`
+}
+
+// DelphiStats is the aggregate per-criterion statistics across all successful
+// raters × candidates in a single round. Mean and StdDev contain only
+// criteria with ≥1 successful rating in this round; criteria absent in
+// either current or prior round are excluded from DeltaMean (and from the
+// convergence check). DeltaMean is omitempty so it's absent on round 1.
+type DelphiStats struct {
+	Mean      map[string]float64 `json:"mean"`
+	StdDev    map[string]float64 `json:"std_dev"`
+	DeltaMean map[string]float64 `json:"delta_mean,omitempty"`
+}
+
+// DelphiRound holds all surviving raters' ratings for a single round plus
+// the round's aggregate stats. Ratings are sorted by Label ascending for
+// stable output across runs.
+type DelphiRound struct {
+	Round   int            `json:"round"`
+	Ratings []DelphiRating `json:"ratings"`
+	Stats   DelphiStats    `json:"stats"`
+}
+
+// DelphiPanel is the Stage 2 payload for the Delphi strategy. Rounds holds
+// the per-round transcript (rounds 1..FinalRound). Converged is true when
+// the strategy exited early because max(DeltaMean) fell below the configured
+// threshold across all criteria. Named "DelphiPanel" — not "Delphi" —
+// because the strategy enum constant already owns the bare name.
+//
+// NO DelphiDropout type. Dropped raters are simply absent from subsequent
+// rounds' Ratings slices; chairman and frontend infer dropout by label-set
+// diff between rounds. Delphi's transcript is a sample (smaller n on
+// dropout), not a narrative — typed dropout markers would invite the
+// chairman prompt to over-explain.
+type DelphiPanel struct {
+	Rounds     []DelphiRound `json:"rounds"`
+	FinalRound int           `json:"final_round"`
+	Converged  bool          `json:"converged"`
+	Criteria   []string      `json:"criteria"`
+}
+
 // Metadata is persisted with every assistant message.
 //
 // VoteTally is populated only by the Majority strategy; RankRefine only by
 // GenerateRankRefine; Debate only by MultiAgentDebate; MoaAggregator only by
-// MixtureOfAgents. omitempty keeps each absent on the wire and at rest for
-// every other strategy.
+// MixtureOfAgents; DelphiPanel only by Delphi. omitempty keeps each absent
+// on the wire and at rest for every other strategy.
 //
 // LabelToModel is a single flat map containing both proposer labels
 // ("Response A" → model-x) and aggregator labels ("Aggregator A" → model-y)
@@ -262,18 +324,19 @@ type Metadata struct {
 	RankRefine        *RankRefine       `json:"rank_refine,omitempty"`
 	Debate            *Debate           `json:"debate,omitempty"`
 	MoaAggregator     *MoaAggregator    `json:"moa_aggregator,omitempty"`
+	DelphiPanel       *DelphiPanel      `json:"delphi,omitempty"`
 }
 
 // Stage2CompleteData is the payload emitted by Runner for the "stage2_complete" event.
 // It bundles peer-review results with the computed aggregate metadata so callers
 // (e.g. the SSE handler) can surface both in one event.
 //
-// Kind discriminates the strategy-specific payload shape. Today's two implemented
-// values are "peer_ranking" (PeerReview) and "role_stub" (RoleBased). Five more
-// are reserved for planned strategies; see docs/strategies.md for their schemas.
+// Kind discriminates the strategy-specific payload shape. All seven kinds are now
+// implemented; see docs/strategies.md for the per-strategy schemas.
 //
-// Round is reserved for future multi-round strategies (MultiAgentDebate, Delphi).
-// Today both implemented strategies emit a single stage2_complete with Round=0.
+// Round is set on per-round events for MultiAgentDebate and Delphi (the
+// stage2_round_complete event family); absent (zero) on terminal
+// stage2_complete events. omitempty keeps it off the wire when unused.
 type Stage2CompleteData struct {
 	Kind     string           `json:"kind"`
 	Round    int              `json:"round,omitempty"`


### PR DESCRIPTION
## Summary

Seventh and **final** deliberation strategy (Delphi method). Multi-round anonymous blind rating with convergence detection. **Strategy roadmap is now complete — all 7 strategies shipped.**

- **Stage 1:** parallel generation across `ct.Models`. Quorum `max(3, ⌈N/2⌉+1)` — higher floor (3 vs 2) because statistical averaging needs ≥3 raters.
- **Rounds 1..R:** each surviving rater concurrently rates ALL Stage 1 candidates against fixed criteria (`correctness`, `clarity`, `completeness`) and produces a 1–2 sentence summary. Per-round event: `stage2_round_complete` with `kind: "delphi_round"` (second strategy after Debate to use the multi-round event family).
- **Anonymisation cut:** rater prompts show prior-round AGGREGATE stats only (mean ± stddev, Δ from round 2+) and the rater's OWN previous-round ratings. **Other raters' raw ratings are NEVER exposed** — aggregate is the entire feedback signal. Round 1 prompts have no self-prev section; round 2+ have it.
- **Convergence:** after every round R≥2, if `max(DeltaMean) < threshold` for ALL criteria in `DeltaMean`, exit early with `Converged: true`. Conservative — `max` ensures every criterion converges; `mean` would let one stable criterion paper over a divergent one. Default threshold 0.1.
- **Per-round quorum re-check:** loud `fmt.Errorf` if survivors fall below `need` (mirrors Debate). NO `DelphiDropout` type — dropped raters absent from subsequent `Ratings` slices.
- **Stage 3:** chairman synthesises across final-round ratings + summaries + converged stats. Synthesis guidance scales with `Converged` flag.

Reuses `Models` + `ChairmanModel` shape — unlike MoA, no new layer-specific model fields. Only two new scalars on `CouncilType` (`MaxDelphiRounds`, `DelphiConvergenceThreshold`). Type named `DelphiPanel` (not `Delphi`) because the strategy enum constant already owns the bare name.

**Two-commit sequencing per Tech Lead review:**
1. `c8f2f57` — behaviour-preserving extraction of `mergeRoundIntoMessage(msg, event)` helper from `App.jsx`. All 35 frontend tests stay green.
2. `fd121e4` — Delphi backend + Delphi branch in the helper + DelphiView + sentinel migration.

**Cost:** N + N×R + 1 worst case (defaults N=4 R=3 → 17 calls); convergence at round 2 → 9 calls.

Closes #216

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./internal/... ./cmd/...` passes (all packages)
- [x] 14 backend cases in `internal/council/delphi_test.go` pass — including transcript-agreement and per-criterion convergence asymmetry
- [x] 1 wire-format integration test in `internal/api/handler_test.go` — asserts per-round event has REQUIRED `round` field on the wire, terminal `stage2_complete` carries `metadata.delphi`
- [x] 5 config tests in `internal/config/config_test.go` (all-set, optionals-unset, models-only, all-unset, invalid threshold)
- [x] 3 frontend tests in `frontend/src/components/Stage2.test.jsx` (3-round timeline, converged-badge-only-on-final, live-progressive append)
- [x] Unknown-kind dispatcher test migrated to synthetic sentinel `__bogus_kind__`
- [x] `npm run lint` passes
- [x] `npm test -- --run` passes (38 tests across 3 files, +3 from Delphi)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)