### PR TITLE
chore(agent-memory): refresh stale memories — W25 dreaming pass

### DIFF
--- a/.claude/agent-memory/MEMORY.md
+++ b/.claude/agent-memory/MEMORY.md
@@ -5,5 +5,7 @@ Each entry below is a link to a memory file with a one-line description.
 
 - [error-status-mapping.md](error-status-mapping.md) — gateway errors surface as council-layer error types; handler must never import openrouter
 - [usage-cost-aggregation.md](usage-cost-aggregation.md) — per-call token/cost aggregated via eval-side LLMClient decorator, never through council.Metadata or stage3_complete
+- [cors-allowed-methods.md](cors-allowed-methods.md) — CORS Access-Control-Allow-Methods must include every verb used by browser fetch (DELETE, PATCH); missing verbs cause preflight 405
+- [storage-title-handling.md](storage-title-handling.md) — SaveTitle already on Storer; maxTitleRunes=50 truncates (not rejects); no RenameConversation needed
 
 <!-- Add pointers here as agents write memories. Keep under 200 lines. -->

--- a/.claude/agent-memory/go-security-reviewer/project_frontend_security_posture.md
+++ b/.claude/agent-memory/go-security-reviewer/project_frontend_security_posture.md
@@ -1,27 +1,34 @@
 ---
