### PR TITLE
⚡ task(tooling): bump Go toolchain 1.26.4 → 1.26.5 (GO-2026-5856)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Install staticcheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ configuration.
 
 ## Stack
 
-- **Backend:** Go 1.26.3
+- **Backend:** Go 1.26.5
 - **Frontend:** React 19 + Vite 8, plain JavaScript (no TypeScript) — lives in `frontend/`
 - **LLM Gateway:** configurable provider via `AI_PROVIDER_NAME` (default `openrouter`); URL override via `LLM_API_BASE_URL` for Ollama / vLLM
 - **API key:** `.env` → `AI_PROVIDER_API_KEY=<key>` (use any non-empty placeholder for keyless providers)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/valpere/vmm-rada
 
-go 1.26.4
+go 1.26.5
 
 require github.com/joho/godotenv v1.5.1
 


### PR DESCRIPTION
## Summary
- Bumps Go toolchain `1.26.4` → `1.26.5` — `govulncheck` flagged **GO-2026-5856** (crypto/tls ECH privacy leak), fixed in `1.26.5`. Toolchain-level (net/http's TLS stack), not project-code-level.
- Tech Lead confirmed `p2` (not `p1`) — this server terminates no inbound TLS (`main.go:192` plain `ListenAndServe()`) and never configures ECH.
- Also bumps a stale `CLAUDE.md:28` reference (`Go 1.26.3`) that was missed during the previous CVE round.

Closes #282

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `govulncheck ./...` — no vulnerabilities found (confirmed GO-2026-5856 cleared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)