### PR TITLE
⚡ task(tooling): fix stale pricing entries in fix-review config.yaml

### DIFF
--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -36,10 +36,11 @@ post_summary_to_pr: true
 telemetry_enabled: true
 
 pricing:
-  "qwen3-coder-next:cloud":  { input: 0.00, output: 0.00 }
-  "deepseek-v4-flash:cloud": { input: 0.00, output: 0.00 }
-  "glm-5.1:cloud":           { input: 0.00, output: 0.00 }
-  # Local failover models
+  # Active cloud reviewers (reviewers.openrouter.round_1/2/3)
+  "qwen3-coder-next:cloud":    { input: 0.00, output: 0.00 }
+  "minimax-m2.7:cloud":        { input: 0.00, output: 0.00 }
+  "devstral-small-2:24b-cloud": { input: 0.00, output: 0.00 }
+  # Local failover models (reviewers.cli)
   "qwen3-coder:30b":  { input: 0.00, output: 0.00 }
   "qwen2.5-coder:7b": { input: 0.00, output: 0.00 }
   "granite3.3:8b":    { input: 0.00, output: 0.00 }


### PR DESCRIPTION
## Summary

- Removes inactive models (`deepseek-v4-flash:cloud`, `glm-5.1:cloud`) from `pricing:` block
- Adds missing active reviewers (`minimax-m2.7:cloud`, `devstral-small-2:24b-cloud`) — these are `round_2` and `round_3` in `reviewers.openrouter`
- Adds comments linking pricing entries to their config sections for clarity

Telemetry cost calculation now covers all 3 active reviewer models.

Closes #256

## Test plan
- [x] `go build ./...` passes
- [x] Config-only change — no source code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)