-name: Frontend security posture (PR #52)
-description: Security architecture decisions and known issues introduced when the React frontend was merged into the monorepo
+name: Frontend security posture
+description: Security architecture decisions and known issues for vmm-rada frontend (updated 2026-06-24)
 type: project
+last-verified: 2026-06-24
 ---
 
-Frontend merged into monorepo in PR #52 (2026-03-31).
+Frontend was originally merged into monorepo in PR #52 (2026-03-31).
+The codebase underwent a v2 clean-slate rewrite. This memory was refreshed
+2026-06-24; issues #53 and #54 no longer exist (issue tracker is empty).
 
-**Positive controls in place:**
-- All LLM output rendered through react-markdown — no raw HTML injection found.
+**Positive controls (verified 2026-06-24):**
+- All LLM output in Stage0/Stage1/Stage3/ChatInterface rendered through `<Markdown>`
+  (react-markdown wrapper) — no raw HTML injection found.
+- **Exception:** `Stage2.jsx:332,336,426,455` — 4 spots render bare JSX string children
+  for debate/MoA content. Fidelity issue (markdown symbols render raw), NOT XSS
+  (React escapes string children; no `dangerouslySetInnerHTML` found anywhere in
+  `frontend/src`). Plan filed: `.claude/plans/2-dreaming-W25-stage2-markdown.md`.
 - No hardcoded secrets or API keys in JS source.
 - No dynamic code execution patterns found.
-- No unvalidated redirects found.
-- api.js is the sole HTTP/fetch boundary — components do not call fetch directly.
-- CORS is allowlist-based on the Go backend (localhost:5173, localhost:3000).
-- VITE_API_BASE is a build-time env var, not a runtime injection point.
+- `api.js` is the sole HTTP/fetch boundary — components do not call fetch directly.
+- CORS allowlist on Go backend; `Access-Control-Allow-Methods` includes DELETE, PATCH.
+- `VITE_API_BASE` is a build-time env var, not a runtime injection point.
+- Stage2.jsx deAnonymizeText: `split(label).join(...)` pattern — immune to regex metacharacters.
 
-**Fixed in PR #52:**
-- ReDoS in Stage2.jsx deAnonymizeText: `new RegExp(label, 'g')` replaced with `split(label).join(...)` — immune to regex metacharacters.
+**Known open security items:**
+- No CSP / security headers on Go backend responses (low severity, no issue tracked).
+- Go toolchain 1.26.3 has CVEs GO-2026-5039/5037 — fixed in 1.26.4. Plan filed:
+  `.claude/plans/2-dreaming-W25-go-toolchain-cve.md`.
 
-**Known open issues (GitHub issues):**
-- #53: No CSP / security headers on Go backend responses. Severity: LOW.
-- #54: Backend error strings surfaced in Stage3 UI — information disclosure if internal errors leak. Severity: LOW.
-
-**Why:** Identified during PR #52 security review.
-
-**How to apply:** When reviewing frontend/src/components/Stage2.jsx, the deAnonymizeText function no longer uses RegExp — confirm split/join pattern is preserved. For Go API changes, check if security headers (#53) have been added.
+**How to apply:** When reviewing `frontend/src/components/`, confirm no component
+uses `fetch()` directly or renders LLM content without the `<Markdown>` wrapper.
+For Go API changes, check CORS `Access-Control-Allow-Methods` includes all verbs
+the browser sends (DELETE, PATCH needed for conversation management).

--- a/.claude/agent-memory/tech-lead/known_issues.md
+++ b/.claude/agent-memory/tech-lead/known_issues.md
@@ -1,44 +1,48 @@
 ---
 name: known_issues
-description: Prioritized improvements and fixes identified in initial codebase analysis (2026-03-14); updated 2026-03-22 to mark resolved items
+description: Known issues and open debt in the vmm-rada v2 codebase (updated 2026-06-24)
 type: project
+last-verified: 2026-06-24
 ---
 
-Initial analysis completed 2026-03-14. Updated 2026-03-22 to mark items resolved by PRs #25–#37.
+**Why:** Helps future sessions skip re-analysis and focus on actual open debt.
+**How to apply:** Check before opening new issues — may already be tracked here.
 
-**Why:** Recorded so future sessions can pick up implementation work without re-analyzing.
-**How to apply:** Work down this list in severity order. Do not add new abstractions without checking this list first for related issues.
+## v2 rewrite note
 
-## Critical
+The codebase was fully rewritten from v1 to v2 (clean-slate). The previous
+`known_issues.md` (last updated 2026-03-22) described v1 problems — all are
+now either resolved or irrelevant to the new architecture. Dead issue refs
+(#9, #13, #53, #54) were removed; those issues no longer exist.
 
-- **No API key validation at startup** — config/config.go: if AI_PROVIDER_API_KEY is empty the server starts silently and every request fails with a cryptic OpenRouter 401. Add a validation step in main.go before starting the HTTP server.
-- **Stage3SynthesizeFinal never returns an error** — council/council.go: signature returns StageThreeResult (no error), swallows the error into a string. Callers (RunFull, handler) cannot distinguish a real error from a valid "error:" response. Change the signature to return (StageThreeResult, error).
-- **No graceful shutdown** — cmd/server/main.go: `http.ListenAndServe` is called with no shutdown handling. A SIGTERM/SIGINT kills in-flight 3-stage requests mid-execution (including mid-SSE stream), leaving the conversation in a partially-written state. Add `http.Server` with `Shutdown` on signal.
+## Open (as of 2026-06-24)
 
-## High
+### Medium
 
-- ~~**Concrete type coupling breaks testability**~~ — ✅ Resolved: PR #27 (interfaces defined at consumer boundaries), PR #37 (handler tests using mock interfaces via `council.Runner`, `storage.Storer`).
-- ~~**No HTTP client timeout**~~ — ✅ Resolved: PR #25 (`http.Client.Timeout` set to 150s in openrouter.Client).
-- ~~**Title generation goroutine leaks on context cancellation**~~ — ✅ Resolved: PR #25 (title goroutine now uses `context.WithTimeout(context.Background(), 30s)`; PR #31 replaced `titleCh` with `awaitTitle func() string` closure scoped inside `if isFirst`).
-- ~~**Handler.sendMessage returns 200 for createConversation**~~ — ✅ Resolved: PR #31 (`createConversation` now returns `http.StatusCreated` 201).
-- **Config.Load() has no validation and no error return** — config/config.go: returns `*Config` without reporting missing required fields. Callers cannot distinguish misconfiguration from empty string. Add a `Validate() error` method or change Load to `Load() (*Config, error)`.
+- **Go toolchain CVE** — `go.mod` and `ci.yml` pin `1.26.3`; GO-2026-5039
+  and GO-2026-5037 are fixed in 1.26.4. Dependabot does not cover the
+  `toolchain` line — needs manual bump. Flagged W23, still open W25.
 
-## Medium
+- **Stage2.jsx bypasses `<Markdown>` wrapper** — 4 spots render bare
+  JSX string children instead of routing through `react-markdown`:
+  `Stage2.jsx:332,336,426,455`. Fidelity risk (markdown symbols render raw),
+  not XSS. Plan drafted: `.claude/plans/2-dreaming-W25-stage2-markdown.md`.
 
-- **CalculateAggregateRankings is exported without a clear consumer reason** — council/council.go: added to Runner interface in PR #36 (Kendall's W), but still called from handler. Should be folded into RunFull so the handler only calls RunFull and receives aggregate rankings + consensus W in the Result. See issue #9.
-- **Duplicate request decoding logic** — api/handler.go: `sendMessage` and `sendMessageStream` are nearly identical in their first ~25 lines (decode body, get conv, check nil, isFirst). DRY violation; extract a helper.
-- **`list` scans all files on every request** — storage/storage.go: List() reads and unmarshals every JSON file in the data dir. With hundreds of conversations this becomes slow and memory-intensive. Consider an in-memory index or a separate metadata file updated on Create/UpdateTitle.
-- ~~**Hardcoded title-generation model**~~ — ✅ Resolved: PR #27 (`TitleModel` field added to Config, defaults to `google/gemini-2.5-flash`, configurable via `TITLE_MODEL` env var).
-- **`log.Printf` is the only observability** — entire codebase: no structured logging, no request IDs, no timing, no way to correlate logs to a specific conversation or request. Adopt `log/slog` (stdlib since Go 1.21) with at minimum `conversation_id` and `model` fields. See issue #13.
-- ~~**`json.NewEncoder(w).Encode(v)` silently drops write errors**~~ — ✅ Resolved: PR #33 (writeJSON now logs encode errors via `slog.Warn` with status context).
-- ~~**Stage 2 peer-ranking prompt is embedded as a raw string literal**~~ — ✅ Resolved: PR #27 (all prompts extracted to named constants in `internal/council/prompts.go`).
-- **`sendMessageStream` does not send a `stage3_start` event before the call** — api/handler.go line 249: SSE docs say `stage3_start` should be emitted; the code emits it correctly but the `stage2_start` and `stage3_start` events are missing for the non-streaming `sendMessage` path (irrelevant there, but the asymmetry should be documented).
+### Low
 
-## Low
+- **`/fix-review` skill vs practice** — skill documents 3 named agents
+  (go-security-reviewer, code-simplifier, tech-lead); PRs #235/#238 used
+  ollama parallel models. Doc/practice divergence unresolved since W23.
+  Plan: `.claude/plans/2-dreaming-W25-fix-review-canonical.md`.
 
-- ~~**No `make lint` with a real linter**~~ — ✅ Resolved: PR #34 (`make lint` now runs `go vet ./...` + `go run honnef.co/go/tools/cmd/staticcheck ./...` via pinned `tools.go` dependency).
-- ~~**No tests**~~ — ✅ Partially resolved: PR #26 (unit tests for `parseRankingFromText`, `CalculateAggregateRankings`), PR #37 (integration tests for storage with real filesystem + race detection), PR #37 (handler tests using mock interfaces). Rada stage integration tests still absent.
-- **`validID` regex compiled at package level** — storage/storage.go: this is actually fine (package-level compiled regex is idiomatic Go), but worth noting for consistency with the rest of the analysis.
-- **`Conversation.CreatedAt` is a string (RFC3339), not `time.Time`** — storage/storage.go: string comparison `metas[i].CreatedAt > metas[j].CreatedAt` works for RFC3339 lexicographically, but using `time.Time` would be more correct and enable duration calculations. Low-priority refactor.
-- ~~**CORS allowed origins are hardcoded**~~ — ✅ Resolved: PR #31 (`CORSOrigins []string` added to Config, loaded from `CORS_ORIGINS` env var, defaults to `["http://localhost:5173", "http://localhost:3000"]`).
-- ~~**`sendMessageStream` `titleCh` channel is always created even when `!isFirst`**~~ — ✅ Resolved: PR #31 (replaced with `awaitTitle func() string` closure; channel now scoped inside `if isFirst` block entirely).
+- **5 Dependabot PRs (#241–#245)** — open since 2026-06-02, all frontend
+  dep bumps. Untriaged. Run `/review-deps` to process.
+
+## Resolved (v2 baseline)
+
+- ✅ API key validation at startup (config.go:109 errors if `AI_PROVIDER_API_KEY` empty)
+- ✅ Graceful shutdown (cmd/server/main.go — SIGTERM/SIGINT → context cancel → drain)
+- ✅ Stage3 error handling (v2 rewrite — function renamed and returns error correctly)
+- ✅ Structured logging — `log/slog` throughout all packages
+- ✅ HTTP client timeout — 120s in openrouter.Client
+- ✅ All v1 PR-based fixes (PR #25–#37) — subsumed by v2 clean rewrite


### PR DESCRIPTION
## Summary
- `tech-lead/known_issues.md` — complete rewrite: v1 analysis (2026-03-22) was describing pre-v2 code; all 3 "Critical" items are resolved in v2; dead issue refs #9/#13/#53/#54 removed; file now tracks actual open v2 debt
- `go-security-reviewer/project_frontend_security_posture.md` — updated 2026-03-31 → 2026-06-24: dead issues #53/#54 removed, Stage2.jsx bare-string exception documented with line numbers, Go toolchain CVE noted
- `agent-memory/MEMORY.md` — added 2 missing index pointers (`cors-allowed-methods.md`, `storage-title-handling.md` — both written 2026-05-31, never indexed)

Dreaming finding: 2026-W25 §4.a, §4.b, §4.c

## Test plan
- [ ] `grep -c "53\|54\|#9\|#13" .claude/agent-memory/tech-lead/known_issues.md` = 0 (dead refs gone)
- [ ] MEMORY.md has 4 entries (was 2)
- [ ] go-security-reviewer memory `last-verified: 2026-06-24`

🤖 Generated with [Claude Code](https://claude.com/claude-code)