### PR TITLE
docs(eval,strategies): strategy showcase — 21 test prompts + markdown reference

### DIFF
--- a/.claude/agent-memory/MEMORY.md
+++ b/.claude/agent-memory/MEMORY.md
@@ -3,4 +3,7 @@
 Shared project-level memories for vmm-rada agents.
 Each entry below is a link to a memory file with a one-line description.
 
+- [error-status-mapping.md](error-status-mapping.md) — gateway errors surface as council-layer error types; handler must never import openrouter
+- [usage-cost-aggregation.md](usage-cost-aggregation.md) — per-call token/cost aggregated via eval-side LLMClient decorator, never through council.Metadata or stage3_complete
+
 <!-- Add pointers here as agents write memories. Keep under 200 lines. -->

--- a/.claude/agent-memory/error-status-mapping.md
+++ b/.claude/agent-memory/error-status-mapping.md
@@ -1,0 +1,15 @@
+---
+name: error-status-mapping
+description: Gateway/openrouter errors must surface to the handler as council-layer error types, never by importing openrouter into api
+type: project
+---
+
+The HTTP handler (`internal/api/handler.go`) maps council-layer error types to status codes — it must NOT import `internal/openrouter`. The canonical example is `handleRunError`, which keys off `*council.QuorumError` → 503. Per-member `Complete()` (LLMClient) errors are absorbed into `StageOneResult.Error` and aggregated by `checkQuorum`; a provider failure reaches the handler as a `*council.QuorumError`, never as a raw openrouter error.
+
+**Why:** The dependency graph is `api → council`, `api → storage`. Adding `api → openrouter` makes the handler depend on both the council abstraction AND the concrete gateway behind it — a Layer 1 interface-misuse violation. It is also usually redundant: when the gateway fails for all members (e.g. circuit open), the run already fails quorum and the existing path already returns 503.
+
+**How to apply:** When a plan proposes mapping an openrouter sentinel (ErrCircuitOpen, rate-limit, timeout) directly in the handler via `errors.Is(err, openrouter.ErrX)`, REJECT the import. Instead surface it through the council layer: either enrich `QuorumError` with a cause/reason, or define a `council.ErrProviderUnavailable` sentinel that openrouter wraps into at the interface boundary. The handler keys off the council-layer type. The enrichment hook is `checkQuorum` in `internal/council/council.go` — the **sole** `QuorumError` construction site — which already sees each member's failure via `StageOneResult.Error`. A `QuorumError.Reason` field set only when *all* failed members wrap the sentinel is the approved pattern (verified 2026-05-30 on the circuit-breaker plan).
+
+Note the two handler error paths: `handleRunError` (JSON, handler.go:701-703) maps `*council.QuorumError → 503`; the SSE path (`handler.go:644`) reuses the existing SSE error event.
+
+Note the two handler error paths: `handleRunError` is the JSON path; the stream path (handler.go ~458+) has already set `text/event-stream` and called `WriteHeader`, so stream errors must reuse the existing SSE error event and never call `WriteHeader` twice.

