### PR TITLE
⚡ feat(config): log AI_PROVIDER_NAME at server and eval startup

### DIFF
--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -66,6 +66,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+	logger.Info("LLM provider", "name", cfg.ProviderName, "base_url", cfg.LLMBaseURL)
 
 	// Default judge to chairman if -judge-model was not provided.
 	jModel := *judgeModel

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -33,6 +33,7 @@ func main() {
 		logger.Error("configuration error", "error", err)
 		os.Exit(1)
 	}
+	logger.Info("LLM provider", "name", cfg.ProviderName, "base_url", cfg.LLMBaseURL)
 
 	// Build the council type registry from config fields.
 	registry := map[string]council.CouncilType{


### PR DESCRIPTION
## Summary

- `cmd/server/main.go` and `cmd/eval/main.go` each emit a structured log line after `config.Load()`:
  `logger.Info("LLM provider", "name", cfg.ProviderName, "base_url", cfg.LLMBaseURL)`
- No behavioural change — purely observability

Closes #229

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (323 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)