### PR TITLE
chore(dreaming): commit W23/W24/W25 reports + W25 plans

### DIFF
--- a/.claude/dreaming/reports/2026-W23.md
+++ b/.claude/dreaming/reports/2026-W23.md
@@ -1,0 +1,83 @@
+# vmm-rada dreaming pass — 2026-W23
+
+Date: 2026-06-07
+Branch surveyed: main (HEAD `ab8fd6d`, 2026-05-31)
+Commits examined: ~40 in 30-day window; **0 merges this week** (W23, Jun 1–7)
+PRs examined: 20 merged (gh pr list --limit 20); 6 read for comments
+
+## TL;DR
+- **The biggest delta this week is good news that overturns a four-week-old finding: `/fix-review` is now actually being invoked.** PRs #235 and #238 carry structured fix-review summary tables — W19→W22 all repeated "fix-review not invoked in practice." That meta-finding is now **stale**; the flywheel turned. (`gh pr view 235/238 --json comments`)
+- **But the fix-review that ran isn't the one we documented.** #235/#238 ran an **"ollama parallel pass"** (qwen3-coder-next, minimax-m2.7, devstral-small-2 + Claude Sonnet 4.6 arbiter). Both `context-essentials.md:40` and `skills/fix-review/SKILL.md` describe **sequential `go-security-reviewer → code-simplifier → tech-lead` agent rounds**. Doc and practice have diverged. Severity: **medium**.
+- **NEW security: the pinned Go toolchain (1.26.3) now has two reachable stdlib CVEs.** govulncheck flags GO-2026-5039 (`net/textproto`, reachable from `cmd/server/main.go:192`) and GO-2026-5037 (`crypto/x509`), both fixed in **go1.26.4**. `go.mod` says `go 1.26.3`; `.github/workflows/ci.yml:22` pins `1.26.3`. Bump both to 1.26.4. Severity: **medium-high**.
+- **Two W22 high-value findings persist untouched** (no code merged this week to fix them): Stage2.jsx raw-JSX rendering and the stale `/ship` Copilot references.
+
+## 1. Context-essentials drift
+
+Checked against `main` @ `ab8fd6d`.
+
+- **Rule 4 — "`react-markdown` is the only renderer for LLM output"** — ❌ **DRIFT persists, unchanged from W22.**
+  - `frontend/src/components/Stage2.jsx` renders LLM output as bare JSX children at `:332 {revision.critique}`, `:336 {revision.content}`, `:426 {result.content}`, `:455 {aggregator.content}`.
+  - Severity: **medium**. As W22 corrected: React escapes string children, so this is **not** an XSS vector — it is a markdown-fidelity + contract violation (debate/MoA output loses formatting; the "one renderer" contract is broken).
+  - Confidence: **high**. Suggest: route all four through the shared `<Markdown>` wrapper.
+
+- **"`/fix-review` runs 3 rounds: security + simplifier + tech-lead → arbiter"** (`context-essentials.md:40`) — ⚠️ **contradicted by observed practice.** #235/#238 summaries say "ollama parallel pass" with 3 ollama cloud models, not the three named agents. Either context-essentials + `SKILL.md` are stale, or an undocumented ollama variant was run. Confidence: **medium** — see §2.
+
+- **All other rules hold (✅):**
+  - `dangerouslySetInnerHTML`/`innerHTML` — none (`grep frontend/src`).
+  - `fetch(` in `components/` — none.
+  - `setCurrent*` in `components/` — none (App.jsx owns state).
+  - `fmt.Println`/`fmt.Print*` in `cmd/` — none.
+  - `--no-verify` — no commits in window.
+  - No TypeScript in `frontend/`.
+  - Plans deleted after issue creation — `.claude/plans/` = `README.md` only.
+  - Confidence: **high**.
+
+## 2. Recurring /fix-review themes
+
+**fix-review now leaves a structured PR-comment trail** (new this week — W22 said it didn't). Two summaries available:
+
+- **PR #238** (eval harness): 8 findings, **2 confirmed / 6 dismissed**. Confirmed: `fmt.Sscanf` partial-parse accepting `"1.5xyz"` → `strconv.ParseFloat`; RNG seed reset per-call making all batch items share A/B ordering → `seed+i`. (Fixes shipped in #239.)
+- **PR #235** (conversation delete/rename): 14 findings, **1 confirmed / 11 dismissed / 2 deferred**. Confirmed: stale `conversations` closure in `handleDeleteConversation` (App.jsx:180).
+
+Themes across the two:
+- **Stale-closure / state-timing bugs in `App.jsx`** (n=1 confirmed, #235) and **off-by-seed RNG reuse** (#238) — both are "shared mutable state read at the wrong time." Low count, not yet a rule-worthy pattern, but worth watching.
+- **High dismiss rate (~80%)** — most findings are 1/3-vote false positives (CORS noise, defensive nil checks flagged as bugs, HTTP-semantics suggestions). The arbiter is doing real filtering work. Confidence: **high**.
+- **Drift signal:** the model lineup that produced these (`qwen3-coder-next:cloud`, `minimax-m2.7:cloud`, `devstral-small-2:24b-cloud`) does not match `SKILL.md`'s `go-security-reviewer / code-simplifier / tech-lead`. **Suggest: reconcile — either update `SKILL.md` + `context-essentials.md:40` to describe the ollama-parallel reality, or confirm the named-agent flow is canonical and the ollama pass was a one-off.** Confidence: **medium** (can't tell which is intended from outside).
+
+## 3. Stale plans
+- ✅ Clean. `.claude/plans/` contains only `README.md`. Convention followed (4 weeks running).
+
+## 4. Agent-memory health
+
+- **`agent-memory/MEMORY.md` index is incomplete** — NEW. It lists only `error-status-mapping.md` and `usage-cost-aggregation.md`, but two more top-level memories exist and are unindexed: `cors-allowed-methods.md` (mtime 2026-05-31) and `storage-title-handling.md` (2026-05-31). The index's own rule ("Add pointers here as agents write memories") wasn't followed. Severity: **low**. Suggest: add the two missing pointers.
+
+- **`tech-lead/known_issues.md`** — unchanged since W22 (mtime 2026-05-30). All three "Critical" items remain listed as open despite being verified-resolved in W22 (API-key validation `config.go:99`, Stage3 error returns, graceful shutdown `main.go:200`), and it still cites dead issue refs #9/#13/#53/#54. Severity: **medium**. Carryover — not yet applied.
+
+- **`go-security-reviewer/project_frontend_security_posture.md`** — mtime 2026-03-31, **now 68 days old** (was 60 at W22). Still lists #53/#54 as "open"; neither exists (tracker is empty — see §6). Severity: **low**.
+
+- **`code-generator/` and `code-simplifier/` memory dirs** — still empty. Carryover from W22; decide (keep-by-design vs remove). Severity: **low**.
+
+## 5. Skill / agent inventory
+
+- **`/ship` skill still stale (10 Copilot references)** — `grep -c copilot skills/ship/SKILL.md` = 10, unchanged from W22. Contradicts global `~/.claude/CLAUDE.md` (Copilot removed 2026-05-13). **Lower urgency than W22 framed it**, now that fix-review is demonstrably active (§2) — but the contradiction is still live and should be scrubbed. Confidence: **high**.
+
+- **Uncommitted `.claude/` working-tree changes (in flight, no PR yet):**
+  - `D .claude/skills/review-deps/SKILL.md` — the `review-deps` skill is being deleted. It's already absent from the active skill list and a `dependabot-reviewer` agent covers the role, so this looks like intentional dedup cleanup.
+  - `M .claude/skills/lib/env.sh`, `M .claude/skills/lib/rest.sh` — helper-lib edits, uncommitted.
+  - Severity: **low** (informational). Per the global rule, `.claude/` changes need explicit sign-off before they land — flagging that this work is staged locally and not yet through a PR.
+
+- **Agents (11) / skills (~10)** — set unchanged. CLAUDE.md's agent table documents 6 (`tech-lead`, `code-generator`, `bug-fixer`, `docs-maintainer`, `ci-build-agent`, `pm-issue-writer`) but 5 more exist on disk (`code-simplifier`, `security-reviewer`, `go-security-reviewer`, `static-analysis`, `test-generator`). These are sub-agents invoked by skills, so the omission is plausibly deliberate — but the table reads as exhaustive when it isn't. Severity: **low**.
+
+## 6. Patterns I noticed
+
+- **Quiet week.** No merges Jun 1–7; HEAD is still #240 from 2026-05-31. This pass is mostly a verification of W22's findings against an unchanged tree — most carryovers are unchanged simply because no code moved.
+- **The flywheel finally turned — but only halfway.** fix-review is now invoked (overturning W22 §2). Yet `/apply-dreaming` still shows **no `[applied]` annotations W19→W22**, and the W22 high-value fixes (Stage2 markdown, /ship Copilot scrub, known_issues regen) all persist verbatim. The review gate works; the dreaming-apply gate still doesn't.
+- **The issue tracker is empty (0 open issues).** Yet real, verified debt exists (Stage2 rendering, stale memories, the Go 1.26.4 bump). Nothing is queued — findings live only in dreaming reports, which aren't being applied. The gap between "known debt" and "tracked work" is the structural weak point this month.
+- **Toolchain pin is a slow-drift trap.** Pinning go-version to an exact patch (1.26.3, commit #195) is good for reproducibility but means stdlib CVEs accumulate silently until something bumps the pin. There's no dependabot equivalent for the Go *toolchain* version — only for modules. Consider a periodic govulncheck-driven bump (the `/housekeeping` skill already runs `go vet`; adding govulncheck there would catch this automatically).
+
+## 7. What I couldn't tell (need manual review)
+
+- **Is the ollama-parallel fix-review canonical or a one-off?** #235/#238 used cloud ollama models, but the skill + essentials describe named Claude agents. Can't determine intent from outside — this decides whether to update the docs or the skill.
+- **CI health on `main`** — `gh run list` not run (read-only window); can't confirm green/red rate or whether the 1.26.3 govulncheck failure already breaks CI.
+- **Whether the `.claude/skills/lib/` + `review-deps` deletion is sanctioned** — it's staged locally; per the global `.claude/`-changes rule it needs explicit approval before committing. Flagging, not judging.
+- **Whether the empty tracker + four-deep unapplied dreaming backlog is deliberate deferral or simply unread** — same ambiguity as W21/W22, still unresolved from outside.

--- a/.claude/dreaming/reports/2026-W24.md
+++ b/.claude/dreaming/reports/2026-W24.md
@@ -1,0 +1,68 @@
+# vmm-rada dreaming pass — 2026-W24
+
+Date: 2026-06-14
+Branch surveyed: main (HEAD `ab8fd6d`, 2026-05-31 — unchanged since W23)
+Commits examined: 17 in 30-day window; **0 merges this week** (W24, Jun 8–14) and **0 last week** — two quiet weeks running
+PRs examined: 20 merged (history) + 5 open Dependabot PRs
+
+## TL;DR
+- **The apply-dreaming gate has now missed 5+ consecutive weeks.** Every W22/W23 finding persists *verbatim* — Stage2.jsx markdown drift, Go 1.26.3 CVE pin, `/ship` Copilot scrub, stale agent memories. No `[applied]` markers anywhere. The dreaming pipeline writes reports nobody acts on. This is the single highest-impact structural issue. **Confidence: high.**
+- **NEW: 5 Dependabot PRs (#241–#245) have sat open since 2026-06-02 (12 days), untriaged.** A `dependabot-reviewer` agent exists for exactly this and hasn't been run. First time the open-PR queue is non-empty in this survey. **Confidence: high.**
+- **Go toolchain CVE pin still live** — `go.mod:3` and `ci.yml:22` both pin `1.26.3`; W23 flagged two reachable stdlib CVEs (GO-2026-5039, GO-2026-5037) fixed in 1.26.4. Untouched. **Severity: medium-high.**
+- The W23 report itself is still untracked (`?? .claude/dreaming/reports/2026-W23.md`) — the reports aren't even being committed, let alone applied.
+
+## 1. Context-essentials drift
+
+Checked against `main` @ `ab8fd6d` (no code moved since W23).
+
+- **Rule 4 — "`react-markdown` is the only renderer for LLM output"** — ❌ **DRIFT persists, unchanged 3 weeks.**
+  - `frontend/src/components/Stage2.jsx:332` `{revision.critique}`, `:336` `{revision.content}`, `:426` `{result.content}`, `:455` `{aggregator.content}` — bare JSX children.
+  - Severity: **medium** (markdown-fidelity + contract violation, not XSS — React escapes string children). Confidence: **high**. Suggest: route all four through the shared `<Markdown>` wrapper.
+
+- **"`/fix-review` runs 3 rounds: security + simplifier + tech-lead → arbiter"** (`context-essentials.md:40`) — ⚠️ **doc/practice divergence, carryover from W23.** PRs #235/#238 ran an "ollama parallel pass" (qwen3-coder-next, minimax-m2.7, devstral-small-2 + Sonnet arbiter), not the three named agents. Unresolved. Confidence: **medium**.
+
+- **All other rules hold (✅, confidence high):**
+  - `dangerouslySetInnerHTML`/`innerHTML` in `frontend/src` — none.
+  - `fetch(` / `setCurrent*` in `components/` — none (App.jsx owns state).
+  - No TypeScript in `frontend/`. `--no-verify` — none in window (only match is inside dreaming reports).
+  - Plans deleted after issue creation — `.claude/plans/` = `README.md` only.
+
+## 2. Recurring /fix-review themes
+
+No new merges this week → no new review trail. Carryover from W23's two analysed PRs (#235, #238):
+- **Stale-closure / state-timing bugs in `App.jsx`** + **off-by-seed RNG reuse** — both "shared mutable state read at the wrong time." Still below rule-worthy threshold (n=2). Watch.
+- **~80% arbiter dismiss rate** holds — the filter is doing real work.
+- No action needed this week; nothing new to fold into a rule.
+
+## 3. Stale plans
+- ✅ Clean. `.claude/plans/` = `README.md` only. Convention held 5 weeks running.
+
+## 4. Agent-memory health
+
+All carryover from W23, all unchanged (no memory file written this week):
+
+- **`agent-memory/MEMORY.md` index incomplete** — mtime 2026-05-30, predates the two memories it should list: `cors-allowed-methods.md` and `storage-title-handling.md` (both 2026-05-31). Index's own rule ("Add pointers as agents write memories") not followed. Severity: **low**. Suggest: add the two pointers.
+- **`tech-lead/known_issues.md`** (mtime 2026-05-30) — still lists three "Critical" items verified-resolved in W22 (API-key validation `config.go:99`, Stage3 error returns, graceful shutdown `main.go:200`) and cites dead refs #9/#13/#53/#54. Severity: **medium**. Carryover, not applied.
+- **`go-security-reviewer/project_frontend_security_posture.md`** — mtime 2026-03-31, **now 75 days old**. Still lists #53/#54 as "open"; tracker is empty. Severity: **low**.
+- **`code-generator/` and `code-simplifier/` memory dirs** — empty (no files in `find`). Carryover. Decide keep-by-design vs remove. Severity: **low**.
+
+## 5. Skill / agent inventory
+
+- **`/ship` skill still stale — 10 Copilot references** (`grep -c copilot skills/ship/SKILL.md` = 10), unchanged W22→W24. Contradicts global `~/.claude/CLAUDE.md` (Copilot removed 2026-05-13). Confidence: **high**. Should be scrubbed.
+- **`dependabot-reviewer` agent is idle while its queue fills** — 5 open Dependabot PRs and the dedicated triage agent hasn't run. This is the agent/work mismatch made concrete. Suggest: run `dependabot-reviewer` on #241–#245. Confidence: **high**.
+- **Staged `.claude/` changes still uncommitted, now ~2 weeks old:** `M lib/env.sh`, `M lib/rest.sh`, `D review-deps/SKILL.md`. Same as W23. The `review-deps` deletion looks like intentional dedup (role covered by `dependabot-reviewer`), but per the global `.claude/`-changes rule it needs explicit sign-off before landing. Flagging, not judging. Severity: **low**.
+- **CLAUDE.md agent table documents 6 of 11 on-disk agents** — the 5 sub-agents (`code-simplifier`, `security-reviewer`, `go-security-reviewer`, `static-analysis`, `test-generator`) are skill-invoked, plausibly omitted deliberately, but the table reads as exhaustive. Severity: **low**.
+
+## 6. Patterns I noticed
+
+- **Two consecutive zero-merge weeks (W23, W24).** HEAD frozen at #240 since 2026-05-31. The only repo activity is Dependabot opening PRs that nobody merges. The project is idling.
+- **The dreaming flywheel is half-broken in a specific, diagnosable way.** The *review* gate works (fix-review demonstrably ran on #235/#238). The *apply* gate has never fired: no `[applied]` markers W19→W24, and the W23/W24 reports aren't even git-committed. Findings accumulate in markdown that has no path to becoming tracked work. **The fix is mechanical: run `/apply-dreaming` once.** Every carryover in this report would clear.
+- **Empty issue tracker + filling PR queue = inverted backlog.** Zero open issues, but real debt exists (Stage2 markdown, Go 1.26.4 bump, stale memories) *and* 5 mergeable-looking dep bumps wait. Work isn't queued where the workflow can see it.
+- **Toolchain-pin CVE trap confirmed, still open.** No Dependabot equivalent for the Go *toolchain* line — only modules. W23's suggestion (add `govulncheck` to `/housekeeping`) still stands and would auto-catch the 1.26.3→1.26.4 gap.
+
+## 7. What I couldn't tell (need manual review)
+
+- **CI health on `main` and on the 5 Dependabot PRs** — `gh run list` / `gh pr checks` require approval in this read-only window; can't confirm green/red or whether the 1.26.3 govulncheck failure already breaks CI. Manual: `gh pr checks 241`.
+- **Are #241–#245 safe to batch-merge?** All are frontend dep bumps (eslint, react-dom, vitest, react, vite) since 2026-06-02. Needs the `dependabot-reviewer` agent's risk classification + CI confirmation — outside this pass's scope.
+- **Is the ollama-parallel fix-review canonical or a one-off?** Same unresolved ambiguity as W23 — decides whether to fix the docs or the skill.
+- **Is the two-week idle deliberate (project paused) or drift?** Can't determine intent from outside; it changes whether "0 merges" is a finding or a non-event.

--- a/.claude/dreaming/reports/2026-W25.md
+++ b/.claude/dreaming/reports/2026-W25.md
@@ -1,0 +1,95 @@
+# vmm-rada dreaming pass — 2026-W25
+
+Date: 2026-06-21
+Branch surveyed: main (HEAD `ab8fd6d`, 2026-05-31 — **unchanged for 21 days**)
+Commits examined: 13 in the 30-day window; **0 merges this week (W25), 0 in W24, 0 in W23** — three quiet weeks running
+PRs examined: 20 merged (history) + 5 open Dependabot PRs (all still open)
+
+## TL;DR
+- **The repo is frozen and the dreaming flywheel is still broken at the *apply* step.** HEAD has not moved since #240 (2026-05-31). W23, W24, and this W25 report are all still untracked (`??` in git status) — reports aren't even committed, let alone applied. No `[applied]` markers exist anywhere. Every actionable finding below is a verbatim carryover. **The single fix that clears this entire report is one `/apply-dreaming` run.** Confidence: **high**.
+- **5 Dependabot PRs (#241–#245) now 19 days stale** (opened 2026-06-02), untriaged. The `dependabot-reviewer` agent built for exactly this has still not been run. Confidence: **high**.
+- **Go toolchain CVE pin still live** — `go.mod:3` and `ci.yml:22` both pin `1.26.3`; W23 flagged GO-2026-5039 / GO-2026-5037 (fixed in 1.26.4). Untouched 3 weeks. Severity: **medium-high**.
+- This pass adds **no new findings** — it confirms the W24 set persists unchanged. The signal *is* the stasis.
+
+## 1. Context-essentials drift
+
+Checked against `main` @ `ab8fd6d` (no code moved since W23).
+
+- **Rule 4 — "`react-markdown` is the only renderer for LLM output"** — ⚠️ **markdown-fidelity drift persists, unchanged 4 weeks.**
+  - `frontend/src/components/Stage2.jsx:332` `{revision.critique}`, `:336` `{revision.content}`, `:426` `{result.content}`, `:455` `{aggregator.content}` — bare JSX string children, not routed through the `<Markdown>` wrapper.
+  - Severity: **medium** (fidelity + contract, **not** XSS — React escapes string children, and `dangerouslySetInnerHTML`/`innerHTML` are confirmed absent). Confidence: **high**.
+
+> [planned 2026-06-24: .claude/plans/2-dreaming-W25-stage2-markdown.md; awaiting /backlog]
+
+- **"`/fix-review` runs 3 rounds: security + simplifier + tech-lead → arbiter"** (`context-essentials.md:40`) — ⚠️ **doc/practice divergence, carryover.** PRs #235/#238 ran an "ollama parallel pass" (qwen3-coder-next, minimax-m2.7, devstral-small-2 + Sonnet arbiter), not the three named agents. Still unresolved: fix the doc or the skill. Confidence: **medium**.
+
+> [planned 2026-06-24: .claude/plans/2-dreaming-W25-fix-review-canonical.md; awaiting /backlog — requires decision on canonical approach before Tech Lead gate]
+
+- **All other rules hold (✅, confidence high):** no `dangerouslySetInnerHTML`/`innerHTML` in `frontend/src`; no `fetch(`/`setCurrentConversation` in `components/` (App.jsx owns state); no TypeScript in `frontend/`; no `--no-verify` in window (only matches are inside dreaming reports); no `fmt.Println` in `cmd/`; `.claude/plans/` = `README.md` only.
+
+> [skipped 2026-06-24: all-clear, no action]
+
+## 2. Recurring /fix-review themes
+
+No new merges → no new review trail. **PR review comments are near-zero on GitHub** (#238: 1 comment/1 review; #236: 0/1; #235: 1/2) — `/fix-review` resolves findings pre-merge, so themes can't be mined from `gh` comments alone; they live in the (uncommitted) reports. Carryover from W23's two analysed PRs:
+- **Stale-closure / state-timing bugs in `App.jsx`** + **off-by-seed RNG reuse** (#239) — both "shared mutable state read at the wrong time." Still n=2, below rule-worthy threshold. Watch.
+- ~80% arbiter dismiss rate holds — the filter does real work. No new rule warranted this week.
+
+> [skipped 2026-06-24: n=2, below rule-worthy threshold; watch in W26+]
+
+## 3. Stale plans
+- ✅ Clean. `.claude/plans/` = `README.md` only. Convention has held 6 weeks running.
+
+> [skipped 2026-06-24: no action needed]
+
+## 4. Agent-memory health
+
+All carryover from W23/W24, all unchanged (no memory file written since 2026-05-31):
+
+- **`agent-memory/MEMORY.md` index incomplete** — index (mtime 2026-05-30) lists only 2 of 4 top-level memories. Missing: `cors-allowed-methods.md` and `storage-title-handling.md` (both 2026-05-31). The index's own rule ("Add pointers as agents write memories") isn't followed. Severity: **low**. Fix: add the two pointers.
+
+> [applied 2026-06-24: added 2 missing pointers to MEMORY.md; PR #248]
+
+- **`tech-lead/known_issues.md`** (mtime 2026-05-30) — still lists three "Critical" items verified-resolved (API-key validation, Stage3 error returns, graceful shutdown) and cites dead refs #9/#13/#53/#54. Severity: **medium**.
+
+> [applied 2026-06-24: complete rewrite — v1 analysis removed, dead refs removed, current v2 open debt documented; PR #248]
+
+- **`go-security-reviewer/project_frontend_security_posture.md`** — mtime 2026-03-31, **now 82 days old**. Lists #53/#54 as "open"; issue tracker is empty (0 open issues). Severity: **low**.
+
+> [applied 2026-06-24: refreshed to 2026-06-24 — dead issues removed, Stage2 exception documented, toolchain CVE noted; PR #248]
+
+- **`code-generator/` and `code-simplifier/` memory dirs** — still empty. Decide keep-by-design vs remove. Severity: **low**.
+
+> [skipped 2026-06-24: dirs empty and not git-tracked; no action required]
+
+## 5. Skill / agent inventory
+
+- **`/ship` skill still stale — 10 Copilot references** (`grep -c -i copilot skills/ship/SKILL.md` = 10), unchanged W22→W25. Contradicts global `~/.claude/CLAUDE.md` (Copilot removed from workflow 2026-05-13). Confidence: **high**. Scrub.
+
+> [applied 2026-06-24: all 10 Copilot references removed, replaced with /fix-review; PR #247]
+
+- **`dependabot-reviewer` idle while its queue fills** — 5 open PRs, dedicated agent never run. Agent/work mismatch made concrete. Confidence: **high**.
+
+> [manual-review-required 2026-06-24: operational task — run /review-deps to triage PRs #241–#245]
+
+- **Staged `.claude/` changes still uncommitted, now ~3 weeks old:** `M lib/env.sh`, `M lib/rest.sh`, `D review-deps/SKILL.md`. The `review-deps` deletion looks like intentional dedup (role now covered by `dependabot-reviewer`), but per the global `.claude/`-changes rule it needs explicit sign-off before landing. Flagging, not judging. Severity: **low**.
+
+> [applied 2026-06-24: committed lib/env.sh, lib/rest.sh improvements + review-deps/SKILL.md deletion with explicit sign-off from /apply-dreaming "y"; PR #249]
+
+## 6. Patterns I noticed
+
+- **Three consecutive zero-merge weeks (W23–W25).** The only repo activity is Dependabot opening PRs nobody merges. Either the project is intentionally paused or it has stalled — the survey can't tell which, but the duration now makes it worth an explicit decision.
+- **The dreaming pipeline is producing write-only output.** Reports W19→W25 generated; zero `[applied]` markers; W23/W24/W25 not even git-tracked. The *review* gate works (fix-review demonstrably ran on #235/#238); the *apply* gate has never fired. This is the highest-leverage structural defect and it is mechanical to fix.
+- **Inverted backlog persists:** 0 open issues, but real debt exists (Stage2 markdown, Go 1.26.4 bump, stale memories, Copilot scrub) *and* 5 mergeable-looking dep bumps wait. Work isn't queued where the workflow can see it. Until debt becomes GitHub issues, `/ship` has nothing to pull.
+- **Toolchain-pin CVE trap confirmed, still open.** Dependabot covers modules, not the Go `toolchain`/`go` line. W23's suggestion — add `govulncheck` to `/housekeeping` — still stands and would auto-catch the 1.26.3→1.26.4 gap.
+
+> [planned 2026-06-24: .claude/plans/2-dreaming-W25-go-toolchain-cve.md; awaiting /backlog]
+
+## 7. What I couldn't tell (need manual review)
+
+- **CI health on `main` and on #241–#245** — `gh pr checks` / `gh run list` not exercised in this read-only window; can't confirm green/red or whether the 1.26.3 pin already trips govulncheck in CI. Manual: `gh pr checks 241`.
+- **Are #241–#245 safe to batch-merge?** All five are frontend dep bumps (vite, react/@types/react, vitest, react-dom, eslint) since 2026-06-02. Needs `dependabot-reviewer` risk classification + CI confirmation — outside this pass's scope.
+- **Is the ollama-parallel fix-review canonical or a one-off?** Unresolved since W23 — decides whether to fix the docs or the skill.
+- **Is the 3-week freeze deliberate or drift?** Intent isn't visible from outside; it determines whether "0 merges" is a finding or a non-event.
+
+> [manual-review-required 2026-06-24: 4 open questions requiring manual investigation or Val decision]

--- a/.claude/plans/2-dreaming-W25-fix-review-canonical.md
+++ b/.claude/plans/2-dreaming-W25-fix-review-canonical.md
@@ -1,0 +1,48 @@
+---
+type: task
+priority: p2
+labels: task, p2: medium
+github_issue: ""
+debt: quick-fix
+effort: xs
+---
+
+# Decide and document canonical /fix-review approach
+
+## Dreaming reference
+§1.b of 2026-W25 report (and W23/W24 carryovers). Confidence: medium.
+
+## Summary
+
+`context-essentials.md:40` and the `/fix-review` skill both describe 3 named agents:
+`go-security-reviewer → code-simplifier → tech-lead → arbiter`.
+
+However, PRs #235 and #238 were reviewed using an "ollama parallel pass"
+(qwen3-coder-next, minimax-m2.7, devstral-small-2 + Sonnet arbiter) — not those agents.
+
+This doc/practice divergence has persisted 3+ weeks (W23→W25). Two possible resolutions:
+
+**Option A — The 3-agent approach is canonical; the ollama run was a one-off.**
+→ No doc change needed. Add a note to the fix-review skill: "The named agents are required;
+ad-hoc model substitution is not canonical."
+
+**Option B — The ollama parallel approach is now canonical (faster/cheaper).**
+→ Update context-essentials.md:40 to say "multi-model review before merge" (remove agent names).
+→ Update fix-review SKILL.md to describe the parallel-models approach.
+→ This is the more significant change and needs Tech Lead sign-off on the new approach.
+
+## Decision needed
+
+Val should decide which option applies. This plan exists to force the decision and
+route it through the Tech Lead gate before any doc change lands.
+
+## Files to change (depends on option chosen)
+
+- Option A: `.claude/skills/fix-review/SKILL.md` — add one-off vs canonical note
+- Option B: `.claude/context-essentials.md` + `.claude/skills/fix-review/SKILL.md`
+
+## Acceptance criteria
+
+- context-essentials.md describes the actual canonical review approach
+- fix-review skill is consistent with context-essentials
+- No more doc/practice divergence flagged by future dreaming passes

--- a/.claude/plans/2-dreaming-W25-go-toolchain-cve.md
+++ b/.claude/plans/2-dreaming-W25-go-toolchain-cve.md
@@ -1,0 +1,58 @@
+---
+type: task
+priority: p2
+labels: task, p2: medium, security
+github_issue: ""
+debt: quick-fix
+effort: xs
+---
+
+# Bump Go toolchain 1.26.3 → 1.26.4 + add govulncheck
+
+## Dreaming reference
+§6 of 2026-W25 report (carryover from W23). CVEs GO-2026-5039 and GO-2026-5037
+fixed in 1.26.4; pin has been open 3+ weeks.
+
+## Summary
+
+Two CVEs in Go 1.26.3 were fixed in 1.26.4. Dependabot does not cover the
+`go` / `toolchain` directive in `go.mod` — only module deps. Needs manual bump.
+
+Additionally, the dreaming report suggests adding `govulncheck` to `/housekeeping`
+so toolchain-pin gaps are auto-detected in future passes.
+
+## Approach
+
+### Part 1 — Bump toolchain (xs effort)
+
+1. `go.mod:3`: `go 1.26.3` → `go 1.26.4`
+2. `.github/workflows/ci.yml:22`: `"1.26.3"` → `"1.26.4"`
+3. Run `go build ./...` and `go test ./...` to confirm no regressions.
+
+### Part 2 — Add govulncheck to /housekeeping (xs effort)
+
+The housekeeping skill (`skills/housekeeping/SKILL.md`) has 7 checks. Add Check 8:
+
+```
+### Check 8 — govulncheck
+
+go run golang.org/x/vuln/cmd/govulncheck@latest ./... 2>&1
+
+Pass: exit 0 (no vulnerabilities)
+Fail: list vulnerabilities with CVE IDs and affected packages
+```
+
+This catches future toolchain-pin CVE gaps that Dependabot misses.
+
+## Files to change
+
+- `go.mod` — bump `go 1.26.4`
+- `.github/workflows/ci.yml` — bump `go-version: "1.26.4"`
+- `.claude/skills/housekeeping/SKILL.md` — add Check 8
+
+## Acceptance criteria
+
+- `go.mod` and `ci.yml` both reference 1.26.4
+- `go build ./...` and `go test ./...` pass
+- `govulncheck ./...` exits 0 on the updated toolchain
+- `/housekeeping` skill includes govulncheck as Check 8

--- a/.claude/plans/2-dreaming-W25-stage2-markdown.md
+++ b/.claude/plans/2-dreaming-W25-stage2-markdown.md
@@ -1,0 +1,47 @@
+---
+type: bug
+priority: p2
+labels: bug, p2: medium, frontend
+github_issue: ""
+debt: quick-fix
+effort: xs
+---
+
+# Stage2.jsx: route LLM content through <Markdown> wrapper
+
+## Dreaming reference
+§1.a of 2026-W25 report. Rule 4 of context-essentials: "`react-markdown` is the only renderer for LLM output." Stage2.jsx bypasses this contract in 4 places.
+
+## Summary
+
+`frontend/src/components/Stage2.jsx` renders LLM-generated text as bare JSX string children in 4 spots, bypassing the `<Markdown>` wrapper that every other Stage component uses (Stage0, Stage1, Stage3, ChatInterface all import `./Markdown`).
+
+The risk is not XSS (React escapes string children; no `dangerouslySetInnerHTML` present) but markdown fidelity — bold, code blocks, lists in model output render as literal symbols instead of formatted text.
+
+## Affected lines
+
+- `:332` — `{revision.critique}` inside `<span className="debate-critique-text">`
+- `:336` — `{revision.content}`
+- `:426` — `{result.content}`
+- `:455` — `{aggregator.content}`
+
+## Approach
+
+1. Add `import Markdown from './Markdown';` at the top of `Stage2.jsx`.
+2. Replace each bare string render with `<Markdown>{field}</Markdown>`.
+   - `:332`: replace `<span className="debate-critique-text">{revision.critique}</span>` → `<Markdown>{revision.critique}</Markdown>` (the span is only there to hold text; the Markdown wrapper renders a block — check if span is needed for CSS or can be dropped).
+   - `:336`: `{revision.content}` → `<Markdown>{revision.content}</Markdown>`
+   - `:426`: `{result.content}` → `<Markdown>{result.content}</Markdown>`
+   - `:455`: `{aggregator.content}` → `<Markdown>{aggregator.content}</Markdown>`
+3. Run `npm run build` + smoke-test in the browser (debate and MoA strategies exercise these paths).
+
+## Files to change
+
+- `frontend/src/components/Stage2.jsx`
+
+## Acceptance criteria
+
+- All four fields render through `<Markdown>` — no bare string children for LLM content.
+- `npm run build` passes.
+- Strategy outputs that contain markdown (bold, code, lists) display correctly in the UI.
+- No `dangerouslySetInnerHTML` introduced.


### PR DESCRIPTION
## Summary
- Commits dreaming reports W23, W24, W25 — all were untracked for 3+ weeks
- W25 annotated with `[applied]`, `[planned]`, `[skipped]`, `[manual-review-required]` markers from today's `/apply-dreaming` run
- Three plan files created from W25 actionable findings:
  - `2-dreaming-W25-stage2-markdown.md` — Stage2.jsx bare JSX → `<Markdown>` wrapper
  - `2-dreaming-W25-fix-review-canonical.md` — decide ollama vs named-agents approach
  - `2-dreaming-W25-go-toolchain-cve.md` — bump Go 1.26.3→1.26.4 + add govulncheck to housekeeping

## Test plan
- [ ] W25 report has `[applied]` markers on §4.a, §4.b, §4.c, §5.a, §5.c
- [ ] W25 report has `[planned]` markers on §1.a, §1.b, §6
- [ ] Three plan files present in `.claude/plans/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)