### PR TITLE
⚖️ feat(openrouter,council): circuit breaker for LLM client

### DIFF
--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -191,7 +191,12 @@ func run() error {
 		return fmt.Errorf("unknown council type %q (known: %v)", *councilType, knownTypes(registry))
 	}
 
-	client := openrouter.NewClient(cfg.ProviderAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger)
+	cb := openrouter.NewCircuitBreaker(openrouter.CircuitBreakerConfig{
+		FailureThreshold: cfg.CBFailureThreshold,
+		WindowDuration:   time.Duration(cfg.CBWindowDurationSecs) * time.Second,
+		ResetTimeout:     time.Duration(cfg.CBResetTimeoutSecs) * time.Second,
+	})
+	client := openrouter.NewClient(cfg.ProviderAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger, cb)
 	runner := council.NewCouncil(client, registry, logger)
 
 	// Honour SIGINT / SIGTERM mid-run — the harness is sequential, so

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -146,7 +146,12 @@ func main() {
 		}
 	}
 
-	client := openrouter.NewClient(cfg.ProviderAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger)
+	cb := openrouter.NewCircuitBreaker(openrouter.CircuitBreakerConfig{
+		FailureThreshold: cfg.CBFailureThreshold,
+		WindowDuration:   time.Duration(cfg.CBWindowDurationSecs) * time.Second,
+		ResetTimeout:     time.Duration(cfg.CBResetTimeoutSecs) * time.Second,
+	})
+	client := openrouter.NewClient(cfg.ProviderAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger, cb)
 	runner := council.NewCouncil(client, registry, logger)
 
 	store, err := storage.NewStore(cfg.DataDir, logger)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,14 @@ type Config struct {
 	// on transient failures (HTTP 429/502/503/504, network timeouts, EOFs).
 	// 0 disables retries. Default: 2 (3 total attempts including the initial).
 	LLMAPIMaxRetries int
+
+	// Circuit breaker parameters. Invalid values warn and fall back to defaults.
+	// CBFailureThreshold: consecutive terminal failures before opening. Default 5.
+	// CBWindowDurationSecs: sliding failure-count window in seconds. Default 60.
+	// CBResetTimeoutSecs: seconds in open state before a probe is allowed. Default 30.
+	CBFailureThreshold    int
+	CBWindowDurationSecs  int
+	CBResetTimeoutSecs    int
 }
 
 // Load reads configuration from environment variables and returns an error if
@@ -339,6 +347,36 @@ func Load() (*Config, error) {
 		}
 	}
 
+	cbFailureThreshold := 5
+	if raw := os.Getenv("LLM_CB_FAILURE_THRESHOLD"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			cbFailureThreshold = v
+		} else {
+			slog.Warn("LLM_CB_FAILURE_THRESHOLD is invalid; using fallback value",
+				"value", raw, "fallback", cbFailureThreshold)
+		}
+	}
+
+	cbWindowDurationSecs := 60
+	if raw := os.Getenv("LLM_CB_WINDOW_DURATION_SECS"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			cbWindowDurationSecs = v
+		} else {
+			slog.Warn("LLM_CB_WINDOW_DURATION_SECS is invalid; using fallback value",
+				"value", raw, "fallback", cbWindowDurationSecs)
+		}
+	}
+
+	cbResetTimeoutSecs := 30
+	if raw := os.Getenv("LLM_CB_RESET_TIMEOUT_SECS"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			cbResetTimeoutSecs = v
+		} else {
+			slog.Warn("LLM_CB_RESET_TIMEOUT_SECS is invalid; using fallback value",
+				"value", raw, "fallback", cbResetTimeoutSecs)
+		}
+	}
+
 	return &Config{
 		ProviderName:                providerName,
 		ProviderAPIKey:              apiKey,
@@ -376,5 +414,9 @@ func Load() (*Config, error) {
 		DelphiConvergenceThreshold: delphiConvergenceThreshold,
 
 		LLMAPIMaxRetries: llmAPIMaxRetries,
+
+		CBFailureThreshold:   cbFailureThreshold,
+		CBWindowDurationSecs: cbWindowDurationSecs,
+		CBResetTimeoutSecs:   cbResetTimeoutSecs,
 	}, nil
 }

