### PR TITLE
fix(eval): per-case RNG seed + strconv for EVAL_MAX_COST_USD

### DIFF
--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -28,6 +28,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -206,7 +207,9 @@ func runBatch(
 
 	maxCost := 1.0
 	if raw := os.Getenv("EVAL_MAX_COST_USD"); raw != "" {
-		if v, fErr := fmt.Sscanf(raw, "%f", &maxCost); v != 1 || fErr != nil {
+		if v, fErr := strconv.ParseFloat(raw, 64); fErr == nil && v > 0 {
+			maxCost = v
+		} else {
 			logger.Warn("EVAL_MAX_COST_USD is invalid; using fallback value", "value", raw, "fallback", maxCost)
 		}
 	}
@@ -254,7 +257,7 @@ func runBatch(
 			JudgeModel:    judgeModel,
 			CouncilType:   councilType,
 			Temperature:   cfg.DefaultCouncilTemperature,
-			Seed:          seed,
+			Seed:          seed + int64(i),
 			Logger:        logger,
 		})
 		results = append(results, r)


### PR DESCRIPTION
## Summary

Two bugs found by `/fix-review` on PR #238:

- **runBatch A/B bias**: `RunSingleCase` creates a fresh RNG with the same seed on every call. In batch mode all 20 items got identical A/B ordering (constant bias toward one pipeline). Fixed: derive `seed + int64(i)` per item so each case gets a different random ordering.
- **EVAL_MAX_COST_USD partial parse**: `fmt.Sscanf(raw, "%f", &maxCost)` silently accepted `"1.5xyz"` (v=1, fErr=nil). Fixed: replaced with `strconv.ParseFloat` which rejects non-numeric suffixes.

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (332 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)