### PR TITLE
chore: gitignore .playwright-mcp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ runs/
 # Session recall index — per-project, local-only
 .claude/sessions.db
 .claude/sessions.db-*
+
+# Playwright MCP scratch artifacts (console logs, page snapshots)
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Global dotfile-ignore blanket rule (`~/.gitignore_global`) was commented out, exposing Playwright MCP's local scratch artifacts (console logs, page snapshots) as untracked

## Test plan
- [ ] Verify `.playwright-mcp/` no longer shows as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)