--- a/internal/council/council.go
+++ b/internal/council/council.go
@@ -1,28 +1,43 @@
 package council
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 )
 
+// ErrCircuitOpen is returned by LLMClient.Complete when the circuit breaker is
+// open and the call is rejected without an HTTP attempt. Defined here so both
+// the openrouter implementation and the council runner can reference it without
+// a circular import.
+var ErrCircuitOpen = errors.New("circuit breaker open")
+
 // QuorumError is returned when not enough council members responded successfully.
 type QuorumError struct {
-	Got  int
-	Need int
+	Got    int
+	Need   int
+	Reason string // "provider circuit open" when all failures are ErrCircuitOpen; empty otherwise
 }
 
 func (e *QuorumError) Error() string {
+	if e.Reason != "" {
+		return fmt.Sprintf("council quorum not met: got %d successful responses, need %d (%s)", e.Got, e.Need, e.Reason)
+	}
 	return fmt.Sprintf("council quorum not met: got %d successful responses, need %d", e.Got, e.Need)
 }
 
 // checkQuorum filters results to successful entries and verifies the minimum quorum.
 // M_min = max(2, ⌈N/2⌉+1) where N = len(results), unless minQuorum > 0 overrides it.
 // Returns the successful subset or *QuorumError if the threshold is not met.
+// QuorumError.Reason is set to "provider circuit open" when every failed member
+// returned ErrCircuitOpen.
 func checkQuorum(results []StageOneResult, minQuorum int) ([]StageOneResult, error) {
-	var successful []StageOneResult
+	var successful, failed []StageOneResult
 	for _, r := range results {
 		if r.Error == nil {
 			successful = append(successful, r)
+		} else {
+			failed = append(failed, r)
 		}
 	}
 	n := len(results)
@@ -31,9 +46,27 @@ func checkQuorum(results []StageOneResult, minQuorum int) ([]StageOneResult, err
 		need = max(2, (n+1)/2+1) // ⌈N/2⌉ = (N+1)/2 in integer arithmetic
 	}
 	if len(successful) < need {
-		return nil, &QuorumError{Got: len(successful), Need: need}
+		qe := &QuorumError{Got: len(successful), Need: need}
+		if allCircuitOpen(failed) {
+			qe.Reason = "provider circuit open"
+		}
+		return nil, qe
 	}
 	return successful, nil
+}
+
+// allCircuitOpen returns true when every entry in failed has ErrCircuitOpen as
+// its error. Returns false for an empty slice (no failures ≠ all circuit open).
+func allCircuitOpen(failed []StageOneResult) bool {
+	if len(failed) == 0 {
+		return false
+	}
+	for _, r := range failed {
+		if !errors.Is(r.Error, ErrCircuitOpen) {
+			return false
+		}
+	}
+	return true
 }
 
 // assignLabels assigns anonymous labels to models using a per-request random shuffle.

