### PR TITLE
chore(tooling): migrate off Ollama models retiring 2026-07-15

### DIFF
--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -149,10 +149,10 @@ Rules: 10-20 bullets total, Ukrainian for content, English for code/file names."
 
 try_opencode() {
   local models=(
-    "ollama/glm-5:cloud"
-    "ollama/kimi-k2.5:cloud"
-    "ollama/minimax-m2.5:cloud"
-    "ollama/qwen3-coder-next:cloud"
+    "ollama/glm-5.2:cloud"
+    "ollama/kimi-k2.7-code:cloud"
+    "ollama/minimax-m3:cloud"
+    "ollama/qwen3.5:cloud"
   )
   command -v opencode &>/dev/null || return 1
   for model in "${models[@]}"; do

--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -11,9 +11,9 @@ api_key_env: AI_PROVIDER_API_KEY
 
 reviewers:
   openrouter:
-    round_1: { model: qwen3-coder-next:cloud }    # coding-focused, cloud quality
+    round_1: { model: qwen3.5:cloud }               # coding-focused, cloud quality
     round_2: { model: minimax-m2.7:cloud }          # MiniMax, non-thinking, long-ctx
-    round_3: { model: devstral-small-2:24b-cloud } # Mistral code model, non-thinking
+    round_3: { model: gemma4:31b-cloud }            # Gemma code model, non-thinking
 
   # Local failover tier — tools-capable models, no network dependency.
   # Engages automatically when the Ollama cloud endpoint probe fails.
@@ -37,9 +37,9 @@ telemetry_enabled: true
 
 pricing:
   # Active cloud reviewers (reviewers.openrouter.round_1/2/3)
-  "qwen3-coder-next:cloud":    { input: 0.00, output: 0.00 }
-  "minimax-m2.7:cloud":        { input: 0.00, output: 0.00 }
-  "devstral-small-2:24b-cloud": { input: 0.00, output: 0.00 }
+  "qwen3.5:cloud":       { input: 0.00, output: 0.00 }
+  "minimax-m2.7:cloud":  { input: 0.00, output: 0.00 }
+  "gemma4:31b-cloud":    { input: 0.00, output: 0.00 }
   # Local failover models (reviewers.cli)
   "qwen3-coder:30b":  { input: 0.00, output: 0.00 }
   "qwen2.5-coder:7b": { input: 0.00, output: 0.00 }


### PR DESCRIPTION
## Summary
Ollama is retiring several cloud models on 2026-07-15 (per vendor email). This project actively uses two of them:

- `.claude/hooks/session-end.sh` opencode fallback list — `glm-5:cloud`, `kimi-k2.5:cloud`, `minimax-m2.5:cloud`, `qwen3-coder-next:cloud` → `glm-5.2:cloud`, `kimi-k2.7-code:cloud`, `minimax-m3:cloud`, `qwen3.5:cloud`
- `.claude/skills/fix-review/config.yaml` round_1 (`qwen3-coder-next:cloud` → `qwen3.5:cloud`) and round_3 (`devstral-small-2:24b-cloud` → `gemma4:31b-cloud`, no vendor-suggested alt exists for devstral-small-2, picked a model already proven elsewhere in the fleet for this slot). Matching `pricing:` block keys updated.

## Test plan
- [x] All five replacement tags confirmed live via `ollama pull` before committing
- [x] `bash -n` syntax check on session-end.sh
- [x] `yaml.safe_load` syntax check on config.yaml
- [ ] Run `/fix-review` on this PR to confirm the new round_1/round_3 models respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)