--- a/.claude/agent-memory/usage-cost-aggregation.md
+++ b/.claude/agent-memory/usage-cost-aggregation.md
@@ -1,0 +1,30 @@
+---
+name: usage-cost-aggregation
+description: Per-call LLM usage/cost must be aggregated via an eval-side LLMClient decorator, not smuggled through council.Metadata
+type: reference
+---
+
+Token/cost telemetry (and any other per-`Complete()`-call metric) is aggregated by
+wrapping `council.LLMClient` in a metering decorator passed into `NewCouncil`, NOT by
+adding totals to `council.Metadata` or any SSE event payload.
+
+**Why:**
+- `council.Metadata` is a persisted + wire type (storage + frontend). Adding eval-only
+  fields (TotalTokens, TotalCostUSD) pollutes the serving path with bench concerns.
+- The `onEvent` callback only sees stage-completion events, never individual LLM calls,
+  so an event consumer cannot sum per-call usage. `stage3_complete` emits a bare
+  `StageThreeResult` with NO `Metadata` field — only `stage2_complete`
+  (`Stage2CompleteData`) carries `Metadata`. Multi-round strategies (Debate/Delphi/MoA)
+  make many more `Complete()` calls than events expose.
+- A decorator keeps 100% of cost logic in `internal/eval`, touches zero council strategy
+  code, and is the lowest-coupling option.
+
+**How to apply:**
+- The ONLY allowed change to `council/types.go` for cost is adding `Usage` to
+  `CompletionResponse` (mirrors OpenRouter's `usage` body field; `CostUSD` omitempty for
+  Ollama). `decodeBody()` already unmarshals the whole body — purely additive.
+- Stage 1 fans out concurrently → any usage accumulator MUST be mutex-guarded or use
+  atomics. Always require a concurrent-accumulation test under `-race`.
+- Reject any plan that threads per-call telemetry through `Metadata` or invents totals on
+  `stage3_complete`. See [[error-status-mapping]] for the related rule that serving-path
+  types must not absorb non-serving concerns.

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
-# VMM Rada — backend configuration
+# VMM Rada — environment configuration
 # Copy to .env and fill in your values.
 #
 #   cp .env.example .env
 #   $EDITOR .env
 
-# ── Provider ────────────────────────────────────────────────────────────────
+# ── Provider ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 # Name of the LLM provider. Used for logging and display. Default: openrouter.
 # Examples: openrouter, ollama, vllm, lmstudio
 AI_PROVIDER_NAME=openrouter
@@ -14,7 +14,20 @@ AI_PROVIDER_NAME=openrouter
 # For OpenRouter: https://openrouter.ai/keys
 AI_PROVIDER_API_KEY=<sk-or-v1-...>
 
-# ── Rada models ──────────────────────────────────────────────────────────
+# ── LLM API endpoint ──────────────────────────────────────────────────────────────────────────────────────────────────────────
+# Base URL for the LLM completion API. Must be http or https.
+# Defaults to OpenRouter (https://openrouter.ai/api/v1/chat/completions) when unset.
+# Set this to use Ollama cloud, local Ollama, vLLM, or any OpenAI-compatible endpoint.
+#
+# AI_PROVIDER_API_KEY holds the key for whichever provider is configured.
+# For keyless local Ollama, use any non-empty placeholder: AI_PROVIDER_API_KEY=ollama
+#
+# Ollama cloud:  LLM_API_BASE_URL=https://api.ollama.com/v1/chat/completions
+# Local Ollama:  LLM_API_BASE_URL=http://localhost:11434/v1/chat/completions
+#
+# LLM_API_BASE_URL=https://api.ollama.com/v1/chat/completions
+
+# ── Rada models ───────────────────────────────────────────────────────────────────────────────────────────────────────────────
 # Comma-separated list of OpenRouter model IDs for council members.
 # Order is randomised per request to avoid position bias.
 # Provider diversity matters most here — pick one model per family.
@@ -31,8 +44,7 @@ RADA_MODELS=anthropic/claude-sonnet-4.6,openai/gpt-5.4-mini,google/gemini-3.1-fl
 # [3] Development (free) — UI/pipeline iteration only, ranking compliance will vary:
 # RADA_MODELS=google/gemma-4-31b-it:free,nvidia/nemotron-3-super-120b-a12b:free,minimax/minimax-m2.5:free,arcee-ai/trinity-large-preview:free
 
-
-# ── Chairman model ──────────────────────────────────────────────────────────
+# ── Chairman model ────────────────────────────────────────────────────────────────────────────────────────────────────────────
 # Model used to synthesise the Stage 3 final answer.
 # One call per query — use the strongest synthesiser your budget allows.
 # When unset, falls back to openai/gpt-4o-mini (dev fallback, logs a warning).
@@ -48,7 +60,7 @@ CHAIRMAN_MODEL=google/gemini-3.1-pro-preview
 # [3] Development (free):
 # CHAIRMAN_MODEL=google/gemma-4-31b-it:free
 
