### PR TITLE
fix(agents): add Agent to code-generator's tools list

### DIFF
--- a/.claude/agents/code-generator.md
+++ b/.claude/agents/code-generator.md
@@ -1,7 +1,7 @@
 ---
 name: code-generator
 description: Use to implement a GitHub issue from start to finish — branch, code, tests, build verification, PR. Requires a tech-lead-approved plan before starting. Never writes documentation or modifies files outside the agreed plan scope.
-tools: Bash, Glob, Grep, Read, Edit, Write, LSP
+tools: Bash, Glob, Grep, Read, Edit, Write, LSP, Agent
 model: sonnet
 memory: project
 ---


### PR DESCRIPTION
## Summary
- `code-generator.md` step 6 ("Tech Lead post-implementation review") launches the `tech-lead` agent from inside `code-generator` itself — a nested subagent spawn.
- Since Claude Code v2.1.172+, a nested spawn requires the parent to explicitly declare `Agent` in its own `tools:` list, or the spawn silently no-ops. `code-generator` was missing it — the post-implementation tech-lead review has most likely never actually run.
- Verified the other 10 agents in this repo only reference other agents in `description:` examples (for the main orchestrator's benefit), not as real nested spawns — `code-generator` is the one genuine case.
- Same bug already fixed in `ragivka` (PR #62) and in the common skills library (commit `3261611`).

## Test plan
- [ ] Next real `/ship` run that reaches code-generator's step 6 — confirm the tech-lead review actually executes and produces a verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)