### PR TITLE
chore(dreaming): refresh stale agent-memory per W28 pass

### DIFF
--- a/.claude/agent-memory/go-security-reviewer/MEMORY.md
+++ b/.claude/agent-memory/go-security-reviewer/MEMORY.md
@@ -1,3 +1,3 @@
 # Memory Index
 
-- [project_frontend_security_posture.md](project_frontend_security_posture.md) — Security posture of the React frontend after monorepo merge (PR #52): positive controls, known open issues (ReDoS in Stage2, no CSP)
+- [project_frontend_security_posture.md](project_frontend_security_posture.md) — Security posture of the React frontend after monorepo merge (PR #52); positive controls verified 2026-07-13, open items: no CSP headers, Go toolchain CVE (rolling target, see file for current CVE ID)

--- a/.claude/agent-memory/go-security-reviewer/project_frontend_security_posture.md
+++ b/.claude/agent-memory/go-security-reviewer/project_frontend_security_posture.md
@@ -1,21 +1,20 @@
 ---
 name: Frontend security posture
-description: Security architecture decisions and known issues for vmm-rada frontend (updated 2026-06-24)
+description: Security architecture decisions and known issues for vmm-rada frontend (updated 2026-07-13)
 type: project
-last-verified: 2026-06-24
+last-verified: 2026-07-13
 ---
 
 Frontend was originally merged into monorepo in PR #52 (2026-03-31).
 The codebase underwent a v2 clean-slate rewrite. This memory was refreshed
 2026-06-24; issues #53 and #54 no longer exist (issue tracker is empty).
 
-**Positive controls (verified 2026-06-24):**
-- All LLM output in Stage0/Stage1/Stage3/ChatInterface rendered through `<Markdown>`
-  (react-markdown wrapper) — no raw HTML injection found.
-- **Exception:** `Stage2.jsx:332,336,426,455` — 4 spots render bare JSX string children
-  for debate/MoA content. Fidelity issue (markdown symbols render raw), NOT XSS
-  (React escapes string children; no `dangerouslySetInnerHTML` found anywhere in
-  `frontend/src`). Plan filed: `.claude/plans/2-dreaming-W25-stage2-markdown.md`.
+**Positive controls (verified 2026-07-13):**
+- All LLM output in Stage0/Stage1/Stage2/Stage3/ChatInterface rendered through
+  `<Markdown>` (react-markdown wrapper) — no raw HTML injection found. The
+  former `Stage2.jsx` exception (bare JSX string children at 4 sites) was
+  resolved by PR #252 — `Stage2.jsx:139,239,333,337,427,456` all now route
+  through `<Markdown>`.
 - No hardcoded secrets or API keys in JS source.
 - No dynamic code execution patterns found.
 - `api.js` is the sole HTTP/fetch boundary — components do not call fetch directly.
@@ -25,8 +24,14 @@ The codebase underwent a v2 clean-slate rewrite. This memory was refreshed
 
 **Known open security items:**
 - No CSP / security headers on Go backend responses (low severity, no issue tracked).
-- Go toolchain 1.26.3 has CVEs GO-2026-5039/5037 — fixed in 1.26.4. Plan filed:
-  `.claude/plans/2-dreaming-W25-go-toolchain-cve.md`.
+- Go toolchain — `1.26.3` CVEs (GO-2026-5039/5037) were fixed by the bump to
+  `1.26.4` (PR #254). A new CVE surfaced 2026-07-12: **GO-2026-5856**
+  (crypto/tls ECH privacy leak), fixed in `1.26.5`, currently un-patched.
+  Rolling target — see dreaming report `2026-W28.md` §6 for trace sites
+  (`cmd/server/main.go:192`, `internal/openrouter/client.go:202,228`,
+  `internal/council/prompts.go:749`). Whether this warrants a `p1` is a
+  Tech Lead call (ECH privacy-leak exploitability for this server's threat
+  model), not yet decided as of 2026-07-13.
 
 **How to apply:** When reviewing `frontend/src/components/`, confirm no component
 uses `fetch()` directly or renders LLM content without the `<Markdown>` wrapper.

--- a/.claude/agent-memory/tech-lead/known_issues.md
+++ b/.claude/agent-memory/tech-lead/known_issues.md
@@ -1,8 +1,8 @@
 ---
 name: known_issues
-description: Known issues and open debt in the vmm-rada v2 codebase (updated 2026-06-24)
+description: Known issues and open debt in the vmm-rada v2 codebase (updated 2026-07-13)
 type: project
-last-verified: 2026-06-24
+last-verified: 2026-07-13
 ---
 
 **Why:** Helps future sessions skip re-analysis and focus on actual open debt.
@@ -15,28 +15,20 @@ The codebase was fully rewritten from v1 to v2 (clean-slate). The previous
 now either resolved or irrelevant to the new architecture. Dead issue refs
 (#9, #13, #53, #54) were removed; those issues no longer exist.
 
-## Open (as of 2026-06-24)
+## Open (as of 2026-07-13)
 
-### Medium
+None. All items tracked as of the W25 dreaming pass were resolved by
+2026-07-01 (see W25→W28 resolutions below). Repo has been in pure
+maintenance mode since — tooling/deps only, no feature work — see
+dreaming report `2026-W28.md` §6 for the current watch item (Go
+toolchain CVE GO-2026-5856, fixed in 1.26.5).
 
-- **Go toolchain CVE** — `go.mod` and `ci.yml` pin `1.26.3`; GO-2026-5039
-  and GO-2026-5037 are fixed in 1.26.4. Dependabot does not cover the
-  `toolchain` line — needs manual bump. Flagged W23, still open W25.
+## Resolved (W25 → W28, closed by 2026-07-01)
 
-- **Stage2.jsx bypasses `<Markdown>` wrapper** — 4 spots render bare
-  JSX string children instead of routing through `react-markdown`:
-  `Stage2.jsx:332,336,426,455`. Fidelity risk (markdown symbols render raw),
-  not XSS. Plan drafted: `.claude/plans/2-dreaming-W25-stage2-markdown.md`.
-
-### Low
-
-- **`/fix-review` skill vs practice** — skill documents 3 named agents
-  (go-security-reviewer, code-simplifier, tech-lead); PRs #235/#238 used
-  ollama parallel models. Doc/practice divergence unresolved since W23.
-  Plan: `.claude/plans/2-dreaming-W25-fix-review-canonical.md`.
-
-- **5 Dependabot PRs (#241–#245)** — open since 2026-06-02, all frontend
-  dep bumps. Untriaged. Run `/review-deps` to process.
+- ✅ Go toolchain CVE (GO-2026-5039/5037) — `go.mod` bumped to `1.26.4` (PR #254)
+- ✅ Stage2.jsx bypassing `<Markdown>` — all render sites now route through it (PR #252): `Stage2.jsx:139,239,333,337,427,456`
+- ✅ `/fix-review` skill vs practice divergence — SKILL.md rewritten to canonical `config.yaml`-driven flow (PR #257)
+- ✅ 5 Dependabot PRs (#241–#245) — all merged/closed by 2026-06-24; `/review-deps` skill itself later deleted (PR #249), superseded by `dependabot-reviewer` agent
 
 ## Resolved (v2 baseline)
 


### PR DESCRIPTION
## Summary
- `tech-lead/known_issues.md` — all 4 "Open" items were stale (resolved by PRs #252/#254/#257/#249). Verified each claim against current code before rewriting; Open section now correctly empty, moved to a new "Resolved (W25→W28)" subsection with PR refs.
- `go-security-reviewer/project_frontend_security_posture.md` — folded the resolved Stage2.jsx `<Markdown>` exception into positive controls, replaced the Go-toolchain open item with the new GO-2026-5856 CVE (tracked separately in `.claude/plans/2-dreaming-W28-go-toolchain-cve.md`), removed dead links to deleted W25 plan files.
- `go-security-reviewer/MEMORY.md` — refreshed index description (was pointing at a stale "ReDoS in Stage2" mention no longer present in the target file).

## Test plan
- N/A — memory/docs-only change, no code touched. All factual claims independently verified via grep/gh before writing (go.mod version, Stage2.jsx render sites, fix-review SKILL.md contents, Dependabot PR states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)