### PR TITLE
chore(tooling): gitignore sqlite WAL/SHM sidecar files for sessions.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ runs/
 
 # Session recall index — per-project, local-only
 .claude/sessions.db
+.claude/sessions.db-*


### PR DESCRIPTION
## Summary
- Adds `.claude/sessions.db-*` to `.gitignore`, covering SQLite WAL/SHM/journal sidecar files (`sessions.db-wal`, `sessions.db-shm`, `sessions.db-journal`) generated by `session-indexer` alongside the already-ignored `sessions.db`.

## Test plan
- N/A — gitignore-only change, no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)