-# ── Rada behaviour ───────────────────────────────────────────────────────
+# ── Rada behaviour ────────────────────────────────────────────────────────────────────────────────────────────────────────────
 # Rada pipeline to use. Currently only "default" is supported.
 # Default: default
 DEFAULT_RADA_TYPE=default
@@ -57,7 +69,7 @@ DEFAULT_RADA_TYPE=default
 # Range: 0.0 (deterministic) – 2.0 (very creative). Default: 0.7
 DEFAULT_RADA_TEMPERATURE=0.7
 
-# ── Stage 0 clarification ──────────────────────────────────────────────────
+# ── Stage 0 clarification ─────────────────────────────────────────────────────────────────────────────────────────────────────
 # Number of clarification rounds the council asks before answering.
 # Set to 0 to disable Stage 0 entirely. Default: 2
 # CLARIFICATION_MAX_ROUNDS=2
@@ -85,7 +97,7 @@ DEFAULT_RADA_TEMPERATURE=0.7
 # ChairmanModel → error. When unset, Stage 0 uses the council type's chairman.
 # CLARIFICATION_ARBITER_MODEL=anthropic/claude-sonnet-4-5
 
-# ── Majority strategy (independent generation + vote tally) ─────────────────
+# ── Majority strategy (independent generation + vote tally) ───────────────────────────────────────────────────────────────────
 # Setting MAJORITY_MODELS is what registers the "majority" council type at
 # startup. Without this var, the strategy ships compiled-in but is NOT
 # reachable via the API — clients passing council_type="majority" will get
@@ -137,7 +149,7 @@ DEFAULT_RADA_TEMPERATURE=0.7
 # is a future variant.
 # GENERATE_RANK_REFINE_CHAIRMAN_MODEL=anthropic/claude-sonnet-4-5
 
-# ── MultiAgentDebate strategy (rounds of mutual critique + revision) ────────
+# ── MultiAgentDebate strategy (rounds of mutual critique + revision) ──────────────────────────────────────────────────────────
 # Setting BOTH DEBATE_MODELS and DEBATE_CHAIRMAN_MODEL registers the "debate"
 # council type. Like GenerateRankRefine, this strategy has no no-LLM path —
 # every round is an LLM call per surviving debater plus one Stage 3 chairman
@@ -165,7 +177,7 @@ DEFAULT_RADA_TEMPERATURE=0.7
 # Invalid values warn and fall back to the runner default.
 # DEBATE_MAX_ROUNDS=2
 
-# ── MixtureOfAgents strategy (proposers → aggregators → refiner) ────────────
+# ── MixtureOfAgents strategy (proposers → aggregators → refiner) ──────────────────────────────────────────────────────────────
 # Three layers, modelled on the Together AI MoA paper. ALL THREE env vars
 # below MUST be set to register the "moa" council type — partial config logs
 # a warning and skips registration. Unlike every other strategy, RADA_MODELS
@@ -230,32 +242,19 @@ DEFAULT_RADA_TEMPERATURE=0.7
 # Invalid values (≤ 0, ≥ 1.0, non-numeric) warn and fall back to default.
 # DELPHI_CONVERGENCE_THRESHOLD=0.1
 
-# ── Storage ─────────────────────────────────────────────────────────────────
+# ── Storage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 # Directory where conversation JSON files are stored.
 # Created automatically if it does not exist. Default: data/conversations
 DATA_DIR=data/conversations
 
-# ── Server ──────────────────────────────────────────────────────────────────
+# ── Server ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 # TCP port the backend HTTP server listens on. Default: 8001
 PORT=8001
 
-# ── Resilience ──────────────────────────────────────────────────────────────
+# ── Resilience ────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 # Maximum number of retries on transient OpenRouter failures (HTTP 429/502/503/504,
 # network timeouts, EOFs from closed keep-alive connections). 0 disables retries.
 # Backoff schedule: 500ms · 1500ms · 4500ms with ±25% jitter, honouring
 # Retry-After headers (capped at 30s) and a 60s cumulative-sleep budget.
 # Default: 2 (= 3 total attempts).
 # LLM_API_MAX_RETRIES=2
