### PR TITLE
chore(repo): gitignore telemetry+runs; add agent memories + dreaming report

### DIFF
--- a/.claude/agent-memory/cors-allowed-methods.md
+++ b/.claude/agent-memory/cors-allowed-methods.md
@@ -1,0 +1,18 @@
+---
+name: cors-allowed-methods
+description: CORS middleware in handler.go hardcodes allowed methods — any new HTTP verb (DELETE/PATCH/PUT) requires updating it
+type: project
+---
+
+The `wrap()` CORS middleware in `internal/api/handler.go` hardcodes
+`Access-Control-Allow-Methods: "GET, POST, OPTIONS"`. Allowed CORS origins are
+a hardcoded allowlist (`allowedOrigins`: localhost:5173, localhost:3000).
+
+**Why:** Any plan that adds an endpoint using a verb beyond GET/POST (DELETE,
+PATCH, PUT) will pass Go-side tests but fail in the browser at CORS preflight,
+because the middleware never advertises the new method. This is easy to miss in
+review because handler unit tests bypass the browser preflight.
+
+**How to apply:** When reviewing a plan that introduces a new HTTP verb, REQUIRE
+the plan to also update the `Access-Control-Allow-Methods` header in `wrap()`.
+Treat its omission as a Layer 2 blocking issue.

--- a/.claude/agent-memory/storage-title-handling.md
+++ b/.claude/agent-memory/storage-title-handling.md
@@ -1,0 +1,21 @@
+---
+name: storage-title-handling
+description: SaveTitle already exists on Storer; title limit is maxTitleRunes=50 with truncation, not 200 with rejection
+type: reference
+---
+
+Conversation title persistence is already implemented:
+- `Store.SaveTitle(id, title)` (internal/storage/storage.go) — read → set Title →
+  write under `s.mu.Lock()`, on the `Storer` interface.
+- Handler enforces `maxTitleRunes = 50` (internal/api/handler.go) and the
+  auto-title path TRUNCATES over-limit titles rather than rejecting them.
+
+**Why:** Plans proposing a "rename" feature tend to invent a new
+`RenameConversation` method (DRY violation — SaveTitle already does it) and assume
+a 200-char limit with 400-on-overflow (contradicts the real 50-rune truncating
+behavior). Both assumptions produce tests that contradict the code.
+
+**How to apply:** For rename/title plans, point the generator at the existing
+`SaveTitle` and reconcile any length-limit acceptance criteria against
+`maxTitleRunes`. Verify the constant still reads 50 before citing it — grep
+`maxTitleRunes` in handler.go.

