### PR TITLE
docs(skills): add agent/skill boundary xref to session-recall

### DIFF
--- a/.claude/skills/session-recall/SKILL.md
+++ b/.claude/skills/session-recall/SKILL.md
@@ -129,7 +129,10 @@ Limitations:
 - Subagent tool allowlists (`bug-fixer`, `code-generator`, `tech-lead`, etc.)
   don't include the `Skill` tool — a spawned subagent can't invoke `/recall`
   or this skill itself mid-task. This section is for the orchestrator to run
-  *before* spawning, not for the subagent to run on its own.
+  *before* spawning, not for the subagent to run on its own. Same root cause
+  as the general agent/skill boundary documented in
+  `~/wrk/common/skills/README.md`'s design principles — see that note
+  before assuming any skill will auto-trigger inside a subagent.
 - No tool-call noise filtering here (unlike `/recall <query>` and
   `session-recall.sh`) — the orchestrator curates what goes into the
   subagent prompt anyway; filter manually if a query pulls in noise.


### PR DESCRIPTION
## Summary
- Adds a cross-reference paragraph to `.claude/skills/session-recall/SKILL.md`'s Limitations section, pointing at the general agent/skill boundary design principle. Same paragraph already present in the library version since 2026-07-06.
- Uses an absolute path (`~/wrk/common/skills/README.md`) instead of the library's relative `../README.md`, since vmm-rada has no local `README.md` two directories above `.claude/skills/session-recall/`.

## Test plan
- N/A — documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)