### PR TITLE
chore: gitignore .env.diff and .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,10 @@ runs/
 
 # Playwright MCP scratch artifacts (console logs, page snapshots)
 .playwright-mcp/
+
+# Local .env diff scratch — contains real secret values, never commit
+.env.diff
+
+# MCP config — machine-specific, no secrets but per-machine server addresses
+.mcp.json
+frontend/.mcp.json


### PR DESCRIPTION
## Summary
- `.env.diff` contained a real API key in plaintext, sitting untracked but exposed once the global dotfile-ignore blanket rule stopped covering it — added to `.gitignore` (file kept on disk, just never tracked)
- `.mcp.json` / `frontend/.mcp.json` — machine-specific MCP server config (local dev addresses, placeholder auth), same pattern already gitignored in aga2aga

## Test plan
- [ ] Verify none of these three paths show as untracked in `git status`
- [ ] Confirm no secret ever reached git history (these files were never committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)