### PR TITLE
⚖️ feat(eval): batch benchmark harness — YAML format, cost tracking, runs/ output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build dev lint test clean fr-dev fr-build fr-lint help
+.PHONY: build dev lint test clean fr-dev fr-build fr-lint eval-single eval-batch help
 
 BIN := bin/vmm-rada
 
@@ -14,6 +14,10 @@ help:
 	@echo "  make fr-dev     vite dev server (localhost:5173)"
 	@echo "  make fr-build   production build"
 	@echo "  make fr-lint    eslint"
+	@echo ""
+	@echo "Eval:"
+	@echo "  make eval-single Q=\"...\"                  run a single ad-hoc question"
+	@echo "  make eval-batch BENCHMARK=<file.yaml>     run a full YAML benchmark"
 
 build:
 	go build -o $(BIN) ./cmd/server
@@ -39,3 +43,9 @@ fr-build:
 
 fr-lint:
 	cd frontend && npm run lint
+
+eval-single:
+	go run ./cmd/eval -question "$(Q)" -baseline-model "$(BASELINE)" -council-type "$(or $(COUNCIL),default)"
+
+eval-batch:
+	go run ./cmd/eval -benchmark "$(BENCHMARK)" -baseline-model "$(BASELINE)" -council-type "$(or $(COUNCIL),default)"

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -2,13 +2,18 @@
 // pre-merge regression detector that compares the council pipeline against
 // a single-model baseline using an LLM-as-judge.
 //
-// Usage:
+// Modes:
 //
-//	go run ./cmd/eval \
-//	    -input internal/eval/testdata/golden.json \
-//	    -out eval-results.json \
-//	    -baseline-model openai/gpt-4o-mini \
-//	    -council-type default
+//	Single question:
+//	  go run ./cmd/eval -question "What is 2+2?" -baseline-model gpt-4o-mini
+//
+//	Batch benchmark (YAML):
+//	  go run ./cmd/eval -benchmark eval/benchmarks/baseline.yaml \
+//	      -baseline-model gpt-4o-mini
+//
+//	Legacy JSON suite:
+//	  go run ./cmd/eval -input internal/eval/testdata/golden.json \
+//	      -out eval-results.json -baseline-model gpt-4o-mini
 //
 // Costs real money (~$1–2 per pass with the balanced model preset). Run
 // before any prompt-template, strategy, or default-models change.
@@ -21,6 +26,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"syscall"
 	"time"
