### PR TITLE
docs(skills): add definition-of-done and observability-checklist references

### DIFF
--- a/.claude/skills/references/definition-of-done.md
+++ b/.claude/skills/references/definition-of-done.md
@@ -1,0 +1,70 @@
+# Definition of Done
+
+Adapted from [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills)
+(MIT) — stack-neutral as-is, kept close to verbatim.
+
+A standing, project-wide bar that every change must clear before it counts as done. Unlike acceptance criteria, which vary per task and answer "did we build the right thing?", the Definition of Done is the same every time and answers "is this finished to our standard?". Use it as the final gate in `backlog` (task planning), `code-generator`'s pre-flight step, and `ship`.
+
+## Definition of Done vs. Acceptance Criteria
+
+| | Acceptance Criteria | Definition of Done |
+|---|---|---|
+| Scope | Specific to one task or spec | Applies to every increment |
+| Changes | Different for each item | Fixed and reused |
+| Answers | "Did we build *this thing*?" | "Is it *ready*?" |
+| Owner | Defined when planning the task | Defined once for the project |
+| Example | "User can reset password via email link" | "Tests pass, no regressions, docs updated" |
+
+The two are complementary. A task is done only when **its** acceptance criteria are met **and** the standing Definition of Done is satisfied. Skipping either leaves work that looks finished but is not.
+
+## The Standing Checklist
+
+Apply this to every change before declaring it done.
+
+### Correctness
+- [ ] All acceptance criteria for the task are met
+- [ ] Code runs and behaves as intended, verified at runtime, not just compiled or typechecked
+- [ ] New behavior is covered by tests that fail without the change and pass with it
+- [ ] Existing tests still pass; no regressions introduced
+- [ ] Edge cases and error paths are handled, not just the happy path
+
+### Quality
+- [ ] Code reveals intent through naming and structure; no comments needed to explain *what* it does
+- [ ] No duplicated business logic
+- [ ] No dead code, debug output, or commented-out blocks left behind
+- [ ] Changes are scoped to the task; no unrelated refactors snuck in
+- [ ] Linting and formatting pass
+
+The depth behind these items lives in `fix-review` (multi-model review) and the `code-simplifier` agent (reducing complexity without changing behavior).
+
+### Integration
+- [ ] Change works with the rest of the system, not just in isolation
+- [ ] Database migrations, config changes, and feature flags are accounted for
+- [ ] Backward compatibility considered for any public interface or API change
+
+### Documentation
+- [ ] Public interfaces, APIs, and user-facing behavior are documented
+- [ ] Architectural decisions worth preserving are recorded (see the `docs-maintainer` agent, or `docs/architecture.md` convention)
+- [ ] Documentation describes the current state in timeless language, not the change history
+
+### Ship-readiness
+- [ ] Security implications reviewed for any untrusted input, auth, or data handling (see `fix-review`'s security pass)
+- [ ] Observability in place for new critical paths (logs, metrics, traces) (see `references/observability-checklist.md`)
+- [ ] Rollback path exists for anything risky (see `ship`)
+- [ ] The human has reviewed and approved before merge or deploy
+
+## How to Apply
+
+- **Per task**: confirm the Correctness and Quality sections before checking the task off.
+- **Per feature**: confirm Integration and Documentation before considering the feature complete.
+- **Per release**: the full checklist is the floor; `ship` adds the deploy-specific gates on top.
+
+Tailor the list to the project once, then reuse it unchanged. A Definition of Done that is renegotiated every sprint is not a Definition of Done.
+
+## Red Flags
+
+- "It's done, I just haven't run it yet": unverified work is not done.
+- "Tests pass" used as a synonym for done while docs, regressions, or runtime verification are skipped.
+- A different bar applied depending on deadline pressure.
+- Acceptance criteria treated as the whole bar, with no standing quality floor.
+- "Done" declared before human review on changes that need it.

--- a/.claude/skills/references/observability-checklist.md
+++ b/.claude/skills/references/observability-checklist.md
@@ -1,0 +1,94 @@
+# Observability Checklist
+
+Adapted from [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills)
+(MIT) — stack-neutral as-is, kept close to verbatim.
+
+Quick reference for instrumenting production code.
+
+## Table of Contents
+
+- [On-Call Questions (Start Here)](#on-call-questions-start-here)
+- [Structured Logging](#structured-logging)
+- [Metrics](#metrics)
+- [Distributed Tracing](#distributed-tracing)
+- [Alerting](#alerting)
+- [Dashboards](#dashboards)
+- [Verify the Telemetry](#verify-the-telemetry)
+- [Pre-Launch Gate](#pre-launch-gate)
+
+## On-Call Questions (Start Here)
+
+Telemetry without a question is noise. Before instrumenting anything:
+
+- [ ] 2–4 questions an on-call engineer will ask about this feature are written down
+- [ ] Every signal below maps to one of those questions
+- [ ] Each question is matched to the right signal type: metrics say **that** something is wrong, traces say **where**, logs say **why**
+
+## Structured Logging
+
+- [ ] Logs are structured (JSON) with stable event names — not free-form strings
+- [ ] Every log line carries a correlation/request ID, generated or accepted at the system boundary
+- [ ] Correlation ID is propagated on every outbound call and async boundary (HTTP headers, queue metadata)
+- [ ] Log levels are consistent: `error` = invariant broken, someone may act; `warn` = degraded but handled; `info` = significant business event; `debug` = off in production
+- [ ] No secrets, tokens, passwords, or unredacted PII in any log line (hard rule, checked by `fix-review`'s security pass)
+- [ ] Fields are allowlisted — no whole request/response bodies, no auth headers
+- [ ] External service calls logged with metadata only: endpoint, status, latency, attempt count, sanitized identifiers
+- [ ] Actual log output spot-checked: structured fields, not `[object Object]`
+
+## Metrics
+
+- [ ] **RED** instrumented for every endpoint and every external dependency: Rate, Errors, Duration
+- [ ] **USE** instrumented for every resource (queues, pools, hosts): Utilization, Saturation, Errors
+- [ ] Latency is a histogram; p50/p95/p99 queryable — never an average
+- [ ] All labels come from small, fixed sets (route template, status class, provider name)
+- [ ] No unbounded label values: no user IDs, tenant IDs, emails, raw URLs, request IDs, or error message text
+- [ ] Status codes grouped by class (`5xx`, not `503`)
+- [ ] Queue depth and processing duration tracked for every worker/queue
+
+## Distributed Tracing
+
+- [ ] OpenTelemetry (or equivalent) initialized at service startup, before other imports
+- [ ] Auto-instrumentation enabled for HTTP, gRPC, and DB clients
+- [ ] Trace context propagated on every outbound call (W3C `traceparent`/`tracestate`) and extracted from every inbound request
+- [ ] Context survives async boundaries — queue messages carry trace metadata
+- [ ] Manual spans only around meaningful internal units of work, with the attributes on-call will filter by
+- [ ] No secrets or PII as span attributes
+- [ ] Head-based sampling at a low default rate; 100% of errors kept if tail sampling is available
+
+## Alerting
+
+- [ ] Every alert is symptom-based (error rate, p99 latency, queue age) — causes (CPU, disk, restarts) go to dashboards, not pagers
+- [ ] Every alert is actionable; "ignore it, it self-heals" alerts are deleted
+- [ ] Every alert links to a runbook — minimum three lines: what it means, first query to run, escalation path
+- [ ] Thresholds and durations justified by an SLO or historical data, not guesses
+- [ ] Two severities only: **page** (user-facing, act now) and **ticket** (degradation, act this week)
+- [ ] Each new alert test-fired once: it reached the right channel and the runbook link works
+- [ ] No alerts that fire daily and get acknowledged without action
+
+## Dashboards
+
+- [ ] Service health dashboard exists: error rate, latency p99, traffic, saturation
+- [ ] Dependency health panel shows per-service error rates and latency
+- [ ] Dashboard answers the on-call questions from the top of this checklist — not "everything except the answer"
+- [ ] Default time range is sensible (1h–6h, not 30d)
+
+## Verify the Telemetry
+
+Instrumentation is code; it can be wrong:
+
+- [ ] Forced an error in staging → found it in the logs by correlation ID
+- [ ] Sent test traffic → metric series appear with expected labels and sane values
+- [ ] Followed one request end-to-end in the tracing UI → no broken spans
+- [ ] An induced failure was diagnosed from telemetry alone, without reading the source
+
+## Pre-Launch Gate
+
+Before a feature ships to production, all of the following are true:
+
+- [ ] Structured logs flowing to the log aggregator
+- [ ] RED metrics visible in dashboards for every new endpoint and dependency
+- [ ] At least one symptom-based alert configured, with runbook, test-fired
+- [ ] A request can be traced across every service it touches
+- [ ] On-call knows where the runbooks are
+
+For launch-day monitoring sequence and rollback triggers, see `ship`.


### PR DESCRIPTION
## Summary
- Direct copy of `references/definition-of-done.md` and `references/observability-checklist.md` from `~/wrk/common/skills/` — no adaptation needed.
- Both files reference `fix-review`/`ship`/`docs-maintainer`/`code-simplifier`, all present here under the same names.
- `observability-checklist.md` is particularly relevant given vmm-rada's SSE streaming (`/review/stream`) and multi-model deliberation surface area.

## Test plan
- N/A — reference docs only, no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)