### PR TITLE
⚖️ task(ci): automate govulncheck — scheduled daily gate

### DIFF
--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -132,6 +132,13 @@ go run golang.org/x/vuln/cmd/govulncheck@latest ./... 2>&1
 
 Note: findings in transitive deps unrelated to the current toolchain pin are informational — flag them but do not block the report.
 
+Backstopped by `.github/workflows/govulncheck.yml` (daily scheduled scan,
+auto-opens a `p1`/`security` issue on new findings) — this manual check
+is now a spot-check, not the only detection mechanism. Keep both: the
+scheduled workflow catches drift when nobody runs `/housekeeping` for
+weeks (the gap that let GO-2026-5856 sit undetected W25→W28); this
+check is still useful for an immediate pre-push read.
+
 ---
 
 ## OUTPUT FORMAT

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,90 @@
+name: govulncheck
+
+# Scheduled (not PR-gating) by design: the gap this closes is `main`
+# going quiet for weeks with no pushes to trigger a scan — a
+# push/PR-triggered check would never fire during exactly that dormant
+# window. See .claude/dreaming/reports/2026-W28.md §6 and issue #283.
+on:
+  schedule:
+    - cron: '0 6 * * *' # daily, offset from dreaming.sh's Sunday 04:00 timer
+  workflow_dispatch: {} # allow manual runs (e.g. a dry-run test)
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run govulncheck
+        id: govulncheck
+        run: |
+          set +e
+          go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 -json ./... > govulncheck-output.json 2> govulncheck-stderr.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Report tool error (not a vulnerability finding)
+        if: steps.govulncheck.outputs.exit_code == '1'
+        run: |
+          echo "::error::govulncheck itself failed (exit 1) — see govulncheck-stderr.log"
+          cat govulncheck-stderr.log
+          exit 1
+
+      # govulncheck exit codes: 0 = clean, 3 = vulnerabilities found
+      # (reachable in the call graph), 1 = tool error.
+      - name: Create or update issues for new findings
+        if: steps.govulncheck.outputs.exit_code == '3'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          CVE_IDS=$(jq -r 'select(.finding != null) | .finding.osv' govulncheck-output.json | sort -u)
+
+          if [ -z "$CVE_IDS" ]; then
+            echo "::error::govulncheck exited 3 (vulnerabilities found) but no .finding entries parsed — check govulncheck-output.json"
+            exit 1
+          fi
+
+          while IFS= read -r CVE; do
+            EXISTING=$(gh issue list --repo "${{ github.repository }}" --state open \
+              --search "$CVE in:title" --json number --jq 'length')
+
+            if [ "$EXISTING" -gt 0 ]; then
+              echo "Issue for $CVE already open — skipping (dedup by CVE ID)"
+              continue
+            fi
+
+            TRACE=$(jq -r --arg cve "$CVE" \
+              'select(.finding.osv == $cve) | .finding.trace[0] |
+               "- \(.package // "unknown package"): \(.function // .receiver // "")"' \
+              govulncheck-output.json | sort -u)
+
+            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+            BODY_FILE=$(mktemp)
+            {
+              printf '## Summary\n\n'
+              printf 'Scheduled `govulncheck` run flagged **%s** as reachable in the call graph.\n\n' "$CVE"
+              printf 'Affected package(s)/call site(s):\n%s\n\n' "$TRACE"
+              printf 'Full JSON output: see the [workflow run](%s) logs.\n\n' "$RUN_URL"
+              printf '## Acceptance Criteria\n\n'
+              printf '- Toolchain or module bumped to a version where `govulncheck ./...` no longer flags %s\n' "$CVE"
+              printf '- `go build ./...` and `go test ./...` pass after the bump\n'
+            } > "$BODY_FILE"
+
+            gh issue create --repo "${{ github.repository }}" \
+              --title "security(tooling): $CVE flagged by govulncheck" \
+              --label "task" --label "p1: high" --label "security" \
+              --body-file "$BODY_FILE"
+          done <<< "$CVE_IDS"


### PR DESCRIPTION
## Summary
- New `.github/workflows/govulncheck.yml` — scheduled daily scan (`cron: '0 6 * * *'`), not PR-gating. Closes the "main goes quiet for weeks, nobody remembers to run /housekeeping" gap that let GO-2026-5856 sit undetected ~3 weeks (W25→W28).
- Tech Lead decisions applied: scheduled not PR-gating, daily cadence, informational-only (opens/updates `p1`/`security` issue, dedup by CVE ID), explicit `permissions: {contents: read, issues: write}`, pinned `govulncheck@v1.6.0` not `@latest`.
- Uses `go-version-file: go.mod` instead of a hardcoded version string — avoids a 4th drift point after today's `go.mod`/`ci.yml`/`CLAUDE.md` version-sync work.
- Created the `security` label (didn't exist in this repo).
- `.claude/skills/housekeeping/SKILL.md` — noted Check 8 is now backstopped by the scheduled workflow (kept, not redundant).

Closes #283

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] YAML syntax validated
- [x] jq trace-extraction logic verified against govulncheck's actual `Finding`/`Frame` JSON schema (source-level check) using synthetic multi-CVE fixtures — caught and fixed an incorrect `.package.name` assumption (real field is a flat `.package` string) before it could silently break issue creation on a real finding
- [ ] Post-merge: trigger via `workflow_dispatch` against a deliberately-reverted `go.mod` for a live dry run (can't simulate locally — local Go toolchain doesn't downgrade via `go.mod`'s minimum-version directive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)