-
-# ── LLM API endpoint ────────────────────────────────────────────────────────
-# Base URL for the LLM completion API. Must be http or https.
-# Defaults to OpenRouter (https://openrouter.ai/api/v1/chat/completions) when unset.
-# Set this to use Ollama cloud, local Ollama, vLLM, or any OpenAI-compatible endpoint.
-#
-# AI_PROVIDER_API_KEY holds the key for whichever provider is configured.
-# For keyless local Ollama, use any non-empty placeholder: AI_PROVIDER_API_KEY=ollama
-#
-# Ollama cloud:  LLM_API_BASE_URL=https://api.ollama.com/v1/chat/completions
-# Local Ollama:  LLM_API_BASE_URL=http://localhost:11434/v1/chat/completions
-#
-# LLM_API_BASE_URL=https://api.ollama.com/v1/chat/completions

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -2,7 +2,7 @@
 
 The `Strategy` enum (`internal/council/types.go`) declares **7 constants — all implemented**. The strategy roadmap is complete.
 
-For architecture context (package layout, layer boundaries, dispatch switch) see [`architecture-v2.md`](./architecture-v2.md). For the academic background of each strategy see [`council-research-synthesis.md`](./council-research-synthesis.md).
+For architecture context (package layout, layer boundaries, dispatch switch) see [`architecture-v2.md`](./architecture-v2.md). For the academic background of each strategy see [`council-research-synthesis.md`](./council-research-synthesis.md). For three hand-picked test prompts per strategy see [`strategy-showcase.md`](./strategy-showcase.md) (machine-readable: `eval/benchmarks/strategy-showcase.yaml`).
 
 Stage 0 (clarification) runs **before** strategy dispatch and is strategy-independent — see the [Stage 0 section in architecture-v2.md](./architecture-v2.md#stage-0-clarification--strategy-independent). It has its own dedicated model configuration (`CLARIFICATION_MODELS`, `CLARIFICATION_ARBITER_MODEL`); see `.env.example`. Both env vars are optional and fall back to the council type's `Models` / `ChairmanModel` when unset.
 

--- a/docs/strategy-showcase.md
+++ b/docs/strategy-showcase.md
@@ -1,0 +1,88 @@
+# Strategy Showcase — Test Prompts
+
+Three test prompts per deliberation strategy, chosen to highlight each strategy's
+deliberation strength. Machine-readable version: `eval/benchmarks/strategy-showcase.yaml`.
+
+---
+
+## PeerReview
+
+*Best when cross-critique between members improves accuracy and depth.*
+
+| # | Prompt |
+|---|--------|
+| peer-001 | Explain the CAP theorem and when you would choose consistency over availability in a distributed system. |
+| peer-002 | What are the key trade-offs between microservices and a monolith? When is each the right architectural choice? |
+| peer-003 | Describe the SOLID principles with a concrete Go example for each one. |
+
+---
+
+## RoleBased
+
+*Best when multiple specialist angles are needed on the same problem.*
+
+| # | Prompt |
+|---|--------|
+| role-001 | We are building a healthcare data platform that stores patient records. What are the critical considerations from technical, legal, security, and UX perspectives? |
+| role-002 | Should a 5-person startup use a managed cloud database or self-host Postgres? Analyse from engineering, cost, operations, and scaling angles. |
+| role-003 | Design a feature flag system for a SaaS product. Cover the API design, data model, rollout mechanics (percentage, user segment), and monitoring/observability. |
+
+---
+
+## Majority
+
+*Best for factual/correctness questions with a clear right answer.*
+
+| # | Prompt |
+|---|--------|
+| maj-001 | What is the time complexity of Dijkstra's algorithm when implemented with a binary min-heap, and why? |
+| maj-002 | Is Redis single-threaded for command execution? Explain the nuance, including how Redis 6+ changed the picture. |
+| maj-003 | What HTTP status code should a REST API return when a resource does not exist versus when the client lacks permission to see it? Explain the security implications of each choice. |
+
+---
+
+## GenerateRankRefine
+
+*Best when quality criteria are clear and the top draft benefits from refinement.*
+
+| # | Prompt |
+|---|--------|
+| grr-001 | Write a Go function that finds all prime numbers up to N using the Sieve of Eratosthenes. Include proper documentation and edge-case handling for N ≤ 1. |
+| grr-002 | Write a concise explanation of how a Bloom filter works, suitable for a technical blog post aimed at junior engineers. Use an analogy and explain the false-positive trade-off. |
+| grr-003 | Write a system design document outline for a URL shortener that handles 10 million stored URLs and 1000 redirects per second. Cover requirements, data model, API, storage choice, and scalability. |
+
+---
+
+## MultiAgentDebate
+
+*Best for contested trade-offs where steel-manning opposing views helps.*
+
+| # | Prompt |
+|---|--------|
+| debate-001 | Is GraphQL always better than REST for new API projects? Make the strongest case for each position, then provide a resolved recommendation with conditions. |
+| debate-002 | Should LLM applications prefer RAG or fine-tuning for incorporating domain-specific knowledge? Debate both approaches and resolve with a decision framework. |
+| debate-003 | Is Kubernetes overkill for a team of 5 engineers? Present and rigorously critique both positions, then recommend a threshold for when Kubernetes becomes the right choice. |
+
+---
+
+## MixtureOfAgents
+
+*Best for code generation and layered multi-aspect analysis.*
+
+| # | Prompt |
+|---|--------|
+| moa-001 | Write a production-ready Go HTTP middleware that handles rate limiting (token bucket, per-IP), structured request logging (slog), and panic recovery with stack trace capture. The middleware must be composable and testable. |
+| moa-002 | Design and implement an in-memory task queue in Go using only the standard library. Cover: public API, fixed-size worker pool, task retry with exponential backoff, and graceful shutdown via context cancellation. |
+| moa-003 | Analyse the trade-offs between event sourcing and traditional CRUD for a financial ledger system. Cover consistency guarantees, auditability, query complexity, storage growth, and operational burden. Conclude with a recommendation. |
+
+---
+
+## Delphi
+
+*Best for estimation, forecasting, and collective judgment converging to consensus.*
+
+| # | Prompt |
+|---|--------|
+| delphi-001 | Estimate the engineering effort (person-weeks) to migrate a 100 000-line Python monolith to Go microservices. Provide a range (optimistic / realistic / pessimistic) with your key assumptions explicitly stated. |
+| delphi-002 | Rate the production readiness of SQLite as the primary database for a B2B SaaS with 10 000 active users and 50 writes per second on a scale of 0–10. Justify your score with specific criteria. |
+| delphi-003 | How many years from now (mid-2026) until LLMs can autonomously complete a two-week greenfield software project at senior-engineer quality, without human intervention? Provide a range and your reasoning. |

--- a/eval/benchmarks/strategy-showcase.yaml
+++ b/eval/benchmarks/strategy-showcase.yaml
@@ -1,0 +1,308 @@
+# Strategy Showcase — one benchmark file per deliberation strategy.
+# Purpose: smoke-test each strategy's deliberation strength with prompts
+# specifically chosen to highlight what that strategy does best.
+#
+# Schema matches eval/benchmark.go BenchmarkItem:
+#   id:       unique identifier (strategy-NNN)
+#   category: code | analysis | factual | creative | estimation
+#   strategy: which council strategy this prompt is designed for
+#   question: the prompt sent to the council
+#   rubric:   (optional) scoring guidance for the meta-judge
+
+# ── PeerReview ────────────────────────────────────────────────────────────────
+# Best when cross-critique between members improves accuracy and depth.
+
+- id: peer-001
+  category: analysis
+  strategy: peer_review
+  question: >
+    Explain the CAP theorem and when you would choose consistency over
+    availability in a distributed system.
+  rubric: >
+    Award full marks for correctly defining all three CAP properties,
+    explaining the consistency-availability trade-off under network
+    partition, and giving concrete examples (e.g. banking vs. DNS).
+    Deduct for conflating CP/AP systems or omitting the partition
+    assumption.
+
+- id: peer-002
+  category: analysis
+  strategy: peer_review
+  question: >
+    What are the key trade-offs between microservices and a monolith?
+    When is each the right architectural choice?
+  rubric: >
+    Full marks: addresses operational complexity, deployment overhead,
+    team coupling, latency, and gives clear guidance on team/scale
+    thresholds. Penalise dogmatic "microservices always win" answers.
+
+- id: peer-003
+  category: analysis
+  strategy: peer_review
+  question: >
+    Describe the SOLID principles with a concrete Go example for each one.
+  rubric: >
+    Must cover all five principles with working (or clearly correct)
+    Go code snippets. Deduct for generic OOP examples that don't
+    account for Go's interface-based composition model.
+
+# ── RoleBased ─────────────────────────────────────────────────────────────────
+# Best when multiple specialist angles are needed on the same problem.
+
+- id: role-001
+  category: analysis
+  strategy: role_based
+  question: >
+    We are building a healthcare data platform that stores patient records.
+    What are the critical considerations from technical, legal, security,
+    and UX perspectives?
+  rubric: >
+    Full marks: covers HIPAA/GDPR compliance, encryption at rest and
+    in transit, audit logging, access control, UI accessibility, and
+    at least one concrete technical recommendation per domain. Penalise
+    for missing the regulatory angle entirely.
+
+- id: role-002
+  category: analysis
+  strategy: role_based
+  question: >
+    Should a 5-person startup use a managed cloud database (e.g. RDS,
+    PlanetScale) or self-host Postgres? Analyse from engineering,
+    cost, operations, and scaling angles.
+  rubric: >
+    Must address at least four dimensions: initial cost, operational
+    burden, scaling ceiling, team expertise requirement. A clear
+    recommendation with stated assumptions is required for full marks.
+
+- id: role-003
+  category: analysis
+  strategy: role_based
+  question: >
+    Design a feature flag system for a SaaS product. Cover the API
+    design, data model, rollout mechanics (percentage, user segment),
+    and monitoring/observability.
+  rubric: >
+    Full marks for a concrete API (endpoints or SDK surface), a viable
+    data model (flags, rules, targeting), at least one rollout
+    strategy beyond simple on/off, and a monitoring approach
+    (flag evaluation latency, stale flag detection).
+
+# ── Majority ──────────────────────────────────────────────────────────────────
+# Best for factual/correctness questions with a clear right answer.
+
+- id: maj-001
+  category: factual
+  strategy: majority
+  question: >
+    What is the time complexity of Dijkstra's algorithm when implemented
+    with a binary min-heap, and why?
+  rubric: >
+    Correct answer: O((V + E) log V). Must explain that each vertex is
+    extracted once (V log V) and each edge relaxation is a heap
+    decrease-key (E log V). Penalise for stating O(V²) without
+    qualifying that as the naive adjacency-matrix variant.
+
+- id: maj-002
+  category: factual
+  strategy: majority
+  question: >
+    Is Redis single-threaded for command execution? Explain the nuance,
+    including how Redis 6+ changed the picture.
+  rubric: >
+    Full marks: yes for the command execution loop (single-threaded
+    event loop); Redis 6+ added threaded I/O for reading/writing
+    network data while keeping command processing single-threaded.
+    Penalise for a flat yes/no without the I/O threading nuance.
+
+- id: maj-003
+  category: factual
+  strategy: majority
+  question: >
+    What HTTP status code should a REST API return when a resource does
+    not exist versus when the client lacks permission to see it? Explain
+    the security implications of each choice.
+  rubric: >
+    404 for not-found, 403 for forbidden (when the resource exists but
+    access is denied), 404 also acceptable for forbidden to avoid
+    resource enumeration. Must acknowledge the security trade-off
+    (information leakage vs. usability). 401 vs 403 distinction a bonus.
+
+# ── GenerateRankRefine ────────────────────────────────────────────────────────
+# Best when quality criteria are clear and top draft benefits from refinement.
+
+- id: grr-001
+  category: code
+  strategy: generate_rank_refine
+  question: >
+    Write a Go function that finds all prime numbers up to N using the
+    Sieve of Eratosthenes. Include proper documentation and edge-case
+    handling for N ≤ 1.
+  rubric: >
+    Full marks: correct algorithm, O(N log log N) complexity, handles
+    N ≤ 1 gracefully, idiomatic Go (named return or clear variable
+    naming, doc comment). Penalise for trial division masquerading
+    as a sieve, or for panics on edge cases.
+
+- id: grr-002
+  category: creative
+  strategy: generate_rank_refine
+  question: >
+    Write a concise explanation of how a Bloom filter works, suitable
+    for a technical blog post aimed at junior engineers. Use an analogy
+    and explain the false-positive trade-off.
+  rubric: >
+    Must include: what a Bloom filter is (probabilistic set membership),
+    an accessible analogy, explanation of false positives vs. false
+    negatives, and at least one real-world use case. Penalise for
+    mathematical notation without plain-English translation.
+
+- id: grr-003
+  category: analysis
+  strategy: generate_rank_refine
+  question: >
+    Write a system design document outline for a URL shortener that
+    handles 10 million stored URLs and 1000 redirects per second.
+    Cover: requirements, data model, API, storage choice, and
+    scalability considerations.
+  rubric: >
+    Full marks: clear functional/non-functional requirements, a viable
+    data model (ID → URL mapping), a redirect API endpoint, a
+    justified storage choice (Redis + Postgres is canonical), and
+    at least one horizontal scaling approach. Penalise for designs
+    that cannot reach the stated RPS.
+
+# ── MultiAgentDebate ──────────────────────────────────────────────────────────
+# Best for contested trade-offs where steel-manning opposing views helps.
+
+- id: debate-001
+  category: analysis
+  strategy: multi_agent_debate
+  question: >
+    Is GraphQL always better than REST for new API projects? Make the
+    strongest case for each position, then provide a resolved
+    recommendation with conditions.
+  rubric: >
+    Full marks: genuine steel-man of both sides (REST: simplicity,
+    caching, tooling; GraphQL: flexibility, underfetch/overfetch
+    elimination). Penalise if the "debate" is one-sided or the
+    resolution lacks concrete conditions (e.g. team size, client
+    diversity, caching requirements).
+
+- id: debate-002
+  category: analysis
+  strategy: multi_agent_debate
+  question: >
+    Should LLM applications prefer RAG or fine-tuning for incorporating
+    domain-specific knowledge? Debate both approaches and resolve
+    with a decision framework.
+  rubric: >
+    Must cover: RAG (up-to-date knowledge, lower cost, interpretable)
+    vs. fine-tuning (latency, no retrieval infra, style alignment).
+    Resolution should include a decision framework (data freshness,
+    budget, latency budget). Penalise for ignoring hybrid approaches.
+
+- id: debate-003
+  category: analysis
+  strategy: multi_agent_debate
+  question: >
+    Is Kubernetes overkill for a team of 5 engineers? Present and
+    rigorously critique both positions, then recommend a threshold
+    for when Kubernetes becomes the right choice.
+  rubric: >
+    Pro-K8s: standardisation, ecosystem, self-healing. Anti-K8s:
+    operational complexity, learning curve, cost at small scale.
+    Resolution must include a concrete threshold (team size, service
+    count, or traffic pattern). Penalise for vague "it depends"
+    without actionable criteria.
+
+# ── MixtureOfAgents ───────────────────────────────────────────────────────────
+# Best for code generation and layered multi-aspect analysis.
+
+- id: moa-001
+  category: code
+  strategy: mixture_of_agents
+  question: >
+    Write a production-ready Go HTTP middleware that handles rate
+    limiting (token bucket, per-IP), structured request logging
+    (slog), and panic recovery with stack trace capture. The
+    middleware must be composable and testable.
+  rubric: >
+    Full marks: correct token bucket implementation (or use of
+    golang.org/x/time/rate), slog-based logging with request ID
+    propagation, panic recovery that does not swallow the stack
+    trace, and clear interface for composability. Penalise for
+    global state or non-testable designs.
+
+- id: moa-002
+  category: code
+  strategy: mixture_of_agents
+  question: >
+    Design and implement an in-memory task queue in Go using only the
+    standard library. Cover: the public API, a fixed-size worker
+    pool, task retry with exponential backoff, and graceful shutdown
+    via context cancellation.
+  rubric: >
+    Must have a clean public API (Submit, Shutdown), correct worker
+    pool with no goroutine leaks, retry logic with backoff (not busy
+    loop), and graceful shutdown that drains in-flight tasks before
+    returning. Penalise for data races (verified via -race).
+
+- id: moa-003
+  category: analysis
+  strategy: mixture_of_agents
+  question: >
+    Analyse the trade-offs between event sourcing and traditional CRUD
+    for a financial ledger system. Cover: consistency guarantees,
+    auditability, query complexity, storage growth, and operational
+    burden. Conclude with a recommendation.
+  rubric: >
+    Full marks: addresses all five dimensions with concrete examples
+    (e.g. CQRS read models for event sourcing, snapshot strategies
+    for storage growth). Recommendation must be conditional on stated
+    constraints. Penalise for treating event sourcing as universally
+    superior.
+
+# ── Delphi ────────────────────────────────────────────────────────────────────
+# Best for estimation, forecasting, and collective judgment converging to consensus.
+
+- id: delphi-001
+  category: estimation
+  strategy: delphi
+  question: >
+    Estimate the engineering effort (person-weeks) to migrate a
+    100 000-line Python monolith to Go microservices. Provide a range
+    (optimistic / realistic / pessimistic) with your key assumptions
+    explicitly stated.
+  rubric: >
+    Full marks: a range (not a single point), explicit assumptions
+    (team size, test coverage, domain complexity, rewrite vs.
+    strangler fig), and at least one major risk factor. Penalise
+    for a single number without a range or for omitting assumptions.
+
+- id: delphi-002
+  category: estimation
+  strategy: delphi
+  question: >
+    Rate the production readiness of SQLite as the primary database
+    for a B2B SaaS with 10 000 active users and 50 writes per second
+    on a scale of 0–10. Justify your score with specific criteria.
+  rubric: >
+    A score alone is insufficient — must justify with concrete
+    criteria (write concurrency, WAL mode, backup complexity,
+    replication absence). Scores 4–7 are defensible with
+    appropriate caveats; 0–3 or 8–10 require strong reasoning.
+
+- id: delphi-003
+  category: estimation
+  strategy: delphi
+  question: >
+    How many years from now (mid-2026) until LLMs can autonomously
+    complete a two-week greenfield software project at senior-engineer
+    quality, without human intervention? Provide a range and your
+    reasoning.
+  rubric: >
+    Full marks: a range (not a single year), reasoning that addresses
+    current capability gaps (long-horizon planning, debugging
+    feedback loops, non-determinism), and at least one named
+    capability milestone required before the threshold is reached.
+    Penalise for unfounded certainty in either direction.


### PR DESCRIPTION
## Summary

- `eval/benchmarks/strategy-showcase.yaml` — 21 test prompts (3 per strategy), each with a scoring rubric, covering all 7 deliberation strategies
- `docs/strategy-showcase.md` — human-readable markdown companion
- `docs/strategies.md` — cross-link added to showcase
- Two new Tech Lead agent memory files from planning sessions (circuit breaker, eval harness)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] YAML well-formed (21 items, 3 per strategy, all IDs unique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)