### PR TITLE
⚡ task(infra): bump Go toolchain 1.26.3 → 1.26.4 + add govulncheck to /housekeeping

### DIFF
--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: housekeeping
-description: "VMM Rada recurring repo health check. Runs 7 checks (stale branches, fmt.Println leaks, tracked .env, tracked backups, TODO/FIXME count, go vet, CI test delta) and outputs a pass/fail table. Usage: /housekeeping"
+description: "VMM Rada recurring repo health check. Runs 8 checks (stale branches, fmt.Println leaks, tracked .env, tracked backups, TODO/FIXME count, go vet, CI test delta, govulncheck) and outputs a pass/fail table. Usage: /housekeeping"
 ---
 
 # Skill: /housekeeping
@@ -11,7 +11,7 @@ description: "VMM Rada recurring repo health check. Runs 7 checks (stale branche
 ## OVERVIEW
 
 ```
-/housekeeping  →  7 checks  →  Markdown table: Check | Status | Detail
+/housekeeping  →  8 checks  →  Markdown table: Check | Status | Detail
                             →  Summary: N passed, M failed
 ```
 
@@ -115,6 +115,22 @@ If CI run log available, extract test count and compare:
 - `DELTA >= 0`: Pass — "N tests (delta: +M)"
 - `DELTA < 0`: Fail — "N tests (delta: -M — tests were removed)"
 - Unable to compare: SKIP — "CI test count not available in artifacts"
+
+---
+
+### Check 8 — govulncheck
+
+**Goal:** No known vulnerabilities in the Go module graph or toolchain.
+
+```bash
+go run golang.org/x/vuln/cmd/govulncheck@latest ./... 2>&1
+```
+
+**Pass:** exit 0 — no vulnerabilities found
+**Fail:** list CVE IDs and affected packages
+**Skip:** if network unavailable or `go run` fails (offline environment)
+
+Note: findings in transitive deps unrelated to the current toolchain pin are informational — flag them but do not block the report.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
 
       - name: Install staticcheck

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/valpere/vmm-rada
 
-go 1.26.3
+go 1.26.4
 
 require github.com/joho/godotenv v1.5.1
 


### PR DESCRIPTION
## Summary

- Bumps `go.mod` and `ci.yml` from Go 1.26.3 to 1.26.4
- Fixes CVE GO-2026-5039 (`net/textproto` error injection, reachable via `net/http`) and GO-2026-5037 (`crypto/x509.VerifyHostname` quadratic DoS, reachable via TLS to LLM provider)
- Adds `govulncheck` as Check 8 to `/housekeeping` skill so future toolchain-pin gaps are detected automatically (Dependabot doesn't track the `go` directive)

Closes #253

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (332 tests, 9 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)