--- a/internal/openrouter/circuitbreaker.go
+++ b/internal/openrouter/circuitbreaker.go
@@ -1,0 +1,114 @@
+package openrouter
+
+import (
+	"sync"
+	"time"
+)
+
+type cbState int
+
+const (
+	cbClosed   cbState = iota
+	cbOpen
+	cbHalfOpen
+)
+
+// CircuitBreakerConfig holds the tuneable parameters for the circuit breaker.
+type CircuitBreakerConfig struct {
+	FailureThreshold int
+	WindowDuration   time.Duration
+	ResetTimeout     time.Duration
+}
+
+// CircuitBreaker implements the three-state (closed → open → half-open → closed)
+// pattern with a sliding-window failure counter. All methods are safe for
+// concurrent use.
+//
+// Transition rules:
+//   - closed → open:      FailureThreshold terminal failures within WindowDuration
+//   - open → half-open:   ResetTimeout elapsed since the circuit opened
+//   - half-open → closed: one successful probe
+//   - half-open → open:   one failed probe
+type CircuitBreaker struct {
+	cfg         CircuitBreakerConfig
+	mu          sync.Mutex
+	state       cbState
+	failures    int
+	windowStart time.Time
+	openedAt    time.Time
+}
+
+// NewCircuitBreaker constructs a CircuitBreaker in the closed state.
+func NewCircuitBreaker(cfg CircuitBreakerConfig) *CircuitBreaker {
+	return &CircuitBreaker{
+		cfg:         cfg,
+		state:       cbClosed,
+		windowStart: time.Now(),
+	}
+}
+
+// Allow reports whether a request should be attempted.
+//   - Closed: always allowed.
+//   - Open: denied unless ResetTimeout has elapsed, in which case the circuit
+//     moves to half-open and one probe is allowed.
+//   - Half-open: denied — only one probe is allowed at a time; subsequent calls
+//     must wait for the probe to succeed or fail before the state changes.
+func (cb *CircuitBreaker) Allow() bool {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	switch cb.state {
+	case cbClosed:
+		return true
+	case cbOpen:
+		if time.Since(cb.openedAt) >= cb.cfg.ResetTimeout {
+			cb.state = cbHalfOpen
+			return true
+		}
+		return false
+	case cbHalfOpen:
+		return false
+	}
+	return false
+}
+
+// RecordSuccess records a successful terminal outcome.
+// In half-open: closes the circuit and resets the failure window.
+// In closed: no-op (success does not affect the failure counter).
+func (cb *CircuitBreaker) RecordSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	if cb.state == cbHalfOpen {
+		cb.state = cbClosed
+		cb.failures = 0
+		cb.windowStart = time.Now()
+	}
+}
+
+// RecordFailure records a terminal failure (retries exhausted or non-retryable
+// error). Per-attempt errors must NOT be recorded here; only call this when the
+// entire Complete() call gives up.
+//
+// In closed: increments the sliding-window counter; opens the circuit when
+// FailureThreshold is reached. Resets the window if WindowDuration has elapsed.
+// In half-open: re-opens the circuit immediately.
+// In open: no-op (already open).
+func (cb *CircuitBreaker) RecordFailure() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	switch cb.state {
+	case cbClosed:
+		now := time.Now()
+		if now.Sub(cb.windowStart) >= cb.cfg.WindowDuration {
+			cb.failures = 0
+			cb.windowStart = now
+		}
+		cb.failures++
+		if cb.failures >= cb.cfg.FailureThreshold {
+			cb.state = cbOpen
+			cb.openedAt = now
+		}
+	case cbHalfOpen:
+		cb.state = cbOpen
+		cb.openedAt = time.Now()
+	}
+}

