### PR TITLE
chore(dreaming): commit W28 report + 2 new plans

### DIFF
--- a/.claude/dreaming/reports/2026-W28.md
+++ b/.claude/dreaming/reports/2026-W28.md
@@ -1,0 +1,74 @@
+# vmm-rada dreaming pass — 2026-W28
+
+Date: 2026-07-12
+Branch surveyed: main
+Commits examined: 22 (since 2026-06-12)
+PRs examined: 20 merged (via `gh pr list`)
+
+## TL;DR
+- **New actionable CVE:** `govulncheck` flags **GO-2026-5856** (crypto/tls ECH privacy leak) in `go1.26.4`, fixed in `1.26.5`. Code is affected via `cmd/server/main.go:192` + openrouter client. Toolchain bump needed.
+- **Two agent-memory files are now stale** — every "open" item in `tech-lead/known_issues.md` and `go-security-reviewer/project_frontend_security_posture.md` was resolved by PRs #252/#254/#257 (last dreaming pass W25). They read as open debt that no longer exists.
+- **Recurring structural gap (3rd occurrence):** "Go toolchain CVE, Dependabot doesn't cover the `toolchain` line" surfaced W23 → W25 → W28. Candidate for automation, not another manual flag.
+- Context-essentials contract: **clean** — no banned-pattern violations found anywhere.
+
+## 1. Context-essentials drift
+Every rule checked; no violations.
+
+- **No raw HTML rendering of LLM output** — `grep dangerouslySetInnerHTML|innerHTML` over `frontend/src` → **no matches**. `high` confidence clean.
+- **No direct `fetch` / `setCurrentConversation` in components** — `grep` over `frontend/src/components` → **no matches**. `high` clean.
+- **Stage2.jsx routes all LLM output through `<Markdown>`** — resolved by PR #252 (`252/commit 12456e8`); `Stage2.jsx:139,239,333,337,427,456` all use `<Markdown>`. The prior W25 exception is gone. `high` clean.
+- **No `fmt.Println` in `cmd/`** — `grep fmt.Print` over `cmd/` → **no matches**. `high` clean.
+- **Backend Go / toolchain** — `go.mod:3` is `go 1.26.4` (bumped from 1.26.3 in PR #254). `high` clean (but see §6 for the new 1.26.5 CVE).
+- **Stale plans deleted after issue creation** — `.claude/plans/` holds only `README.md`. `high` clean.
+
+## 2. Recurring /fix-review themes
+None minable this window. All 22 commits since 2026-06-12 are `chore(tooling)`, `chore(deps)` (Dependabot), `chore(dreaming)`, or single-file fixes — **no feature PRs went through the `/backlog → /ship → /fix-review` pipeline**. There is no new review-comment corpus to theme-mine.
+- Confidence: `high` (that there's nothing to report), not a gap in the process.
+
+## 3. Stale plans
+- **None.** `.claude/plans/` = `README.md` only. The W25 plans (`stage2-markdown`, `go-toolchain-cve`, `fix-review-canonical`) were shipped and cleared in commit `267` (2026-07-01). Clean lifecycle — no lingering plans.
+
+## 4. Agent-memory health
+
+- **tech-lead/known_issues.md** (mtime 2026-06-24) — **stale, all "Open" items now closed:**
+  - "Go toolchain CVE … pins 1.26.3" → fixed by PR #254 (`go.mod:3` = 1.26.4). ❌ outdated.
+  - "Stage2.jsx bypasses `<Markdown>` … :332,336,426,455" → fixed by PR #252. ❌ outdated.
+  - "`/fix-review` skill vs practice divergence" → resolved by PR #257 (`rewrite SKILL.md to canonical config.yaml`). ❌ outdated.
+  - "5 Dependabot PRs #241–#245 … run `/review-deps`" → all merged 2026-06-24; **and `/review-deps` was deleted** (PR #249, use `dependabot-reviewer` agent). ❌ doubly stale.
+  - Suggest: rewrite the "Open" section — it currently lists zero genuinely-open items. `high` confidence.
+
+  > [applied 2026-07-13: rewrote Open section (now empty, points to Resolved), added W25→W28 Resolved subsection with PR refs; verified all 4 claims against current code before writing]
+
+- **go-security-reviewer/project_frontend_security_posture.md** (mtime 2026-06-24) — **partially stale:**
+  - "Exception: Stage2.jsx:332,336,426,455 renders bare JSX children" → resolved (PR #252). ❌ outdated.
+  - "Go toolchain 1.26.3 has CVEs … fixed in 1.26.4" → done (#254), but should be **replaced** with the new GO-2026-5856 (fixed 1.26.5). Rolling target.
+  - References deleted plan files (`2-dreaming-W25-*`). ❌ dead links.
+  - The positive controls (no `dangerouslySetInnerHTML`, `api.js` sole fetch boundary, CORS verbs) remain accurate. Suggest: refresh the two open items. `high`.
+
+  > [applied 2026-07-13: resolved Stage2.jsx exception folded into positive controls with PR #252 ref; Go toolchain item replaced with GO-2026-5856 + trace sites; dead plan-file links removed]
+
+- **go-security-reviewer/MEMORY.md** — mtime 2026-03-31 (>3 months); index only, content-file it points to was refreshed 2026-06-24. Cosmetic staleness, `low`.
+
+  > [applied 2026-07-13: refreshed index description to match current project_frontend_security_posture.md content]
+
+- **Empty agent dirs:** `.claude/agent-memory/code-generator/` and `.../code-simplifier/` contain **no files** (empty dirs). Either seed a MEMORY.md or leave — no harm, `low`.
+
+  > [skipped 2026-07-13: no harm as-is, seeding empty memory files without real content would be worse than leaving empty]
+
+- **Contradictions with context-essentials:** none found. Memories are consistent with the contract.
+- **Cross-agent duplicates:** the Stage2/Go-toolchain items appear in *both* tech-lead and go-security-reviewer memories — mild duplication, but scoped correctly (architectural vs security lens). Not worth deduping.
+
+## 5. Skill / agent inventory
+- **Skills:** 13 present; all referenced in CLAUDE.md workflow or global rules. No obvious orphans. `/review-deps` already removed (PR #249) — memory `feedback_no_review_deps_skill` confirms; no residue in `.claude/skills/`.
+- **Agents:** 11 present. Scopes are non-overlapping (`security-reviewer` = frontend, `go-security-reviewer` = backend; `bug-fixer` vs `code-generator` vs `static-analysis` cleanly separated). No overlap flagged.
+- No unused-skill evidence to act on this window.
+
+## 6. Patterns I noticed
+- **The Go-toolchain-CVE treadmill.** GO-2026-5039/5037 (→1.26.4, W25) is now followed by **GO-2026-5856** (→1.26.5, surfaced live by the `govulncheck` pre-tool hook during this pass). Traces: `cmd/server/main.go:192`, `internal/openrouter/client.go:202,228`, `internal/council/prompts.go:749`. This is the **third dreaming pass** touching "Dependabot doesn't cover the `toolchain` line, needs a manual bump." The recurrence itself is the finding: consider a scheduled/CI govulncheck gate that auto-opens a `p1` issue on a fixed-in version, rather than re-flagging manually each pass. `high` confidence on the CVE; `medium` on the automation suggestion.
+
+  > [planned 2026-07-13: .claude/plans/2-dreaming-W28-go-toolchain-cve.md (CVE bump, high confidence); .claude/plans/2-dreaming-W28-govulncheck-automation.md (CI/scheduled automation, medium confidence); awaiting /backlog for both]
+- **Repo is in pure maintenance mode.** ~4 weeks with zero feature work — only tooling, deps, dreaming. Not a problem, but explains why §2 is empty and why agent memories drift (nothing exercises them).
+
+## 7. What I couldn't tell (need manual review)
+- **PR review-comment corpus** — could not enumerate comment bodies; `gh pr view` loop calls were blocked by the shell hook (`simple_expansion` / approval gates) in this non-interactive session. Given all recent PRs are chore/deps, low value, but I could not *confirm* absence of substantive comments on #252/#254/#257.
+- **Whether GO-2026-5856 warrants a p1 now** — it's an ECH privacy-leak in TLS; exploitability for this server's threat model is a Tech Lead call, not derivable read-only.

--- a/.claude/plans/2-dreaming-W28-go-toolchain-cve.md
+++ b/.claude/plans/2-dreaming-W28-go-toolchain-cve.md
@@ -1,0 +1,58 @@
+---
+type: task
+priority: p2
+labels: task, p2: medium, security
+github_issue: ""
+debt: quick-fix
+effort: xs
+---
+
+# Bump Go toolchain 1.26.4 → 1.26.5 (GO-2026-5856)
+
+## Dreaming reference
+§6 of 2026-W28 report. Third occurrence of this same structural gap
+(W23 → W25 → W28) — Dependabot doesn't cover the `go`/`toolchain`
+directive in `go.mod`, only module deps.
+
+## Summary
+
+`govulncheck` flags **GO-2026-5856** (crypto/tls ECH privacy leak) in
+`go1.26.4`, fixed in `1.26.5`. Traced (toolchain-level, not
+project-code-level) via `cmd/server/main.go:192`,
+`internal/openrouter/client.go:202,228`, `internal/council/prompts.go:749`
+— all paths that link `net/http`'s TLS stack, not code this project
+directly controls.
+
+The W25 plan for the previous CVE round (GO-2026-5039/5037 → 1.26.4)
+already added `govulncheck` as Check 8 to `/housekeeping`
+(`.claude/skills/housekeeping/SKILL.md:121`) — that part is done and
+doesn't need repeating. The gap is that `/housekeeping` is manual —
+nothing runs it automatically, so this CVE sat undetected until the
+next dreaming pass found it by chance. See the companion medium-priority
+item (this same dreaming pass, §6) for the automation follow-up
+(scheduled/CI govulncheck gate) — out of scope for this plan, tracked
+separately.
+
+**Tech Lead judgment needed:** the 2026-W28 report explicitly flags
+that whether this warrants `p1` (vs. the `p2` default here) is a call
+based on ECH privacy-leak exploitability for this server's threat
+model — this plan defaults to `p2` per the previous round's precedent,
+Tech Lead may reclassify.
+
+## Approach
+
+1. `go.mod:3`: `go 1.26.4` → `go 1.26.5`
+2. `.github/workflows/ci.yml:21`: `go-version: "1.26.4"` → `"1.26.5"`
+3. Run `go build ./...` and `go test ./...` to confirm no regressions.
+4. Run `govulncheck ./...` to confirm GO-2026-5856 no longer flags.
+
+## Files to change
+
+- `go.mod` — bump `go 1.26.5`
+- `.github/workflows/ci.yml` — bump `go-version: "1.26.5"`
+
+## Acceptance criteria
+
+- `go.mod` and `ci.yml` both reference 1.26.5
+- `go build ./...` and `go test ./...` pass
+- `govulncheck ./...` no longer flags GO-2026-5856

--- a/.claude/plans/2-dreaming-W28-govulncheck-automation.md
+++ b/.claude/plans/2-dreaming-W28-govulncheck-automation.md
@@ -1,0 +1,75 @@
+---
+type: task
+priority: p2
+labels: task, p2: medium, security, ci
+github_issue: ""
+debt: balanced
+effort: s
+---
+
+# Automate govulncheck — scheduled gate instead of manual /housekeeping
+
+## Dreaming reference
+§6 of 2026-W28 report — "The Go-toolchain-CVE treadmill." Third dreaming
+pass in a row (W23 → W25 → W28) surfacing the same structural gap:
+Dependabot doesn't cover the `go`/`toolchain` directive, and the
+existing detection mechanism (`govulncheck` as Check 8 in
+`/housekeeping`, added by the W25 plan) is manual — nobody ran it
+between W25 (2026-06-21) and W28 (2026-07-12), so GO-2026-5856 sat
+undetected for ~3 weeks until the next dreaming pass happened to
+invoke it.
+
+## Summary
+
+`/housekeeping`'s govulncheck check works correctly when run, but
+relies on someone remembering to run `/housekeeping`. The fix isn't
+another manual flag — it's removing the human-memory dependency
+entirely. Two viable approaches, Tech Lead to pick:
+
+**Option A — Scheduled GitHub Actions workflow (recommended default)**
+New `.github/workflows/govulncheck.yml`, cron-triggered (e.g. daily or
+weekly — matches the cadence of `dreaming.sh`'s existing Sunday
+04:00 timer). Runs `govulncheck ./...`; on new findings, opens or
+updates a `p1`-labeled GitHub issue (idempotent — check for an
+existing open issue with a matching CVE ID before creating a
+duplicate). Non-blocking to normal PR merges (doesn't gate `ci.yml`),
+purely a detection/alerting mechanism.
+
+**Option B — Add to existing ci.yml on every PR/push to main**
+Add a `govulncheck` step to the existing `go` job in `ci.yml`. Catches
+new CVEs on every push instead of waiting for a schedule, but: (a) can
+block unrelated PRs on a vulnerability the PR author didn't introduce
+and has no fix available for yet, (b) doesn't fail fast if `main`
+itself goes quiet for weeks (same gap as Dependabot, just faster
+per-push).
+
+**Tech Lead call:** cadence (daily vs weekly), blocking vs
+informational-only, and issue-dedup strategy (by CVE ID, by go.mod
+line) all need a decision before implementation — this plan proposes
+Option A as the default but doesn't prescribe the final shape.
+
+## Approach (Option A, if selected)
+
+1. New workflow file, cron schedule (`on: schedule: cron: ...`).
+2. Run `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`.
+3. Parse output; if non-zero exit (vulnerabilities found), check for an
+   existing open GitHub issue referencing the same CVE ID(s)
+   (`gh issue list --search "GO-XXXX-XXXX in:title"`).
+4. If none exists, `gh issue create` with `p1`/`security` labels,
+   CVE ID(s), affected package(s), and fixed-in version in the body.
+5. If a matching issue already exists, no-op (avoid duplicate noise).
+
+## Files to change
+
+- New: `.github/workflows/govulncheck.yml`
+- Possibly: `.claude/skills/housekeeping/SKILL.md` — note that Check 8
+  is now redundant with the scheduled workflow, or keep both (manual
+  spot-check + automated gate aren't mutually exclusive)
+
+## Acceptance criteria
+
+- New workflow runs on schedule without manual intervention
+- A deliberately-reverted `go.mod` version (or a known-vulnerable test
+  case) triggers issue creation in a dry run
+- Re-running against an already-flagged CVE does not create a duplicate issue
+- Tech Lead has signed off on cadence + blocking/non-blocking choice


### PR DESCRIPTION
## Summary
- W28 dreaming pass report, annotated with `[applied/planned/skipped]` markers from the `/apply-dreaming` run on 2026-07-13.
- Two new plans created from W28 findings:
  - `2-dreaming-W28-go-toolchain-cve.md` — bump Go `1.26.4→1.26.5` (GO-2026-5856, crypto/tls ECH privacy leak)
  - `2-dreaming-W28-govulncheck-automation.md` — 3rd recurrence of the same structural gap (W23→W25→W28: Dependabot doesn't cover the toolchain line). `/housekeeping`'s govulncheck check (added by the W25 plan) works but is manual — proposes a scheduled/CI gate instead.

## Test plan
- N/A — dreaming report + plan drafts, no code touched. Plans await `/backlog` → Tech Lead gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)