### PR TITLE
chore: track W27 dreaming report and frontend GitHub/gitignore config

### DIFF
--- a/.claude/dreaming/reports/2026-W27.md
+++ b/.claude/dreaming/reports/2026-W27.md
@@ -1,0 +1,64 @@
+# vmm-rada dreaming pass — 2026-W27
+
+Date: 2026-07-05
+Branch surveyed: main
+Commits examined: 19 (since 2026-06-05)
+PRs examined: 15 merged (#246–#270)
+
+## TL;DR
+- **`tech-lead/known_issues.md` is fully stale** — all 4 "Open" items (Go CVE, Stage2 Markdown, fix-review canonical, Dependabot #241–245) were resolved by PRs #252/#254/#257/#241–246. High confidence, direct edit candidate.
+- **Two agent-memory files reference deleted plan files** (`2-dreaming-W25-*.md`) and the removed `/review-deps` skill — dangling pointers to a workflow that no longer exists.
+- **Zero code violations of context-essentials** — frontend rules, banned patterns, `fmt.Println`, and `dangerouslySetInnerHTML` all clean.
+- Last 30 days were entirely tooling/dreaming/deps — no feature PRs, so no new `/fix-review` themes to mine.
+
+## 1. Context-essentials drift
+No drift found. Every rule verified clean:
+- **Raw HTML / `dangerouslySetInnerHTML`** — Grep over `frontend/src`: no matches (also confirmed by PR #252 `12456e8`, which routed the last Stage2.jsx bypass through `<Markdown>`). Severity: none.
+- **`fetch(` / `setCurrentConversation` in components** — Grep over `frontend/src/components`: no matches. State writes stay in `App.jsx`. Severity: none.
+- **`fmt.Println` in `cmd/`** — no matches. Severity: none.
+- **`--no-verify`** — no such commits in 30-day log. Severity: none.
+- **Squash-merge / plan lifecycle** — `.claude/plans/` holds only `README.md`; every issue-plan was deleted after creation per workflow. Severity: none.
+- **Go stack** — `go.mod` and `ci.yml` both pin `1.26.4` (PR #254). Severity: none.
+
+## 2. Recurring /fix-review themes
+None extractable this window. All 15 merged PRs were `chore(tooling)`, `chore(dreaming)`, `chore(deps)`, or single-file `⚡ task` commits. Review comment/review counts on the code-touching PRs (#252, #257) were 1–2 and procedural, not thematic. No candidate for a new rule or skill.
+- Confidence: high (that there is nothing to promote), based on `gh pr list` titles + comment counts.
+
+## 3. Stale plans
+None. `.claude/plans/` contains only `README.md` (4.1K). The W25 plans (`2-dreaming-W25-stage2-markdown.md`, `-go-toolchain-cve.md`, `-fix-review-canonical.md`) were correctly cleared after shipping (PR #267 "clear applied W25 plans"). Workflow discipline is healthy here.
+
+## 4. Agent-memory health
+
+- **tech-lead** (`known_issues.md`, mtime 2026-05-30 index / content dated 2026-06-24):
+  - **Stale — all 4 "Open" items resolved:**
+    - "Go toolchain CVE / still open W25" → **fixed** by PR #254; `go.mod` now `1.26.4`. (`known_issues.md:22-24`)
+    - "Stage2.jsx bypasses `<Markdown>`" → **fixed** by PR #252 `12456e8`. Grep confirms no bare-string LLM renders remain. (`known_issues.md:26-29`)
+    - "`/fix-review` skill vs practice divergence" → **resolved** by PR #257 (canonical rewrite) + #259/#260. (`known_issues.md:33-36`)
+    - "5 Dependabot PRs #241–245 untriaged" → **all merged** (#241,243,244,245 + #246). Also tells reader to run `/review-deps`, a **skill deleted in PR #249** (`.claude/plans` memory `feedback_no_review_deps_skill` says use `dependabot-reviewer` agent). (`known_issues.md:38-39`)
+  - Contradictions with context-essentials: none.
+  - Suggest: rewrite "Open" section — likely empty now, or demote CSP/security-headers (still genuinely open, low) as the only survivor.
+
+- **go-security-reviewer** (`project_frontend_security_posture.md`, mtime 2026-06-24):
+  - Stale: lines 16-18 still document the Stage2.jsx exception as present and reference the now-deleted plan `2-dreaming-W25-stage2-markdown.md` (line 18); line 28-29 references deleted `2-dreaming-W25-go-toolchain-cve.md` and the now-patched 1.26.3 CVE. Positive-controls list otherwise accurate.
+  - `MEMORY.md` index (mtime 2026-03-31) is the oldest file in the tree but its pointer text is still valid; only the mtime is old.
+  - Suggest: drop the Stage2 exception + Go-CVE bullets; strip dangling plan-file paths.
+
+- **code-generator / code-simplifier**: both dirs **empty** (no `MEMORY.md`). Not stale — just unused. No action.
+
+- **Top-level shared memories** (`error-status-mapping`, `usage-cost-aggregation`, `cors-allowed-methods`, `storage-title-handling`): all v2-relevant, mtimes 2026-05-30/31, no contradictions. Healthy.
+
+- **Duplicates across agents:** none found.
+
+## 5. Skill / agent inventory
+- **Skills** (`.claude/skills/`): 13 skills, all referenced in CLAUDE.md workflow. `generate-session-recall` + `session-recall` + `session-end` are the recently-added trio (PR #266) — complementary, not duplicated. No obsolete skills; `review-deps` was already removed (PR #249). No action.
+- **Agents** (`.claude/agents/`): 11 agents. `go-security-reviewer` vs `security-reviewer` have explicit non-overlapping scopes (backend Go vs frontend React) documented in their descriptions — intentional split, not redundancy. `bug-fixer` vs `code-generator` vs `static-analysis` have clear reactive/proactive/lint boundaries. No overlapping roles to consolidate.
+
+## 6. Patterns I noticed
+- **Dreaming-driven maintenance is working well.** The W25 pass filed 3 plans; all 3 shipped as PRs #252/#254/#257 and the plan files were cleaned up (PR #267). The loop closes correctly. The one gap: **agent-memory `known_issues.md` was not updated when those plans shipped** — the memory still describes them as open. Consider adding a step to `/apply-dreaming` (or the ship flow) that clears the corresponding `known_issues.md` entry when a dreaming-filed plan merges.
+- **Memory freshness lags shipping by design.** Both stale memory files carry `last-verified: 2026-06-24` — accurate as of that date, invalidated the same day by the PRs that followed in the batch. This is the classic "verified-then-immediately-superseded" trap the memory-hygiene rules warn about.
+- **`.claude/dreaming/reports/2026-W27.md` is 0B** — placeholder for this run; expected.
+
+## 7. What I couldn't tell (need manual review)
+- Whether **CSP / security headers** on the Go backend (only surviving genuine open item, low severity) is worth a plan or should be marked `wontfix`. No issue tracks it; the user's call.
+- Whether the empty `code-generator/` and `code-simplifier/` memory dirs are intentionally reserved or should be removed — harmless either way, cosmetic.
+- Review-comment *content* on #252/#257 was not deep-read (counts only). If a thematic audit is wanted, those two are the only code-touching PRs in the window worth reading in full.

--- a/frontend/.github/copilot-instructions.md
+++ b/frontend/.github/copilot-instructions.md
@@ -1,0 +1,33 @@
+# Copilot Repository Instructions
+
+## Project
+
+React 19 + Vite single-page application for **VMM Rada** — a 3-stage deliberation system where multiple LLMs answer a question, peer-review each other anonymously, and a Chairman model synthesizes a final answer.
+
+The frontend communicates with a Go backend running on port 8001 via REST and Server-Sent Events (SSE). See `docs/api-contract.md` and `docs/streaming.md` for the API contract.
+
+## Commands
+
+```bash
+npm install       # install dependencies
+npm run dev       # dev server at http://localhost:5173
+npm run build     # production build
+npm run lint      # ESLint
+```
+
+There is no test suite.
+
+## Architecture
+
+- **`src/api.js`** — single API client; `API_BASE` points to the Go backend
+- **`src/App.jsx`** — all application state; no Redux or Context API
+- **`src/components/`** — `Sidebar`, `ChatInterface`, `Stage1`, `Stage2`, `Stage3`
+
+Assistant messages are built progressively during SSE streaming. Each stage (`stage1`, `stage2`, `stage3`) starts as `null` and is filled as events arrive. `metadata` (label_to_model, aggregate_rankings) is ephemeral — returned only during streaming, not persisted by the backend.
+
+## Conventions
+
+- No TypeScript; plain JavaScript (ESM)
+- Each component has a co-located CSS file
+- All model responses rendered via `react-markdown`
+- Branch protection is active — all changes require a pull request

--- a/frontend/.github/dependabot.yml
+++ b/frontend/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,43 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Un-exclude from global gitignore's .* rule
+!.env.example
+!.npmrc
+
+# Claude Code project config (un-exclude from global gitignore's .* rule)
+!.claude/
+!.claude/agents/
+!.claude/agents/**
+!.claude/agent-memory/
+!.claude/agent-memory/**
+!.claude/plans/
+!.claude/plans/**
+!.claude/skills/
+!.claude/skills/**
+# Keep ephemeral/local files excluded:
+.claude/.onlooking-from-backend.md
+.claude/.onlooking-from-backend.md.lock
+.claude/settings.local.json
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?


### PR DESCRIPTION
## Summary
- `.claude/dreaming/reports/2026-W27.md` — consistent with W19-W25 already tracked in history
- `frontend/.gitignore` — legitimate per-subdirectory gitignore that was never added
- `frontend/.github/{copilot-instructions.md,dependabot.yml}` — real CI/Copilot config for the frontend subdirectory, never added

All three were untracked (exposed by the recent global dotfile-ignore change) but are legitimate content, not secrets — unlike `.env.diff`/`.mcp.json` handled in #272.

## Test plan
- [ ] Confirm frontend CI/Copilot behavior unaffected (files were already present on disk, just untracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)