--- a/internal/openrouter/circuitbreaker_test.go
+++ b/internal/openrouter/circuitbreaker_test.go
@@ -1,0 +1,103 @@
+package openrouter
+
+import (
+	"testing"
+	"time"
+)
+
+func testCBConfig(threshold int, window, reset time.Duration) CircuitBreakerConfig {
+	return CircuitBreakerConfig{
+		FailureThreshold: threshold,
+		WindowDuration:   window,
+		ResetTimeout:     reset,
+	}
+}
+
+// TestCB_InitialState_Allows verifies the circuit starts closed and allows calls.
+func TestCB_InitialState_Allows(t *testing.T) {
+	cb := NewCircuitBreaker(testCBConfig(3, time.Minute, time.Minute))
+	if !cb.Allow() {
+		t.Error("new circuit breaker should allow requests")
+	}
+}
+
+// TestCB_OpenAfterThreshold verifies the circuit opens after FailureThreshold failures.
+func TestCB_OpenAfterThreshold(t *testing.T) {
+	cb := NewCircuitBreaker(testCBConfig(3, time.Minute, time.Minute))
+	for i := range 2 {
+		cb.RecordFailure()
+		if !cb.Allow() {
+			t.Errorf("circuit should still be closed after %d failures", i+1)
+		}
+	}
+	cb.RecordFailure() // 3rd failure — should open
+	if cb.Allow() {
+		t.Error("circuit should be open after reaching threshold")
+	}
+}
+
+// TestCB_BlocksWhenOpen verifies that an open circuit rejects all calls.
+func TestCB_BlocksWhenOpen(t *testing.T) {
+	cb := NewCircuitBreaker(testCBConfig(1, time.Minute, time.Hour))
+	cb.RecordFailure()
+	for range 5 {
+		if cb.Allow() {
+			t.Error("open circuit should block requests")
+		}
+	}
+}
+
+// TestCB_TransitionsToHalfOpenAfterReset verifies the circuit moves to half-open
+// after ResetTimeout and allows one probe.
+func TestCB_TransitionsToHalfOpenAfterReset(t *testing.T) {
+	cb := NewCircuitBreaker(testCBConfig(1, time.Minute, 10*time.Millisecond))
+	cb.RecordFailure() // open
+	if cb.Allow() {
+		t.Fatal("circuit should be open immediately after failure")
+	}
+	time.Sleep(20 * time.Millisecond)
+	if !cb.Allow() {
+		t.Error("circuit should allow one probe after reset timeout")
+	}
+	// Second call while half-open: denied
+	if cb.Allow() {
+		t.Error("circuit should deny second call in half-open state")
+	}
+}
+
+// TestCB_HalfOpen_SuccessCloses verifies a successful probe closes the circuit.
+func TestCB_HalfOpen_SuccessCloses(t *testing.T) {
+	cb := NewCircuitBreaker(testCBConfig(1, time.Minute, 10*time.Millisecond))
+	cb.RecordFailure()
+	time.Sleep(20 * time.Millisecond)
+	cb.Allow() // move to half-open
+	cb.RecordSuccess()
+	if !cb.Allow() {
+		t.Error("circuit should be closed after successful probe")
+	}
+}
+
+// TestCB_HalfOpen_FailureReopens verifies a failed probe re-opens the circuit.
+func TestCB_HalfOpen_FailureReopens(t *testing.T) {
+	cb := NewCircuitBreaker(testCBConfig(1, time.Minute, 10*time.Millisecond))
+	cb.RecordFailure()
+	time.Sleep(20 * time.Millisecond)
+	cb.Allow() // move to half-open
+	cb.RecordFailure()
+	if cb.Allow() {
+		t.Error("circuit should be open after failed probe")
+	}
+}
+
+// TestCB_WindowReset verifies the failure counter resets when the window expires.
+func TestCB_WindowReset(t *testing.T) {
+	cb := NewCircuitBreaker(testCBConfig(3, 20*time.Millisecond, time.Hour))
+	cb.RecordFailure()
+	cb.RecordFailure() // 2 of 3 — still closed
+	time.Sleep(30 * time.Millisecond)
+	// Window expired — next failure starts a fresh window
+	cb.RecordFailure() // 1 of 3 in new window
+	if !cb.Allow() {
+		t.Error("circuit should still be closed after window reset")
+	}
+}