--- a/.claude/dreaming/reports/2026-W22.md
+++ b/.claude/dreaming/reports/2026-W22.md
@@ -1,0 +1,82 @@
+# vmm-rada dreaming pass — 2026-W22
+
+Date: 2026-05-31
+Branch surveyed: main
+Commits examined: 40 (since 2026-05-01, 30-day window); ~7 PRs landed since W21 (2026-05-24)
+PRs examined: 20 merged (gh pr list --limit 20)
+
+## TL;DR
+- **NEW / highest-impact: the `/ship` skill is stale and now contradicts a user-level global rule.** `.claude/skills/ship/SKILL.md` still bakes "wait for Copilot review" / "address Copilot comments" into Steps 7–8, but global `~/.claude/CLAUDE.md` records that Copilot was removed from the workflow on 2026-05-13 and replaced by `/fix-review`. This is the one finding that genuinely changed this week. Severity: **high**.
+- **`tech-lead/known_issues.md` is now provably stale** — I verified in code that all 3 "Critical" items (API-key validation, Stage3 error return, graceful shutdown) are **resolved**, yet they're still listed as open. W21 said "not verified"; this pass confirms. Plus it cites GitHub issues (#9, #13, #53, #54) that no longer exist in the tracker.
+- **Rule-4 frontend drift persists and has spread** — `Stage2.jsx` now renders LLM output as raw JSX at **4 sites** (336, 426, 455, + critique 332), up from W21's 2. Important correction to prior reports: this is a *markdown-fidelity / contract* violation, **not an XSS hole** (React escapes string children).
+- The project rename `llm-council → vmm-rada` (#227) was **clean** — no leftover identifiers in `go.mod`, `docs/`, `README.md`, or `.claude/`.
+
+## 1. Context-essentials drift
+
+Checks run against current `main` (`fe27db5`).
+
+- **Rule 4 — "`react-markdown` is the only renderer for LLM output"** — ❌ **DRIFT persists & widened**.
+  - `frontend/src/components/Stage2.jsx` imports only `useState` + CSS (no Markdown component). LLM-generated fields rendered as bare JSX children: `:336 {revision.content}`, `:332 {revision.critique}`, `:426 {result.content}`, `:455 {aggregator.content}`.
+  - Severity: **medium**. **Correction to W20/W21 framing:** these are JSX text children, which React auto-escapes — there is **no `dangerouslySetInnerHTML` and no XSS vector here**. The real cost is (a) markdown formatting is lost in the debate/MoA views and (b) the "all LLM output → one renderer" contract is broken. Prioritize as a UX/consistency bug, not a security bug.
+  - Suggest: route all four through the shared `<Markdown>` wrapper used elsewhere.
+
+- **Rule "App.jsx owns all state"** — ✅ holds. `grep setCurrent frontend/src/components/` → no hits.
+- **Rule "Components are pure UI; no `fetch`/`api.js`"** — ✅ holds. No hits.
+- **Rule "No raw HTML rendering" (`dangerouslySetInnerHTML`/`innerHTML`)** — ✅ holds. No hits.
+- **Rule "No `fmt.Println` in `cmd/`"** — ✅ holds.
+- **Rule "No `--no-verify`"** — ✅ holds (no matching commits in window).
+- **Rule "Plans deleted after issue creation"** — ✅ holds. `.claude/plans/` = `README.md` only.
+- **Rule "No TypeScript in `frontend/`"** — ✅ holds (`**/*.{ts,tsx}` → none).
+
+Confidence: **high**.
+
+## 2. Recurring /fix-review themes
+
+- **No new PR-comment data.** `gh pr view <n> --json comments` returns 0 for substantive PRs; `--json reviews` shows only `copilot-pull-request-reviewer` (e.g. #217). fix-review leaves no PR-comment trail (consolidated into commits), so themes aren't re-derivable from the API this week.
+- **Meta-theme: `/fix-review` still not invoked in practice** — re-confirmed. `git log --grep="fix-review" -i` since 120d returns no per-PR follow-up commits other than the W19-apply PR #207. Every strategy PR (#206/#211/#213/#215/#217) merged on Copilot review alone. Confidence: **high**.
+- Carryover backend themes from W20/W21 (`ConsensusW=0.0` hardcoded in debate/delphi/moa; prompt format-arg mismatches at `prompts.go:616,749`) were **not re-verified this pass** — no commits touched those files since W21, so assume unchanged.
+
+## 3. Stale plans
+- ✅ Clean. `.claude/plans/` contains only `README.md`. Convention followed.
+
+## 4. Agent-memory health
+
+- **`tech-lead/known_issues.md`** — content dated 2026-03-14/03-22. **Now verified stale** (W21 left these "not verified"):
+  - "Critical: No API-key validation at startup" → **resolved**: `internal/config/config.go:99-101` returns `errors.New("AI_PROVIDER_API_KEY is required but not set")`.
+  - "Critical: Stage3SynthesizeFinal never returns an error" → **resolved**: all Stage3 funcs now return `(StageThreeResult, error)` (`debate.go:318`, `majority.go:165`, `generaterankrefine.go:253`, etc.).
+  - "Critical: No graceful shutdown" → **resolved**: `cmd/server/main.go:200 srv.Shutdown(shutdownCtx)`.
+  - "High: Config.Load() has no validation/error return" → **resolved**: `Load() (*Config, error)`.
+  - Stale issue refs: file cites #9, #13, #53, #54; `gh issue list` shows none of these exist (current open issues are #229–#231). 
+  - Severity: **medium** — tech-lead loads this and will reason from a March-era snapshot, three full Critical items out of date.
+  - Suggest: regenerate from current `main`, or mark the four items ✅ resolved and drop dead issue numbers.
+
+- **`go-security-reviewer/project_frontend_security_posture.md`** — mtime 2026-03-31, **60 days old** (now crosses the 60-day threshold). Still lists #53/#54 as "Known open issues" — neither exists in the tracker. Severity: **low**.
+
+- **`code-generator/` and `code-simplifier/` agent-memory dirs** — still empty (created ~54+ days ago, never written). Either these agents don't write memory by design, or the convention is dead weight. Severity: **low**. Suggest: decide and document, or remove the empty dirs.
+
+- **`tech-lead/project_architecture.md`** — content fresh (W19-apply updated it); ✅ no action.
+
+## 5. Skill / agent inventory
+
+- **`/ship` skill is stale (NEW finding, high value).** `.claude/skills/ship/SKILL.md` lines 3, 17, 24, 108, 178, 192, 196, 202, 213, 243 still center the flow on Copilot ("Step 7: Wait for Copilot review", "Step 8: Address Copilot comments", commit message `address Copilot review comments`). This contradicts:
+  - global `~/.claude/CLAUDE.md`: *"Copilot was removed from the active workflow on 2026-05-13… `/fix-review` replaced it. Any per-project memory that still tells the agent to 'wait for Copilot review' is stale."*
+  - project `CLAUDE.md`, which already advertises `/fix-review` as the review gate.
+  - Also stale in `CLAUDE.md` PR-workflow §("/ship → waits for Copilot review"), `.claude/agent-memory/tech-lead/project_architecture.md`, and `docs/frontend/development-workflow.md`.
+  - Confidence: **high**. Suggest: rewrite ship Steps 7–8 to invoke `/fix-review` instead of polling Copilot; scrub the Copilot references from the four files above. This is the cleanest high-value fix available this week.
+
+- **Agents (11)** — unchanged since W20 (last edit 2026-05-10). No overlaps newly introduced.
+- **Skills (11)** — unchanged set. `lib/` is still helper scripts (`env.sh`, `rest.sh`), not a real skill — W20/W21 flagged; undecided.
+
+## 6. Patterns I noticed
+
+- **The maintenance lull broke.** W21 noted a dependabot-only window; since then real work landed: #227 (rename), #228 (provider abstraction + `RADA_MODELS` typo fix), #232 (strategy showcase docs), #233 (untrack `settings.local.json`). So the project is active again — but **still no `/apply-dreaming` invocation**: W19/W20/W21 findings remain unapplied, and this is W22. Four reports deep with one partial apply (#207). The flywheel gap W21 called out is now more pronounced, not less.
+- **Rename hygiene was excellent** — a whole-repo identifier rename (#227) with zero residue in code, docs, or `.claude/`. Worth noting as a positive; whatever process did it worked.
+- **`.claude/settings.local.json` was committed then untracked (#233).** This is exactly the drift the global rule about mempalace-hooks-in-`settings.local.json` warns about — the file is gitignored and must stay local. Resolved correctly, but worth a glance that no secrets/hook config leaked in the commit history before untracking.
+- **Stale-memory accumulation outpaces curation.** Two of three agent-memory files (`known_issues.md`, `frontend_security_posture.md`) reference a dead issue-numbering scheme (#9/#13/#53/#54). The issue tracker was evidently reset/renumbered (current issues start ~#194+), orphaning every memory that cited a low issue number.
+
+## 7. What I couldn't tell (need manual review)
+
+- **CI health** — `gh run list --branch main` required approval and was not run; could not confirm the green/red rate or whether `go test ./...` passes on current `main`. Manual check recommended.
+- **Whether ship-skill Copilot retention is deliberate.** Possible Val still wants a Copilot pass *plus* `/fix-review` on this repo specifically, overriding the global removal. If so, the global rule and project skill should be reconciled explicitly rather than left as silent contradiction.
+- **Whether the W19→W22 dreaming backlog is deferred-on-purpose or simply unread.** No `[applied]` annotations exist past W19. Same ambiguity W21 raised — still unresolved from outside.
+- **The dead issue-number scheme** — whether #9/#13/#53/#54 map to any current issue (renumbered) or were dropped entirely when the tracker was reset. Determines whether the memory refs can be rewritten or just deleted.

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,12 @@ frontend/dist/
 
 # Playwright test screenshots
 *.png
+
+tmp/
+chromium/
+
+# fix-review operational telemetry (local, not shared)
+.claude/skills/fix-review/telemetry.jsonl
+
+# Eval batch run output
+runs/


### PR DESCRIPTION
## Summary

- `.gitignore`: ignore `fix-review/telemetry.jsonl`, eval `runs/` dir, `tmp/`, `chromium/`
- `.claude/agent-memory/`: two Tech Lead memories generated during conversation delete+rename work (CORS allowed-methods, SaveTitle/maxTitleRunes)
- `.claude/dreaming/reports/2026-W22.md`: vmm-rada dreaming report W22

🤖 Generated with [Claude Code](https://claude.com/claude-code)