@@ -42,12 +48,14 @@ func main() {
 
 func run() error {
 	var (
-		inputPath     = flag.String("input", "internal/eval/testdata/golden.json", "path to golden case JSON file")
-		outPath       = flag.String("out", "eval-results.json", "path to write the results JSON envelope")
+		inputPath     = flag.String("input", "", "path to golden case JSON file (legacy mode)")
+		outPath       = flag.String("out", "eval-results.json", "path to write results JSON (legacy mode)")
 		baselineModel = flag.String("baseline-model", "", "single-model baseline (required)")
 		judgeModel    = flag.String("judge-model", "", "judge model — defaults to chairman; MUST differ from baseline")
 		councilType   = flag.String("council-type", "default", "council type registered in the server registry")
 		seed          = flag.Int64("seed", 0, "RNG seed for A/B order (0 = time-based, captured into output meta)")
+		question      = flag.String("question", "", "run a single question ad-hoc")
+		benchmarkFile = flag.String("benchmark", "", "path to YAML benchmark file for batch mode")
 	)
 	flag.Parse()
 
@@ -77,117 +85,49 @@ func run() error {
 		return fmt.Errorf("judge model %q must differ from baseline model to avoid self-preference bias; pass -judge-model explicitly", jModel)
 	}
 
-	// Read input file twice's worth of work in one pass: parse + hash. The
-	// hash is echoed into the output meta so a flipped result can be replayed
-	// against the exact same prompt set.
-	data, err := os.ReadFile(*inputPath)
-	if err != nil {
-		return fmt.Errorf("read input: %w", err)
-	}
-	suite, err := eval.LoadSuite(data)
-	if err != nil {
-		return err
-	}
-	if len(suite.Cases) == 0 {
-		return fmt.Errorf("input %q contains zero cases", *inputPath)
-	}
-
 	chosenSeed := *seed
 	if chosenSeed == 0 {
 		chosenSeed = time.Now().UnixNano()
 	}
 
-	// Build the council pipeline using the same wiring shape as cmd/server.
-	registry := map[string]council.CouncilType{
-		cfg.DefaultCouncilType: {
-			Name:          cfg.DefaultCouncilType,
-			Strategy:      council.PeerReview,
-			Models:        cfg.DefaultCouncilModels,
-			ChairmanModel: cfg.DefaultCouncilChairmanModel,
-			Temperature:   cfg.DefaultCouncilTemperature,
-		},
+	// Honour SIGINT / SIGTERM mid-run — the harness is sequential, so
+	// cancelling between cases is enough; no goroutine cleanup is needed.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// ── Mode dispatch ────────────────────────────────────────────────────────
+	// Priority: --benchmark > --question > --input (legacy JSON)
+	if *benchmarkFile != "" {
+		return runBatch(ctx, *benchmarkFile, *baselineModel, jModel, *councilType, chosenSeed, cfg, logger)
 	}
-	// Mirror cmd/server's opt-in Majority registration so eval can target
-	// the strategy via -council-type majority when MAJORITY_MODELS is set.
-	// ChairmanModel is NOT defaulted to the global CHAIRMAN_MODEL — see
-	// cmd/server/main.go for the rationale.
-	if len(cfg.MajorityModels) > 0 {
-		registry["majority"] = council.CouncilType{
-			Name:          "majority",
-			Strategy:      council.Majority,
-			Models:        cfg.MajorityModels,
-			ChairmanModel: cfg.MajorityChairmanModel,
-			Temperature:   cfg.DefaultCouncilTemperature,
+
+	var (
+		suite    eval.Suite
+		inputSHA string
+	)
+	if *question != "" {
+		suite = eval.Suite{Cases: []eval.Case{{ID: "adhoc-001", Prompt: *question, Category: "adhoc"}}}
+		inputSHA = eval.SuiteSHA256([]byte(*question))
+	} else {
+		// Legacy JSON suite mode.
+		if *inputPath == "" {
+			return fmt.Errorf("one of -question, -benchmark, or -input is required")
 		}
-	}
-	// Mirror cmd/server's opt-in GenerateRankRefine registration. Both env
-	// vars are required (no no-LLM path); skip with a warn if chairman is
-	// missing.
-	if len(cfg.GenerateRankRefineModels) > 0 {
-		if cfg.GenerateRankRefineChairmanModel == "" {
-			logger.Warn("GENERATE_RANK_REFINE_MODELS set but GENERATE_RANK_REFINE_CHAIRMAN_MODEL is empty; skipping registration of \"generate-rank-refine\" council type")
-		} else {
-			registry["generate-rank-refine"] = council.CouncilType{
-				Name:          "generate-rank-refine",
-				Strategy:      council.GenerateRankRefine,
-				Models:        cfg.GenerateRankRefineModels,
-				ChairmanModel: cfg.GenerateRankRefineChairmanModel,
-				Temperature:   cfg.DefaultCouncilTemperature,
-			}
+		data, err := os.ReadFile(*inputPath)
+		if err != nil {
+			return fmt.Errorf("read input: %w", err)
 		}
-	}
-	// Mirror cmd/server's opt-in MultiAgentDebate registration.
-	if len(cfg.DebateModels) > 0 {
-		if cfg.DebateChairmanModel == "" {
-			logger.Warn("DEBATE_MODELS set but DEBATE_CHAIRMAN_MODEL is empty; skipping registration of \"debate\" council type")
-		} else {
-			registry["debate"] = council.CouncilType{
-				Name:            "debate",
-				Strategy:        council.MultiAgentDebate,
-				Models:          cfg.DebateModels,
-				ChairmanModel:   cfg.DebateChairmanModel,
-				Temperature:     cfg.DefaultCouncilTemperature,
-				MaxDebateRounds: cfg.DebateMaxRounds,
-			}
+		suite, err = eval.LoadSuite(data)
+		if err != nil {
+			return err
 		}
-	}
-	// Mirror cmd/server's opt-in MixtureOfAgents registration. Requires all
-	// three MOA_* env vars; partial config is logged and skipped.
-	if len(cfg.MoaProposerModels) > 0 || len(cfg.MoaAggregatorModels) > 0 || cfg.MoaRefinerModel != "" {
-		switch {
-		case len(cfg.MoaProposerModels) == 0:
-			logger.Warn("MOA_AGGREGATOR_MODELS or MOA_REFINER_MODEL set but MOA_PROPOSER_MODELS is empty; skipping registration of \"moa\" council type")
-		case len(cfg.MoaAggregatorModels) == 0:
-			logger.Warn("MOA_PROPOSER_MODELS set but MOA_AGGREGATOR_MODELS is empty; skipping registration of \"moa\" council type")
-		case cfg.MoaRefinerModel == "":
-			logger.Warn("MOA_PROPOSER_MODELS / MOA_AGGREGATOR_MODELS set but MOA_REFINER_MODEL is empty; skipping registration of \"moa\" council type")
-		default:
-			registry["moa"] = council.CouncilType{
-				Name:             "moa",
-				Strategy:         council.MixtureOfAgents,
-				ProposerModels:   cfg.MoaProposerModels,
-				AggregatorModels: cfg.MoaAggregatorModels,
-				RefinerModel:     cfg.MoaRefinerModel,
-				Temperature:      cfg.DefaultCouncilTemperature,
-			}
+		if len(suite.Cases) == 0 {
+			return fmt.Errorf("input %q contains zero cases", *inputPath)
 		}
+		inputSHA = eval.SuiteSHA256(data)
 	}
-	// Mirror cmd/server's opt-in Delphi registration.
-	if len(cfg.DelphiModels) > 0 {
-		if cfg.DelphiChairmanModel == "" {
-			logger.Warn("DELPHI_MODELS set but DELPHI_CHAIRMAN_MODEL is empty; skipping registration of \"delphi\" council type")
-		} else {
-			registry["delphi"] = council.CouncilType{
-				Name:                       "delphi",
-				Strategy:                   council.Delphi,
-				Models:                     cfg.DelphiModels,
-				ChairmanModel:              cfg.DelphiChairmanModel,
-				Temperature:                cfg.DefaultCouncilTemperature,
-				MaxDelphiRounds:            cfg.DelphiMaxRounds,
-				DelphiConvergenceThreshold: cfg.DelphiConvergenceThreshold,
-			}
-		}
-	}
+
+	registry := buildRegistry(cfg)
 	if _, ok := registry[*councilType]; !ok {
 		return fmt.Errorf("unknown council type %q (known: %v)", *councilType, knownTypes(registry))
 	}
@@ -199,11 +139,6 @@ func run() error {
 	})
 	client := openrouter.NewClient(cfg.ProviderAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger, cb)
 	runner := council.NewCouncil(client, registry, logger)
-
-	// Honour SIGINT / SIGTERM mid-run — the harness is sequential, so
-	// cancelling between cases is enough; no goroutine cleanup is needed.
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	results, err := eval.Run(ctx, eval.Options{
 		Suite:         suite,
@@ -222,7 +157,7 @@ func run() error {
 
 	meta := eval.Meta{
 		Seed:          chosenSeed,
-		InputSHA256:   eval.SuiteSHA256(data),
+		InputSHA256:   inputSHA,
 		BaselineModel: *baselineModel,
 		JudgeModel:    jModel,
 		CouncilType:   *councilType,
@@ -245,6 +180,201 @@ func run() error {
 		return fmt.Errorf("write stderr: %w", err)
 	}
 	return nil
+}
+
+// runBatch loads a YAML benchmark file and runs all items sequentially,
+// writing a BatchReport to runs/<timestamp>/report.json. Progress is
+// printed to stderr after each item. Aborts if EVAL_MAX_COST_USD is exceeded.
+func runBatch(
+	ctx context.Context,
+	benchmarkPath, baselineModel, judgeModel, councilType string,
+	seed int64,
+	cfg *config.Config,
+	logger *slog.Logger,
+) error {
+	data, err := os.ReadFile(benchmarkPath)
+	if err != nil {
+		return fmt.Errorf("read benchmark: %w", err)
+	}
+	items, err := eval.LoadBenchmark(data)
+	if err != nil {
+		return fmt.Errorf("parse benchmark: %w", err)
+	}
+	if len(items) == 0 {
+		return fmt.Errorf("benchmark %q contains zero items", benchmarkPath)
+	}
+
+	maxCost := 1.0
+	if raw := os.Getenv("EVAL_MAX_COST_USD"); raw != "" {
+		if v, fErr := fmt.Sscanf(raw, "%f", &maxCost); v != 1 || fErr != nil {
+			logger.Warn("EVAL_MAX_COST_USD is invalid; using fallback value", "value", raw, "fallback", maxCost)
+		}
+	}
+
+	registry := buildRegistry(cfg)
+	if _, ok := registry[councilType]; !ok {
+		return fmt.Errorf("unknown council type %q (known: %v)", councilType, knownTypes(registry))
+	}
+
+	cb := openrouter.NewCircuitBreaker(openrouter.CircuitBreakerConfig{
+		FailureThreshold: cfg.CBFailureThreshold,
+		WindowDuration:   time.Duration(cfg.CBWindowDurationSecs) * time.Second,
+		ResetTimeout:     time.Duration(cfg.CBResetTimeoutSecs) * time.Second,
+	})
+	baseClient := openrouter.NewClient(cfg.ProviderAPIKey, cfg.LLMBaseURL, 120*time.Second, cfg.LLMAPIMaxRetries, logger, cb)
+	meter := eval.NewMeteringClient(baseClient)
+	runner := council.NewCouncil(meter, registry, logger)
+
+	startedAt := time.Now()
+	runID := startedAt.Format("20060102-150405")
+
+	outDir := filepath.Join("runs", runID)
+	if err := os.MkdirAll(outDir, 0750); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+
+	// Convert benchmark items to eval cases.
+	cases := make([]eval.Case, len(items))
+	for i, it := range items {
+		cases[i] = eval.Case{ID: it.ID, Prompt: it.Question, Category: it.Category}
+	}
+	suite := eval.Suite{Cases: cases}
+
+	results := make([]eval.Result, 0, len(items))
+	for i, c := range suite.Cases {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		itemStart := time.Now()
+		r := eval.RunSingleCase(ctx, c, eval.Options{
+			Suite:         eval.Suite{Cases: []eval.Case{c}},
+			Runner:        runner,
+			Client:        meter,
+			BaselineModel: baselineModel,
+			JudgeModel:    judgeModel,
+			CouncilType:   councilType,
+			Temperature:   cfg.DefaultCouncilTemperature,
+			Seed:          seed,
+			Logger:        logger,
+		})
+		results = append(results, r)
+		elapsed := time.Since(itemStart).Seconds()
+		_, _, costSoFar := meter.Totals()
+		fmt.Fprintf(os.Stderr, "[%d/%d] %s %s (%.1fs)\n",
+			i+1, len(items), c.ID, r.JudgeVerdict, elapsed)
+
+		if costSoFar > maxCost {
+			logger.Warn("EVAL_MAX_COST_USD exceeded — aborting",
+				"cost_usd", costSoFar, "limit_usd", maxCost, "completed", i+1)
+			break
+		}
+
+		if i < len(items)-1 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second):
+			}
+		}
+	}
+
+	pt, ct, totalCost := meter.Totals()
+	report := eval.BatchReport{
+		RunID:         runID,
+		BenchmarkFile: benchmarkPath,
+		StartedAt:     startedAt,
+		FinishedAt:    time.Now(),
+		Meta: eval.Meta{
+			Seed:          seed,
+			InputSHA256:   eval.SuiteSHA256(data),
+			BaselineModel: baselineModel,
+			JudgeModel:    judgeModel,
+			CouncilType:   councilType,
+		},
+		Results:      results,
+		Summary:      eval.Aggregate(results),
+		TotalTokens:  pt + ct,
+		TotalCostUSD: totalCost,
+	}
+
+	outPath := filepath.Join(outDir, "report.json")
+	f, err := os.Create(outPath)
+	if err != nil {
+		return fmt.Errorf("create report: %w", err)
+	}
+	defer f.Close()
+	if err := eval.WriteBatchReport(f, report); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stdout, "%s\n", report.Summary.Format(len(results)))
+	fmt.Fprintf(os.Stderr, "wrote %s (tokens=%d cost=$%.4f)\n", outPath, report.TotalTokens, totalCost)
+	return nil
+}
+
+// buildRegistry constructs the council type registry from cfg, mirroring
+// cmd/server/main.go. Extracted here so runBatch can use it without
+// duplicating the long opt-in registration block.
+func buildRegistry(cfg *config.Config) map[string]council.CouncilType {
+	registry := map[string]council.CouncilType{
+		cfg.DefaultCouncilType: {
+			Name:          cfg.DefaultCouncilType,
+			Strategy:      council.PeerReview,
+			Models:        cfg.DefaultCouncilModels,
+			ChairmanModel: cfg.DefaultCouncilChairmanModel,
+			Temperature:   cfg.DefaultCouncilTemperature,
+		},
+	}
+	if len(cfg.MajorityModels) > 0 {
+		registry["majority"] = council.CouncilType{
+			Name:          "majority",
+			Strategy:      council.Majority,
+			Models:        cfg.MajorityModels,
+			ChairmanModel: cfg.MajorityChairmanModel,
+			Temperature:   cfg.DefaultCouncilTemperature,
+		}
+	}
+	if len(cfg.GenerateRankRefineModels) > 0 && cfg.GenerateRankRefineChairmanModel != "" {
+		registry["generate-rank-refine"] = council.CouncilType{
+			Name:          "generate-rank-refine",
+			Strategy:      council.GenerateRankRefine,
+			Models:        cfg.GenerateRankRefineModels,
+			ChairmanModel: cfg.GenerateRankRefineChairmanModel,
+			Temperature:   cfg.DefaultCouncilTemperature,
+		}
+	}
+	if len(cfg.DebateModels) > 0 && cfg.DebateChairmanModel != "" {
+		registry["debate"] = council.CouncilType{
+			Name:            "debate",
+			Strategy:        council.MultiAgentDebate,
+			Models:          cfg.DebateModels,
+			ChairmanModel:   cfg.DebateChairmanModel,
+			Temperature:     cfg.DefaultCouncilTemperature,
+			MaxDebateRounds: cfg.DebateMaxRounds,
+		}
+	}
+	if len(cfg.MoaProposerModels) > 0 && len(cfg.MoaAggregatorModels) > 0 && cfg.MoaRefinerModel != "" {
+		registry["moa"] = council.CouncilType{
+			Name:             "moa",
+			Strategy:         council.MixtureOfAgents,
+			ProposerModels:   cfg.MoaProposerModels,
+			AggregatorModels: cfg.MoaAggregatorModels,
+			RefinerModel:     cfg.MoaRefinerModel,
+			Temperature:      cfg.DefaultCouncilTemperature,
+		}
+	}
+	if len(cfg.DelphiModels) > 0 && cfg.DelphiChairmanModel != "" {
+		registry["delphi"] = council.CouncilType{
+			Name:                       "delphi",
+			Strategy:                   council.Delphi,
+			Models:                     cfg.DelphiModels,
+			ChairmanModel:              cfg.DelphiChairmanModel,
+			Temperature:                cfg.DefaultCouncilTemperature,
+			MaxDelphiRounds:            cfg.DelphiMaxRounds,
+			DelphiConvergenceThreshold: cfg.DelphiConvergenceThreshold,
+		}
+	}
+	return registry
 }
 
 // knownTypes returns the keys of registry sorted lexicographically — used

--- a/eval/benchmarks/baseline.yaml
+++ b/eval/benchmarks/baseline.yaml
@@ -1,0 +1,245 @@
+# Baseline benchmark — 20 questions across 4 categories (5 each).
+# Purpose: catch regressions in council quality vs. a single-model baseline.
+# Run before any prompt-template, strategy, or default-models change.
+#
+# Schema: id, category, question, rubric (optional)
+
+# ── Code (5) ─────────────────────────────────────────────────────────────────
+
+- id: code-001
+  category: code
+  question: >
+    Write a Go function that checks whether a string is a valid palindrome,
+    ignoring non-alphanumeric characters and case. Include a brief doc comment
+    and a table-driven test with at least 4 cases.
+  rubric: >
+    Award marks for correct normalisation (strip non-alnum, lowercase),
+    correct two-pointer or reverse comparison, proper doc comment, and
+    meaningful test cases (empty string, single char, mixed case, punctuation).
+
+- id: code-002
+  category: code
+  question: >
+    Implement a generic stack in Go (Go 1.18+ generics) with Push, Pop,
+    Peek, Len, and IsEmpty methods. Pop and Peek must return (T, bool) to
+    signal an empty stack without panicking.
+  rubric: >
+    Award marks for correct type parameter constraint (any), correct slice
+    backing, safe Pop/Peek returning false on empty, and compile-correctness
+    of the generic syntax.
+
+- id: code-003
+  category: code
+  question: >
+    Write a concurrent Go program that fetches URLs from a channel using a
+    fixed-size worker pool (4 workers), records the HTTP status code for each
+    URL, and gracefully shuts down when the input channel is closed. Use only
+    the standard library.
+  rubric: >
+    Award marks for correct goroutine fan-out pattern, proper WaitGroup usage,
+    no goroutine leak on shutdown, and idiomatic channel close signalling.
+
+- id: code-004
+  category: code
+  question: >
+    Explain the difference between a mutex (sync.Mutex) and a read-write
+    mutex (sync.RWMutex) in Go. Give a concrete example showing when
+    RWMutex provides a measurable throughput advantage over Mutex.
+  rubric: >
+    Award marks for explaining read-lock parallelism, write-lock exclusivity,
+    concrete scenario (e.g. cache with many readers + occasional writer), and
+    noting the overhead of RWMutex for write-heavy workloads.
+
+- id: code-005
+  category: code
+  question: >
+    Design a rate limiter in Go using the token bucket algorithm. The
+    implementation must be safe for concurrent use, configurable (rate and
+    burst), and expose an Allow() bool method. Do not use external packages.
+  rubric: >
+    Award marks for correct token replenishment logic, mutex-safe state,
+    proper handling of burst capacity, and clean API. Deduct for data races
+    or incorrect token calculation.
+
+# ── Analysis (5) ─────────────────────────────────────────────────────────────
+
+- id: analysis-001
+  category: analysis
+  question: >
+    Compare the trade-offs between event sourcing and traditional CRUD for
+    a financial ledger system. Cover: consistency guarantees, auditability,
+    query complexity, storage growth, and operational burden.
+  rubric: >
+    Award marks for addressing all five dimensions, giving concrete examples
+    from the financial domain, and providing a nuanced recommendation rather
+    than a blanket preference.
+
+- id: analysis-002
+  category: analysis
+  question: >
+    A startup has a monolithic Rails app that handles 50 000 users. The CTO
+    wants to migrate to microservices. Analyse the risks and benefits, and
+    recommend a migration strategy with concrete milestones.
+  rubric: >
+    Award marks for identifying real risks (distributed systems complexity,
+    data consistency, operational overhead), tangible benefits (independent
+    deployment, team autonomy), and a phased strategy (strangler-fig pattern
+    or equivalent).
+
+- id: analysis-003
+  category: analysis
+  question: >
+    Explain how garbage collection works in Go (tricolor mark-and-sweep,
+    write barrier, stop-the-world pauses). What are the practical implications
+    for latency-sensitive services, and how can developers reduce GC pressure?
+  rubric: >
+    Award marks for accurate description of the tricolor algorithm, correct
+    explanation of write barriers, honest characterisation of STW pauses in
+    modern Go (sub-millisecond), and practical advice (reduce allocations,
+    use sync.Pool, pre-size slices/maps).
+
+- id: analysis-004
+  category: analysis
+  question: >
+    Compare PostgreSQL and MongoDB for a SaaS application that stores
+    user-generated content (posts, comments, reactions) with heavy read
+    traffic (10:1 read/write ratio). The schema is expected to evolve
+    frequently. Which would you choose and why?
+  rubric: >
+    Award marks for discussing schema flexibility, ACID guarantees,
+    indexing strategies, read scalability, and schema migration complexity.
+    Deduct for oversimplified "use Postgres for everything" or "NoSQL is
+    always flexible" reasoning.
+
+- id: analysis-005
+  category: analysis
+  question: >
+    What are the key differences between optimistic and pessimistic locking
+    in databases? When should each be used, and what are the failure modes
+    of each approach under high contention?
+  rubric: >
+    Award marks for correct definitions, concrete use-case guidance
+    (optimistic for low-contention reads, pessimistic for write-heavy
+    critical sections), and honest discussion of failure modes (optimistic:
+    retry storms; pessimistic: deadlocks, lock escalation).
+
+# ── Factual (5) ──────────────────────────────────────────────────────────────
+
+- id: factual-001
+  category: factual
+  question: >
+    What is the time complexity of quicksort in the best, average, and
+    worst cases? What causes the worst case, and how does the choice of
+    pivot strategy mitigate it?
+  rubric: >
+    Award marks for correct O(n log n) average, O(n²) worst case, correct
+    identification of already-sorted input as the worst-case trigger for
+    naive pivot, and explanation of randomised or median-of-three pivot.
+
+- id: factual-002
+  category: factual
+  question: >
+    What does the CAP theorem state? Name two real distributed systems that
+    prioritise consistency over availability (CP) and two that prioritise
+    availability over consistency (AP). Explain your classification.
+  rubric: >
+    Award marks for correct theorem statement (Consistency, Availability,
+    Partition tolerance — pick 2 of 3 under partition), correct examples
+    (CP: HBase, Zookeeper; AP: Cassandra, CouchDB or equivalent), and
+    accurate classification reasoning.
+
+- id: factual-003
+  category: factual
+  question: >
+    What HTTP status code should a REST API return when a requested resource
+    does not exist? What about when the client is authenticated but lacks
+    permission to access it? Explain the security implication of returning
+    404 vs 403 in each case.
+  rubric: >
+    Award marks for 404 (not found), 403 (forbidden), correct explanation
+    that 403 leaks resource existence (enumeration attack surface), and
+    the trade-off of returning 404 for both cases to prevent enumeration.
+
+- id: factual-004
+  category: factual
+  question: >
+    Explain what a B-tree index is and why databases use it instead of a
+    hash index for range queries. What is the typical time complexity for
+    point lookups and range scans?
+  rubric: >
+    Award marks for correct description of balanced tree structure,
+    O(log n) point lookup, O(log n + k) range scan, and correct explanation
+    that hash indexes cannot satisfy range queries (no ordering).
+
+- id: factual-005
+  category: factual
+  question: >
+    What is the difference between TCP and UDP? Name two protocols built on
+    each and explain why each choice of transport was appropriate.
+  rubric: >
+    Award marks for correct characterisation of TCP (reliable, ordered,
+    connection-oriented) vs UDP (unreliable, unordered, connectionless),
+    appropriate examples (TCP: HTTP/HTTPS, SMTP; UDP: DNS, QUIC/video
+    streaming), and sound reasoning for each.
+
+# ── Creative (5) ─────────────────────────────────────────────────────────────
+
+- id: creative-001
+  category: creative
+  question: >
+    Write a concise explanation of how a Bloom filter works, aimed at a
+    junior engineer who has never seen probabilistic data structures. Use
+    one analogy, explain the false-positive trade-off, and give a real-world
+    use case.
+  rubric: >
+    Award marks for a clear accessible analogy, correct explanation that
+    Bloom filters have no false negatives, accurate description of the
+    space-accuracy trade-off, and a relevant use case (e.g. cache pre-check,
+    spell checker, or database query optimisation).
+
+- id: creative-002
+  category: creative
+  question: >
+    Write a system design document outline for a URL shortener that handles
+    10 million stored URLs and 1000 redirects per second. Cover: functional
+    requirements, data model, API design, storage choice, and a scaling
+    bottleneck you'd address first.
+  rubric: >
+    Award marks for plausible throughput math, a concrete data model (short
+    code → long URL mapping), REST API sketch, justified storage choice
+    (Redis/Postgres or similar), and a specific bottleneck (e.g. redirect
+    hot path, key generation collision).
+
+- id: creative-003
+  category: creative
+  question: >
+    Explain the concept of dependency injection to a developer who only
+    knows procedural programming. Use a concrete analogy from everyday life
+    and show a before-and-after code example in any language.
+  rubric: >
+    Award marks for an accessible non-code analogy (e.g. restaurant/kitchen,
+    power outlet), correct explanation of inversion of control, and a clear
+    before/after code example that demonstrates the testability benefit.
+
+- id: creative-004
+  category: creative
+  question: >
+    Design a feature flag system for a SaaS product. Cover the API design,
+    data model, rollout mechanics (percentage-based, user-segment targeting),
+    and the observability you would add to detect a bad rollout early.
+  rubric: >
+    Award marks for a practical API surface (create/update/evaluate endpoints),
+    a data model that supports targeting rules, percentage rollout logic,
+    and concrete observability (error rate dashboards, flag evaluation events).
+
+- id: creative-005
+  category: creative
+  question: >
+    Write a post-mortem template for a production incident. Include sections
+    for timeline, root cause analysis, contributing factors, impact
+    quantification, action items (with owners and due dates), and lessons
+    learned. Explain why each section matters.
+  rubric: >
+    Award marks for a complete and usable template with all requested sections,
+    brief but accurate explanation of each section's purpose (blameless culture,
+    systemic vs. human causes, measurable impact, SMART action items).

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/valpere/vmm-rada
 go 1.26.3
 
 require github.com/joho/godotenv v1.5.1
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,5 @@
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -103,11 +103,20 @@ type CompletionRequest struct {
 	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
 }
 
+// Usage holds token counts and optional cost returned by the LLM gateway.
+// CostUSD is omitempty because local providers (Ollama) do not report cost.
+type Usage struct {
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	CostUSD          float64 `json:"cost_usd,omitempty"`
+}
+
 // CompletionResponse is received from the LLM gateway.
 type CompletionResponse struct {
 	Choices []struct {
 		Message ChatMessage `json:"message"`
 	} `json:"choices"`
+	Usage Usage `json:"usage"`
 }
 
 // EventFunc is the callback used to stream stage-completion events to the caller.

--- a/internal/eval/batchreport.go
+++ b/internal/eval/batchreport.go
@@ -1,0 +1,32 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// BatchReport is the top-level record written to runs/<timestamp>/report.json.
+// It extends the single-run Output with metering totals and timing metadata.
+type BatchReport struct {
+	RunID         string    `json:"run_id"`
+	BenchmarkFile string    `json:"benchmark_file"`
+	StartedAt     time.Time `json:"started_at"`
+	FinishedAt    time.Time `json:"finished_at"`
+	Meta          Meta      `json:"meta"`
+	Results       []Result  `json:"results"`
+	Summary       Summary   `json:"summary"`
+	TotalTokens   int       `json:"total_tokens"`
+	TotalCostUSD  float64   `json:"total_cost_usd"`
+}
+
+// WriteBatchReport serialises report as indented JSON to w.
+func WriteBatchReport(w io.Writer, report BatchReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(report); err != nil {
+		return fmt.Errorf("encode batch report: %w", err)
+	}
+	return nil
+}

--- a/internal/eval/batchreport_test.go
+++ b/internal/eval/batchreport_test.go
@@ -1,0 +1,57 @@
+package eval
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestBatchReport_RoundTrip(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	report := BatchReport{
+		RunID:         "20260601-120000",
+		BenchmarkFile: "eval/benchmarks/baseline.yaml",
+		StartedAt:     now,
+		FinishedAt:    now.Add(5 * time.Minute),
+		Meta: Meta{
+			Seed:          42,
+			BaselineModel: "gpt-4o-mini",
+			JudgeModel:    "claude-sonnet",
+			CouncilType:   "default",
+		},
+		Results: []Result{
+			{ID: "code-001", JudgeVerdict: VerdictCouncil},
+			{ID: "factual-001", JudgeVerdict: VerdictTie},
+		},
+		Summary:      Summary{CouncilWon: 1, Ties: 1},
+		TotalTokens:  1234,
+		TotalCostUSD: 0.05,
+	}
+
+	var buf bytes.Buffer
+	if err := WriteBatchReport(&buf, report); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var got BatchReport
+	if err := json.NewDecoder(&buf).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.RunID != report.RunID {
+		t.Errorf("RunID: got %q, want %q", got.RunID, report.RunID)
+	}
+	if got.TotalTokens != report.TotalTokens {
+		t.Errorf("TotalTokens: got %d, want %d", got.TotalTokens, report.TotalTokens)
+	}
+	if got.TotalCostUSD != report.TotalCostUSD {
+		t.Errorf("TotalCostUSD: got %f, want %f", got.TotalCostUSD, report.TotalCostUSD)
+	}
+	if len(got.Results) != 2 {
+		t.Errorf("Results: got %d, want 2", len(got.Results))
+	}
+	if got.Summary.CouncilWon != 1 || got.Summary.Ties != 1 {
+		t.Errorf("Summary: got %+v, want {CouncilWon:1 Ties:1}", got.Summary)
+	}
+}

--- a/internal/eval/benchmark.go
+++ b/internal/eval/benchmark.go
@@ -1,0 +1,48 @@
+package eval
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// BenchmarkItem is one question in a YAML benchmark file.
+type BenchmarkItem struct {
+	ID       string `yaml:"id"`
+	Category string `yaml:"category"`
+	Strategy string `yaml:"strategy,omitempty"`
+	Question string `yaml:"question"`
+	Rubric   string `yaml:"rubric,omitempty"`
+}
+
+// LoadBenchmark parses a YAML benchmark file into a slice of BenchmarkItems.
+// Returns a typed error when any item is missing the required id or question
+// fields.
+func LoadBenchmark(data []byte) ([]BenchmarkItem, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var items []BenchmarkItem
+	if err := yaml.Unmarshal(data, &items); err != nil {
+		return nil, fmt.Errorf("parse benchmark: %w", err)
+	}
+	for i, item := range items {
+		if item.ID == "" {
+			return nil, &BenchmarkValidationError{Index: i, Field: "id"}
+		}
+		if item.Question == "" {
+			return nil, &BenchmarkValidationError{Index: i, Field: "question"}
+		}
+	}
+	return items, nil
+}
+
+// BenchmarkValidationError is returned when a required field is missing.
+type BenchmarkValidationError struct {
+	Index int
+	Field string
+}
+
+func (e *BenchmarkValidationError) Error() string {
+	return fmt.Sprintf("benchmark item %d: missing required field %q", e.Index, e.Field)
+}

--- a/internal/eval/benchmark_test.go
+++ b/internal/eval/benchmark_test.go
@@ -1,0 +1,87 @@
+package eval
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestLoadBenchmark_ValidParse(t *testing.T) {
+	yaml := []byte(`
+- id: code-001
+  category: code
+  question: Write a Go function that reverses a string.
+- id: analysis-001
+  category: analysis
+  question: Explain the CAP theorem.
+  rubric: Must cover all three properties.
+`)
+	items, err := LoadBenchmark(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(items))
+	}
+	if items[0].ID != "code-001" || items[0].Category != "code" {
+		t.Errorf("item 0: got id=%q cat=%q", items[0].ID, items[0].Category)
+	}
+	if items[1].Rubric == "" {
+		t.Error("item 1 rubric should be non-empty")
+	}
+}
+
+func TestLoadBenchmark_MissingID(t *testing.T) {
+	yaml := []byte(`
+- category: code
+  question: Write a Go function.
+`)
+	_, err := LoadBenchmark(yaml)
+	var ve *BenchmarkValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *BenchmarkValidationError, got %T: %v", err, err)
+	}
+	if ve.Field != "id" {
+		t.Errorf("want field=%q, got %q", "id", ve.Field)
+	}
+}
+
+func TestLoadBenchmark_MissingQuestion(t *testing.T) {
+	yaml := []byte(`
+- id: code-001
+  category: code
+`)
+	_, err := LoadBenchmark(yaml)
+	var ve *BenchmarkValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *BenchmarkValidationError, got %T: %v", err, err)
+	}
+	if ve.Field != "question" {
+		t.Errorf("want field=%q, got %q", "question", ve.Field)
+	}
+}
+
+func TestLoadBenchmark_EmptyFile(t *testing.T) {
+	items, err := LoadBenchmark([]byte{})
+	if err != nil {
+		t.Fatalf("unexpected error on empty input: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("want 0 items, got %d", len(items))
+	}
+}
+
+func TestLoadBenchmark_UnknownFieldIgnored(t *testing.T) {
+	yaml := []byte(`
+- id: code-001
+  category: code
+  question: Write something.
+  unknown_future_field: ignored
+`)
+	items, err := LoadBenchmark(yaml)
+	if err != nil {
+		t.Fatalf("unknown field should be ignored, got error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("want 1 item, got %d", len(items))
+	}
+}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -218,6 +218,20 @@ func remapVerdict(raw string, councilFirst bool) Verdict {
 	}
 }
 
+// RunSingleCase executes one case end-to-end and returns its Result.
+// It is the per-item primitive used by the batch runner. opts.Seed is used
+// to initialise the per-run RNG (the batch runner should pass the same seed
+// for reproducibility).
+func RunSingleCase(ctx context.Context, c Case, opts Options) Result {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	rng := rand.New(rand.NewPCG(uint64(opts.Seed), 0))
+	judge := &Judge{Client: opts.Client, Model: opts.JudgeModel, Temperature: opts.Temperature}
+	return runCase(ctx, c, opts, judge, rng, logger)
+}
+
 // LoadSuite is a convenience helper for the cmd/eval CLI: it parses a JSON
 // array of cases. It lives here rather than in cmd/ so tests can use it.
 func LoadSuite(data []byte) (Suite, error) {

--- a/internal/eval/metering.go
+++ b/internal/eval/metering.go
@@ -1,0 +1,51 @@
+package eval
+
+import (
+	"context"
+	"sync"
+
+	"github.com/valpere/vmm-rada/internal/council"
+)
+
+// meteringClient wraps a council.LLMClient and accumulates token counts and
+// costs across calls. Only successful calls (err == nil) are counted.
+// All methods are safe for concurrent use.
+type meteringClient struct {
+	inner            council.LLMClient
+	mu               sync.Mutex
+	promptTokens     int
+	completionTokens int
+	costUSD          float64
+}
+
+// NewMeteringClient wraps inner with token/cost accumulation.
+func NewMeteringClient(inner council.LLMClient) *meteringClient {
+	return &meteringClient{inner: inner}
+}
+
+func (m *meteringClient) Complete(ctx context.Context, req council.CompletionRequest) (council.CompletionResponse, error) {
+	resp, err := m.inner.Complete(ctx, req)
+	if err == nil {
+		m.mu.Lock()
+		m.promptTokens += resp.Usage.PromptTokens
+		m.completionTokens += resp.Usage.CompletionTokens
+		m.costUSD += resp.Usage.CostUSD
+		m.mu.Unlock()
+	}
+	return resp, err
+}
+
+// Totals returns the accumulated token counts and cost. Safe to call
+// concurrently with Complete.
+func (m *meteringClient) Totals() (promptTokens, completionTokens int, costUSD float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.promptTokens, m.completionTokens, m.costUSD
+}
+
+// TotalTokens returns promptTokens + completionTokens.
+func (m *meteringClient) TotalTokens() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.promptTokens + m.completionTokens
+}

--- a/internal/eval/metering_test.go
+++ b/internal/eval/metering_test.go
@@ -1,0 +1,87 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/valpere/vmm-rada/internal/council"
+)
+
+type stubLLMClient struct {
+	resp council.CompletionResponse
+	err  error
+}
+
+func (s *stubLLMClient) Complete(_ context.Context, _ council.CompletionRequest) (council.CompletionResponse, error) {
+	return s.resp, s.err
+}
+
+func TestMeteringClient_AccumulatesOnSuccess(t *testing.T) {
+	stub := &stubLLMClient{
+		resp: council.CompletionResponse{
+			Choices: []struct {
+				Message council.ChatMessage `json:"message"`
+			}{{Message: council.ChatMessage{Role: "assistant", Content: "hello"}}},
+			Usage: council.Usage{PromptTokens: 10, CompletionTokens: 5, CostUSD: 0.001},
+		},
+	}
+	mc := NewMeteringClient(stub)
+
+	for range 3 {
+		_, err := mc.Complete(context.Background(), council.CompletionRequest{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	pt, ct, cost := mc.Totals()
+	if pt != 30 || ct != 15 {
+		t.Errorf("tokens: want pt=30 ct=15, got pt=%d ct=%d", pt, ct)
+	}
+	if cost < 0.0029 || cost > 0.0031 {
+		t.Errorf("cost: want ~0.003, got %f", cost)
+	}
+}
+
+func TestMeteringClient_NoAccumulationOnError(t *testing.T) {
+	stub := &stubLLMClient{
+		resp: council.CompletionResponse{
+			Usage: council.Usage{PromptTokens: 100, CompletionTokens: 50},
+		},
+		err: errors.New("LLM call failed"),
+	}
+	mc := NewMeteringClient(stub)
+
+	_, _ = mc.Complete(context.Background(), council.CompletionRequest{})
+
+	pt, ct, _ := mc.Totals()
+	if pt != 0 || ct != 0 {
+		t.Errorf("tokens should be 0 on error, got pt=%d ct=%d", pt, ct)
+	}
+}
+
+func TestMeteringClient_ConcurrentAccumulation(t *testing.T) {
+	stub := &stubLLMClient{
+		resp: council.CompletionResponse{
+			Usage: council.Usage{PromptTokens: 1, CompletionTokens: 1},
+		},
+	}
+	mc := NewMeteringClient(stub)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = mc.Complete(context.Background(), council.CompletionRequest{})
+		}()
+	}
+	wg.Wait()
+
+	if total := mc.TotalTokens(); total != goroutines*2 {
+		t.Errorf("want %d total tokens, got %d", goroutines*2, total)
+	}
+}


### PR DESCRIPTION
## Summary

- `Usage{PromptTokens, CompletionTokens, CostUSD}` added to `council.CompletionResponse`; parsed automatically from `.usage` JSON field
- `internal/eval/benchmark.go` — `LoadBenchmark([]byte)` parses YAML via `gopkg.in/yaml.v3`; typed `BenchmarkValidationError` for missing `id`/`question`
- `internal/eval/metering.go` — `meteringClient` decorator accumulates tokens+cost on successful calls; mutex-safe
- `internal/eval/batchreport.go` — `BatchReport` struct + `WriteBatchReport`
- `eval.RunSingleCase` exported for per-item batch execution
- `cmd/eval --question "..."` — ad-hoc single question mode
- `cmd/eval --benchmark <file.yaml>` — batch mode: runs items sequentially with 1s pause, writes `runs/<timestamp>/report.json`, prints `[N/Total] id verdict (elapsed)` to stderr, aborts on `EVAL_MAX_COST_USD` (default \$1.00)
- `eval/benchmarks/baseline.yaml` — 20 questions (code×5, analysis×5, factual×5, creative×5)
- `Makefile`: `eval-single Q="..." BASELINE=...` and `eval-batch BENCHMARK=... BASELINE=...`
- `buildRegistry` extracted from `run()` to avoid duplication

Closes #231

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes — 332 tests (+9 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)