--- a/internal/openrouter/client.go
+++ b/internal/openrouter/client.go
@@ -49,6 +49,7 @@ type Client struct {
 	http       *http.Client
 	maxRetries int          // total retries (1 initial attempt + maxRetries retries)
 	logger     *slog.Logger // never nil — NewClient substitutes slog.Default()
+	cb         *CircuitBreaker // optional; nil disables circuit breaking
 
 	// retryBaseDelay is the first attempt's nominal backoff. Per-Client so tests
 	// can shrink it without mutating package-level state and breaking parallel runs.
@@ -61,10 +62,11 @@ type Client struct {
 }
 
 // NewClient creates a Client with the given API key, base URL, HTTP timeout,
-// retry budget, and logger. baseURL overrides the default OpenRouter endpoint;
-// pass "" to use the default. maxRetries of 0 means a single attempt (no
-// retries). A nil logger falls back to slog.Default().
-func NewClient(apiKey, baseURL string, timeout time.Duration, maxRetries int, logger *slog.Logger) *Client {
+// retry budget, logger, and optional circuit breaker. baseURL overrides the
+// default OpenRouter endpoint; pass "" to use the default. maxRetries of 0
+// means a single attempt (no retries). A nil logger falls back to
+// slog.Default(). A nil cb disables circuit breaking.
+func NewClient(apiKey, baseURL string, timeout time.Duration, maxRetries int, logger *slog.Logger, cb *CircuitBreaker) *Client {
 	if baseURL == "" {
 		baseURL = defaultURL
 	}
@@ -80,6 +82,7 @@ func NewClient(apiKey, baseURL string, timeout time.Duration, maxRetries int, lo
 		http:                         &http.Client{Timeout: timeout},
 		maxRetries:                   maxRetries,
 		logger:                       logger,
+		cb:                           cb,
 		retryBaseDelay:               defaultRetryBaseDelay,
 		maxCumulativeBackoffDuration: defaultMaxCumulativeBackoffDuration,
 	}
@@ -93,7 +96,14 @@ var _ council.LLMClient = (*Client)(nil)
 // exponential backoff and ±25% jitter, honoring Retry-After headers (capped at
 // 30 s) and a cumulative 60 s sleep budget. Returns *APIError on non-200
 // responses after retries are exhausted.
+//
+// If a circuit breaker is configured and open, Complete returns council.ErrCircuitOpen
+// immediately without making an HTTP call.
 func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (council.CompletionResponse, error) {
+	if c.cb != nil && !c.cb.Allow() {
+		return council.CompletionResponse{}, council.ErrCircuitOpen
+	}
+
 	body, err := json.Marshal(req)
 	if err != nil {
 		return council.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
@@ -121,10 +131,17 @@ func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (c
 					c.logger.Info("openrouter: failed after retries",
 						"attempts", attempt+1, "final_error", finalErr)
 				}
+				if c.cb != nil {
+					c.cb.RecordFailure()
+				}
 				return council.CompletionResponse{}, finalErr
 			}
 			// Successful 200 + decoded body.
-			return c.decodeBody(resp)
+			result, decErr := c.decodeBody(resp)
+			if decErr == nil && c.cb != nil {
+				c.cb.RecordSuccess()
+			}
+			return result, decErr
 		}
 
 		// Retryable. lastErr always tracks the most recent reason for retry so
@@ -139,6 +156,9 @@ func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (c
 			}
 			c.logger.Info("openrouter: retries exhausted",
 				"attempts", attempt+1, "final_error", lastErr)
+			if c.cb != nil {
+				c.cb.RecordFailure()
+			}
 			return council.CompletionResponse{}, lastErr
 		}
 
@@ -147,6 +167,9 @@ func (c *Client) Complete(ctx context.Context, req council.CompletionRequest) (c
 			c.logger.Info("openrouter: cumulative backoff cap reached",
 				"cumulative_ms", cumulativeBackoff.Milliseconds(),
 				"final_error", lastErr)
+			if c.cb != nil {
+				c.cb.RecordFailure()
+			}
 			return council.CompletionResponse{}, lastErr
 		}
 		cumulativeBackoff += delay

--- a/internal/openrouter/client_test.go
+++ b/internal/openrouter/client_test.go
@@ -234,7 +234,7 @@ func TestComplete_ResponseFormatForwarded(t *testing.T) {
 // ── TestNewClient ─────────────────────────────────────────────────────────────
 
 func TestNewClient_DefaultURL(t *testing.T) {
-	c := NewClient("my-key", "", 30*time.Second, 2, nil)
+	c := NewClient("my-key", "", 30*time.Second, 2, nil, nil)
 	if c.apiKey != "my-key" {
 		t.Errorf("apiKey: got %q, want %q", c.apiKey, "my-key")
 	}
@@ -254,7 +254,7 @@ func TestNewClient_DefaultURL(t *testing.T) {
 
 func TestNewClient_CustomURL(t *testing.T) {
 	const custom = "http://localhost:11434/v1/chat/completions"
-	c := NewClient("ollama", custom, 10*time.Second, 0, nil)
+	c := NewClient("ollama", custom, 10*time.Second, 0, nil, nil)
 	if c.baseURL != custom {
 		t.Errorf("baseURL: got %q, want %q", c.baseURL, custom)
 	}
@@ -264,7 +264,7 @@ func TestNewClient_CustomURL(t *testing.T) {
 }
 
 func TestNewClient_NegativeRetriesClampedToZero(t *testing.T) {
-	c := NewClient("k", "", time.Second, -5, nil)
+	c := NewClient("k", "", time.Second, -5, nil, nil)
 	if c.maxRetries != 0 {
 		t.Errorf("maxRetries: got %d, want 0 (clamped)", c.maxRetries)
 	}
@@ -651,5 +651,82 @@ func TestIsRetriableStatus(t *testing.T) {
 				t.Errorf("isRetriableStatus(%d) = %v, want %v", tc.code, got, tc.want)
 			}
 		})
+	}
+}
+
+// ── Circuit breaker smoke tests ───────────────────────────────────────────────
+
+// TestComplete_CircuitOpen_FailsFast verifies Complete returns council.ErrCircuitOpen
+// immediately (no HTTP call) when the circuit breaker is open.
+func TestComplete_CircuitOpen_FailsFast(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		writeJSON(w, mockCompletion{Choices: []struct {
+			Message struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+		}{{Message: struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		}{Role: "assistant", Content: "hello"}}}})
+	}))
+	defer srv.Close()
+
+	cb := NewCircuitBreaker(CircuitBreakerConfig{
+		FailureThreshold: 1,
+		WindowDuration:   time.Minute,
+		ResetTimeout:     time.Hour,
+	})
+	cb.RecordFailure() // force open
+
+	c := testClient("key", srv)
+	c.cb = cb
+
+	_, err := c.Complete(context.Background(), council.CompletionRequest{Model: "m"})
+	if !errors.Is(err, council.ErrCircuitOpen) {
+		t.Errorf("want council.ErrCircuitOpen, got %v", err)
+	}
+	if called {
+		t.Error("HTTP server should not have been called when circuit is open")
+	}
+}
+
+// TestComplete_CircuitClosed_RecordsSuccess verifies a successful call transitions
+// the CB through half-open to closed.
+func TestComplete_CircuitClosed_RecordsSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, mockCompletion{Choices: []struct {
+			Message struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+		}{{Message: struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		}{Role: "assistant", Content: "ok"}}}})
+	}))
+	defer srv.Close()
+
+	cb := NewCircuitBreaker(CircuitBreakerConfig{
+		FailureThreshold: 1,
+		WindowDuration:   time.Minute,
+		ResetTimeout:     10 * time.Millisecond,
+	})
+	cb.RecordFailure() // open
+	time.Sleep(20 * time.Millisecond)
+	// Now in half-open — one probe allowed.
+
+	c := testClient("key", srv)
+	c.cb = cb
+
+	_, err := c.Complete(context.Background(), council.CompletionRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// CB should now be closed — allow a second call.
+	if !cb.Allow() {
+		t.Error("circuit should be closed after successful probe")
 	}
 }


### PR DESCRIPTION
## Summary

- `ErrCircuitOpen` sentinel defined in `internal/council` (interface contract — no layer violation)
- Three-state circuit breaker: closed → open → half-open → closed with sliding-window failure counting
- `Client.Complete()` fails-fast with `ErrCircuitOpen` when circuit is open (no HTTP call)
- `RecordFailure` on terminal outcomes only (retries exhausted / non-retryable); `RecordSuccess` in half-open→closed
- `QuorumError.Reason` = `"provider circuit open"` when all failed stage-1 members hit the circuit breaker; existing `*QuorumError → 503` handler path fires unchanged
- 3 env vars with warn+fallback: `LLM_CB_FAILURE_THRESHOLD` (5), `LLM_CB_WINDOW_DURATION_SECS` (60), `LLM_CB_RESET_TIMEOUT_SECS` (30)
- `internal/api/handler.go` untouched — no new imports

Closes #230

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes — 323 tests (7 CB unit + 2 client smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)