### PR TITLE
fix(tooling): sync session-last.sh + hook-common.sh with common library

### DIFF
--- a/.claude/hooks/_lib/hook-common.sh
+++ b/.claude/hooks/_lib/hook-common.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
-# Shared logging setup for vmm-rada Claude Code hooks.
+# Shared logging setup for Claude Code hooks installed via /generate-session-end.
 #
 # Usage: source this file, then call hook_setup_logging "<script-name>"
 # Sets LOG_FILE (global) and redirects stderr to the log + terminal.
+#
+# Log dir is per-project, derived from the repo name so each project's
+# hooks log separately (e.g. session-indexer -> ~/.cache/session-indexer/).
+# Override with HOOK_LOG_DIR.
 
 hook_setup_logging() {
   local script_name="$1"
-  LOG_DIR="${VMM_RADA_HOOK_LOG_DIR:-${HOME}/.cache/vmm-rada}"
+  local project_name
+  project_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")")
+  # Never operate on the ~/.cache root itself (e.g. cwd=/ with no git → basename "/" → "/").
+  case "$project_name" in ""|"/"|".") project_name="session-end-hooks" ;; esac
+  LOG_DIR="${HOOK_LOG_DIR:-${HOME}/.cache/${project_name}}"
   mkdir -p "$LOG_DIR" && chmod 700 "$LOG_DIR"
   LOG_FILE="$LOG_DIR/hooks.log"
   exec 2> >(tee -a "$LOG_FILE" >&2)

--- a/.claude/hooks/session-last.sh
+++ b/.claude/hooks/session-last.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # SessionStart hook: injects the most recent entry from .claude/session-log.md.
 #
-# Skips if the file doesn't exist or the last entry is older than 30 days.
+# Skips if the file doesn't exist or is empty. Rotation is count-based
+# (last 10 entries) — no age filtering here.
 
 set -euo pipefail
 
@@ -38,17 +39,12 @@ if [[ -z "$LAST_ENTRY" ]]; then
   exit 0
 fi
 
-# Parse date from entry header (## YYYY-MM-DD)
+# Parse date from entry header (## YYYY-MM-DD) — used only for the age label
 ENTRY_DATE=$(echo "$LAST_ENTRY" | grep -oP '^## \K\d{4}-\d{2}-\d{2}' || echo "")
 if [[ -n "$ENTRY_DATE" ]]; then
   ENTRY_TS=$(date -d "$ENTRY_DATE" +%s 2>/dev/null || echo 0)
   NOW=$(date +%s)
   AGE=$(( NOW - ENTRY_TS ))
-  MAX_AGE=$(( 30 * 24 * 3600 ))
-  if [[ $AGE -gt $MAX_AGE ]]; then
-    echo "[$(date -Iseconds)] session-last: last entry is >30d old, skipping" >> "$LOG_FILE"
-    exit 0
-  fi
   AGE_DAYS=$(( AGE / 86400 ))
   AGE_HOURS=$(( (AGE % 86400) / 3600 ))
   AGE_LABEL="${AGE_DAYS}d ${AGE_HOURS}h ago"

--- a/docs/session-recall-setup.md
+++ b/docs/session-recall-setup.md
@@ -181,8 +181,11 @@ Previous session context (2d 3h ago):
 - ...
 ```
 
-Injection is skipped only if `session-log.md` doesn't exist. Rotation is
-count-based (last 10 entries kept) — no age filtering.
+Injection is skipped if `session-log.md` doesn't exist or contains no
+`## YYYY-MM-DD` entries (e.g. an empty file). No age filtering — the age
+label is always shown so you can judge staleness yourself. Rotation
+(last 10 entries kept) is enforced by `session-end.sh` on write, not by
+this read-only injection hook.
 
 ---
 

--- a/docs/session-recall-setup.md
+++ b/docs/session-recall-setup.md
@@ -181,7 +181,8 @@ Previous session context (2d 3h ago):
 - ...
 ```
 
-Injection is skipped if the last entry is older than 30 days.
+Injection is skipped only if `session-log.md` doesn't exist. Rotation is
+count-based (last 10 entries kept) — no age filtering.
 
 ---
 


### PR DESCRIPTION
## Summary
- `session-last.sh` had drifted from the library — still used the old age-based skip (>30 days) instead of the current count-based rotation (no age filtering).
- `hook-common.sh` had drifted — still hardcoded `vmm-rada`/`VMM_RADA_HOOK_LOG_DIR` instead of the genericized `git rev-parse`-derived log dir from library fix `d5a7ce2` (the fix meant to remove vmm-rada-specific hardcoding never made it back into vmm-rada itself).
- `docs/session-recall-setup.md` had a matching stale "30 days" reference.

Found via a full re-verification of installed skills/hooks against `~/wrk/common/skills/`.

## Test plan
- [x] `bash -n` syntax check on both hook scripts
- [x] Confirmed `basename $(git rev-parse --show-toplevel)` still resolves to `vmm-rada` — hook log path unchanged (`~/.cache/vmm-rada/`)
- [x] Diffed all session-end/session-recall files against library post-fix — full match

🤖 Generated with [Claude Code](https://claude.com/claude-code)