### PR TITLE
chore: track W29 dreaming report

### DIFF
--- a/.claude/dreaming/reports/2026-W29.md
+++ b/.claude/dreaming/reports/2026-W29.md
@@ -1,0 +1,61 @@
+# vmm-rada dreaming pass — 2026-W29
+
+Date: 2026-07-19
+Branch surveyed: chore/remove-generate-session-recall
+Commits examined: 34 (since 2026-06-19)
+PRs examined: 20 merged + issue list (10 recent, all CLOSED)
+
+## TL;DR
+- **One newly-stale agent memory:** `go-security-reviewer/project_frontend_security_posture.md` still lists **GO-2026-5856 as "currently un-patched" on `go.mod 1.26.4`** — but `go.mod` is now `1.26.5` (PR #285/#282) and the CVE is fixed. This is the *inverse* of the W28 finding (W28 flagged it as open; it's now closed). `high`.
+- **W28 findings all resolved with closure:** the recurring "Go-toolchain-CVE treadmill" was structurally fixed, not just re-flagged — `govulncheck.yml` scheduled gate shipped (#286/#283) + toolchain bump (#285/#282). Issues #282 and #283 both CLOSED.
+- **Context-essentials contract: clean** — no banned-pattern violations anywhere (identical to W28).
+- **Repo still in pure maintenance mode** — ~7 weeks, zero feature PRs. §2 (fix-review themes) remains unmineable.
+
+## 1. Context-essentials drift
+Every rule checked; no violations. Same clean state as W28.
+
+- **No raw HTML rendering of LLM output** — `git grep dangerouslySetInnerHTML|innerHTML` over `frontend/src` → **no matches**. `high` clean.
+- **No direct `fetch` in components** — `git grep 'fetch('` over `frontend/src/components` → **no matches**. `high` clean.
+- **No state writes outside App.jsx** — `git grep setCurrent` over `frontend/src/components` → **no matches**. `high` clean.
+- **No `fmt.Println` in `cmd/`** — `git grep fmt.Println -- cmd` → **no matches**. `high` clean.
+- **No `--no-verify`** — no commit in history references it (one false-positive match `f228d4d` is an unrelated docs commit whose subject contains "Stage…"). `high` clean.
+- **Backend Go toolchain** — `go.mod` = `go 1.26.5` (bumped in PR #285). `high` clean.
+- **Plans deleted after issue creation** — `.claude/plans/` holds only `README.md`. `high` clean.
+
+## 2. Recurring /fix-review themes
+None minable this window — unchanged from W28. All 34 commits since 2026-06-19 are `chore(tooling)`, `chore(dreaming)`, `chore(skills)`, `docs(skills)`, or single-file fixes. **No feature PR traversed `/backlog → /ship → /fix-review`.** No review-comment corpus to theme-mine.
+- Confidence: `high` (nothing to report, not a process gap).
+
+## 3. Stale plans
+- **None.** `.claude/plans/` = `README.md` only. The two W28 plans (`go-toolchain-cve`, `govulncheck-automation`) were promoted to issues #282/#283 and cleared in commit `0b0f2a0` (#284). Clean lifecycle.
+
+## 4. Agent-memory health
+
+- **go-security-reviewer/project_frontend_security_posture.md** (last-verified 2026-07-13) — **NEWLY STALE:**
+  - Lines 27–34: "GO-2026-5856 … fixed in `1.26.5`, **currently un-patched**" and "Whether this warrants a `p1` is a Tech Lead call … not yet decided as of 2026-07-13." → **Resolved.** `go.mod` is now `1.26.5` (PR #285), issue #282 CLOSED. The item should move to a resolved/positive-control note, not read as open debt.
+  - Positive controls (Markdown-only render, `api.js` sole fetch boundary, CORS verbs, no secrets) remain accurate.
+  - Suggest: fold the GO-2026-5856 item into "resolved" and note the new `govulncheck.yml` gate now catches future toolchain CVEs automatically. `high`.
+
+- **tech-lead/known_issues.md** (last-verified 2026-07-13) — **mildly stale:**
+  - Lines 22–24: "Open: None … see W28 §6 for the current watch item (GO-2026-5856, fixed in 1.26.5)." → the watch item is now **resolved** (#285). One-line refresh to point at the `govulncheck.yml` automation instead of a live watch item. `medium`.
+
+- **Empty agent dirs** — `.claude/agent-memory/code-generator/` and `.../code-simplifier/` still empty (both confirmed `(empty)`). W28 intentionally skipped seeding these; no change warranted. `low`.
+
+- **User auto-memory `feedback_session_recall.md`** (in `MEMORY.md` index) — potentially stale: it records "Per-project session-end + session-recall (semantic search) fully implemented." The **per-project session-recall skill was removed** this window (PR #287 `1320e14`, plus `3cd293a` removing the installer) — it moved to user-level. `session-end` skill remains project-local. Suggest verifying/refreshing this memory to reflect the user-level migration. `medium` (this is auto-memory, adjacent to the dreaming scope).
+
+- **Contradictions with context-essentials:** none. **Cross-agent duplicates:** the Go-toolchain item still appears in both tech-lead and go-security-reviewer memories — both now need the same "resolved" update; scoped correctly, not worth deduping.
+
+## 5. Skill / agent inventory
+- **Skills:** `.claude/skills/` = apply-dreaming, backlog, doubt-driven-development, find-bugs, fix-review, housekeeping, improve, revival, self-learn, session-end, ship (+ `lib/`, `references/`). All referenced in CLAUDE.md workflow or global rules. `doubt-driven-development` added this window (#276). **`session-recall` correctly absent** — removed as project skill (#287), now user-level. No orphans.
+- **Agents:** 11 present, scopes non-overlapping (`security-reviewer`=frontend, `go-security-reviewer`=backend; `bug-fixer`/`code-generator`/`static-analysis` cleanly separated). No overlap flagged. Unchanged from W28.
+- **CI:** `.github/workflows/` = `ci.yml` + `govulncheck.yml` (new, #286). The scheduled-CVE-gate automation the last three dreaming passes recommended now exists.
+
+## 6. Patterns I noticed
+- **The CVE treadmill was actually closed.** W23→W25→W28 kept re-flagging "Dependabot doesn't cover the `toolchain` line, manual bump needed." W28 promoted the fix to a plan; this window it *shipped* — `govulncheck.yml` scheduled daily gate (#286/#283) plus the reactive bump to 1.26.5 (#285/#282). This is the healthy outcome: a recurring manual finding converted into automation. Future toolchain CVEs should now surface via CI, not dreaming passes.
+- **Dreaming-driven remediation loop is working.** W28's four applied `[applied 2026-07-13]` annotations + two `[planned]` plans → both plans became issues → both issues shipped and closed within the same week. The pipeline (`dreaming report → plan → /backlog → issue → /ship`) demonstrably closes.
+- **~7 weeks of maintenance-only mode.** Zero feature work since early June. Explains empty §2 and why agent memories drift (nothing exercises them). Not a defect — but if this persists, the feature-oriented agents (code-generator, test-generator) and their memory dirs will keep aging without use.
+
+## 7. What I couldn't tell (need manual review)
+- **Live `govulncheck` confirmation** — the `govulncheck ./...` run was blocked by the shell approval gate in this non-interactive session. I infer GO-2026-5856 is patched from `go.mod 1.26.5` (the fixed-in version per W28 §6) + the closed issue #282, but could not observe a clean scan directly. `medium` confidence on "clean"; the new `govulncheck.yml` CI gate is the authoritative check.
+- **PR review-comment corpus** — could not enumerate comment bodies (all recent PRs are chore/deps/skills anyway; low value).
+- **Whether `feedback_session_recall.md` needs rewrite vs. deletion** — depends on how the user-level session-recall now relates to the still-project-local `session-end` skill; that boundary is a user call, not derivable read-only.


### PR DESCRIPTION
## Summary
- W29 dreaming pass report — confirms both W28 findings fully resolved (issues #282/#283 closed, CVE treadmill structurally fixed via `govulncheck.yml`).
- Flags one newly-stale agent memory (`go-security-reviewer/project_frontend_security_posture.md` still shows GO-2026-5856 as un-patched on `go.mod 1.26.4` — now `1.26.5`) and a mildly-stale `tech-lead/known_issues.md` watch-item reference. Not applied here — report only, `/apply-dreaming` can process these next.
- Stripped a stray leftover thinking-fragment line that had leaked into the top of the report file before committing.

## Test plan
- N/A — dreaming report only, no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)