### PR TITLE
chore(skills): sync orphaned lib/rest.sh with library

### DIFF
--- a/.claude/skills/lib/rest.sh
+++ b/.claude/skills/lib/rest.sh
@@ -72,6 +72,17 @@ ollama_content() {
   printf '%s' "$1" | jq -r '.message.content // empty'
 }
 
+# Like ollama_payload_system but sets think:false (top-level field on
+# /api/chat, not inside options) and a capped num_predict. Without this,
+# reasoning-capable cloud models (deepseek, kimi, etc.) can burn their whole
+# token budget on hidden thinking and return empty content on large prompts.
+ollama_payload_system_no_think() {
+  local num_predict="${4:-4000}"
+  jq -n --arg model "$1" --arg sys "$2" --arg prompt "$3" --argjson np "$num_predict" \
+    '{model:$model, messages:[{role:"system",content:$sys},{role:"user",content:$prompt}],
+      stream:false, think:false, options:{num_predict:$np}}'
+}
+
 # ---------------------------------------------------------------------------
 # OpenRouter — /api/v1/chat/completions (OpenAI-compatible)
 # Response: { "choices": [{ "message": { "content": "..." } }] }
@@ -125,11 +136,13 @@ chat_payload_system() {
 }
 
 # Like chat_payload_system but suppresses reasoning tokens on thinking models.
-# Use for DeepSeek-family models on OpenRouter; no-op on Ollama.
+# Use for DeepSeek-family models on OpenRouter, or any reasoning-capable
+# model on Ollama (deepseek, kimi, etc. via /api/chat's top-level think field).
+# Optional 5th arg: num_predict cap, Ollama branch only (default 4000).
 chat_payload_system_no_think() {
   case "$1" in
     openrouter) openrouter_payload_system_no_think "$2" "$3" "$4" ;;
-    *)          ollama_payload_system              "$2" "$3" "$4" ;;
+    *)          ollama_payload_system_no_think      "$2" "$3" "$4" "$5" ;;
   esac
 }
 


### PR DESCRIPTION
## Summary
- `.claude/skills/lib/rest.sh` is not sourced by any `SKILL.md` in this repo (confirmed via grep) — `fix-review` uses its own `ollama-review.sh` with inline jq payloads instead. This file is a leftover from a previous `fix-review` iteration.
- Blind-copy from `~/wrk/common/skills/lib/rest.sh` — zero runtime callers means zero behavior change, but picks up the `chat_payload_system_no_think` fix for reasoning-model empty-content (deepseek/kimi) already applied upstream, in case the file is ever wired up again.
- `lib/env.sh` checked separately — already identical to the library, no change needed.

## Test plan
- [x] `bash -n` syntax check
- [x] Confirmed zero callers via `grep -rl "rest.sh\|chat_payload_system" .claude/skills/*/SKILL.md` — no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)