### PR TITLE
chore(dreaming): refresh stale agent-memory per W29 pass

### DIFF
--- a/.claude/agent-memory/go-security-reviewer/project_frontend_security_posture.md
+++ b/.claude/agent-memory/go-security-reviewer/project_frontend_security_posture.md
@@ -1,8 +1,8 @@
 ---
 name: Frontend security posture
-description: Security architecture decisions and known issues for vmm-rada frontend (updated 2026-07-13)
+description: Security architecture decisions and known issues for vmm-rada frontend (updated 2026-07-19)
 type: project
-last-verified: 2026-07-13
+last-verified: 2026-07-19
 ---
 
 Frontend was originally merged into monorepo in PR #52 (2026-03-31).
@@ -24,14 +24,17 @@ The codebase underwent a v2 clean-slate rewrite. This memory was refreshed
 
 **Known open security items:**
 - No CSP / security headers on Go backend responses (low severity, no issue tracked).
-- Go toolchain — `1.26.3` CVEs (GO-2026-5039/5037) were fixed by the bump to
-  `1.26.4` (PR #254). A new CVE surfaced 2026-07-12: **GO-2026-5856**
-  (crypto/tls ECH privacy leak), fixed in `1.26.5`, currently un-patched.
-  Rolling target — see dreaming report `2026-W28.md` §6 for trace sites
-  (`cmd/server/main.go:192`, `internal/openrouter/client.go:202,228`,
-  `internal/council/prompts.go:749`). Whether this warrants a `p1` is a
-  Tech Lead call (ECH privacy-leak exploitability for this server's threat
-  model), not yet decided as of 2026-07-13.
+
+**Resolved (Go toolchain CVE treadmill):**
+- `1.26.3` CVEs (GO-2026-5039/5037) fixed by the bump to `1.26.4` (PR #254).
+  `1.26.4`'s own **GO-2026-5856** (crypto/tls ECH privacy leak) fixed by the
+  bump to `1.26.5` (PR #285, issue #282) — Tech Lead confirmed `p2` (server
+  terminates no inbound TLS, ECH never configured). `go.mod` currently pins
+  `1.26.5`.
+- This recurring manual-detection gap is now closed structurally: a
+  scheduled daily `govulncheck.yml` CI gate (PR #286, issue #283) opens a
+  `p1`/`security` issue automatically on future toolchain CVEs — no longer
+  dependent on a dreaming pass noticing.
 
 **How to apply:** When reviewing `frontend/src/components/`, confirm no component
 uses `fetch()` directly or renders LLM content without the `<Markdown>` wrapper.

--- a/.claude/agent-memory/tech-lead/known_issues.md
+++ b/.claude/agent-memory/tech-lead/known_issues.md
@@ -1,8 +1,8 @@
 ---
 name: known_issues
-description: Known issues and open debt in the vmm-rada v2 codebase (updated 2026-07-13)
+description: Known issues and open debt in the vmm-rada v2 codebase (updated 2026-07-19)
 type: project
-last-verified: 2026-07-13
+last-verified: 2026-07-19
 ---
 
 **Why:** Helps future sessions skip re-analysis and focus on actual open debt.
@@ -15,17 +15,19 @@ The codebase was fully rewritten from v1 to v2 (clean-slate). The previous
 now either resolved or irrelevant to the new architecture. Dead issue refs
 (#9, #13, #53, #54) were removed; those issues no longer exist.
 
-## Open (as of 2026-07-13)
+## Open (as of 2026-07-19)
 
-None. All items tracked as of the W25 dreaming pass were resolved by
-2026-07-01 (see W25→W28 resolutions below). Repo has been in pure
-maintenance mode since — tooling/deps only, no feature work — see
-dreaming report `2026-W28.md` §6 for the current watch item (Go
-toolchain CVE GO-2026-5856, fixed in 1.26.5).
+None. Repo has been in pure maintenance mode for ~7 weeks — tooling/deps
+only, no feature work. The Go-toolchain-CVE recurrence (W23→W25→W28) is
+now structurally closed, not just re-flagged: a scheduled daily
+`govulncheck.yml` CI gate (PR #286, issue #283) auto-opens a `p1`/
+`security` issue on future toolchain CVEs — no watch-item to track here
+anymore.
 
-## Resolved (W25 → W28, closed by 2026-07-01)
+## Resolved (W25 → W29)
 
-- ✅ Go toolchain CVE (GO-2026-5039/5037) — `go.mod` bumped to `1.26.4` (PR #254)
+- ✅ Go toolchain CVE (GO-2026-5039/5037 → 1.26.4, PR #254; GO-2026-5856 → 1.26.5, PR #285/#282)
+- ✅ Go-toolchain-CVE detection automated — `govulncheck.yml` scheduled daily gate (PR #286/#283), replaces manual `/housekeeping` Check 8 as the primary detection path
 - ✅ Stage2.jsx bypassing `<Markdown>` — all render sites now route through it (PR #252): `Stage2.jsx:139,239,333,337,427,456`
 - ✅ `/fix-review` skill vs practice divergence — SKILL.md rewritten to canonical `config.yaml`-driven flow (PR #257)
 - ✅ 5 Dependabot PRs (#241–#245) — all merged/closed by 2026-06-24; `/review-deps` skill itself later deleted (PR #249), superseded by `dependabot-reviewer` agent

--- a/.claude/dreaming/reports/2026-W29.md
+++ b/.claude/dreaming/reports/2026-W29.md
@@ -36,12 +36,20 @@ None minable this window — unchanged from W28. All 34 commits since 2026-06-19
   - Positive controls (Markdown-only render, `api.js` sole fetch boundary, CORS verbs, no secrets) remain accurate.
   - Suggest: fold the GO-2026-5856 item into "resolved" and note the new `govulncheck.yml` gate now catches future toolchain CVEs automatically. `high`.
 
+  > [applied 2026-07-19: folded GO-2026-5856 into a new "Resolved" subsection with PR/issue refs, noted govulncheck.yml as the new detection mechanism]
+
 - **tech-lead/known_issues.md** (last-verified 2026-07-13) — **mildly stale:**
   - Lines 22–24: "Open: None … see W28 §6 for the current watch item (GO-2026-5856, fixed in 1.26.5)." → the watch item is now **resolved** (#285). One-line refresh to point at the `govulncheck.yml` automation instead of a live watch item. `medium`.
 
+  > [applied 2026-07-19: Open section refreshed to point at govulncheck.yml automation, Resolved section extended with W25→W29 range and both GO-2026-5856 PRs]
+
 - **Empty agent dirs** — `.claude/agent-memory/code-generator/` and `.../code-simplifier/` still empty (both confirmed `(empty)`). W28 intentionally skipped seeding these; no change warranted. `low`.
 
+  > [skipped 2026-07-19: report itself states "no change warranted"]
+
 - **User auto-memory `feedback_session_recall.md`** (in `MEMORY.md` index) — potentially stale: it records "Per-project session-end + session-recall (semantic search) fully implemented." The **per-project session-recall skill was removed** this window (PR #287 `1320e14`, plus `3cd293a` removing the installer) — it moved to user-level. `session-end` skill remains project-local. Suggest verifying/refreshing this memory to reflect the user-level migration. `medium` (this is auto-memory, adjacent to the dreaming scope).
+
+  > [applied 2026-07-19: rewrote to distinguish command-surface migration (/recall → user-level, PRs #287/#288) from mechanism (hooks + sessions.db, verified unchanged/still project-local per PR bodies); direct edit to Claude's own auto-memory, outside this git repo]
 
 - **Contradictions with context-essentials:** none. **Cross-agent duplicates:** the Go-toolchain item still appears in both tech-lead and go-security-reviewer memories — both now need the same "resolved" update; scoped correctly, not worth deduping.
 


### PR DESCRIPTION
## Summary
- `go-security-reviewer/project_frontend_security_posture.md` — GO-2026-5856 was showing as "currently un-patched" on `go.mod 1.26.4`; verified `go.mod` is now `1.26.5` (PR #285) before rewriting, folded into a new Resolved subsection noting `govulncheck.yml` (PR #286) as the ongoing detection mechanism.
- `tech-lead/known_issues.md` — Open section still pointed at a live GO-2026-5856 watch item; refreshed to note the item is closed and detection is now automated, extended Resolved range to W25→W29.
- W29 dreaming report annotated with `[applied/skipped]` markers.

## Test plan
- N/A — memory/docs-only change, no code touched. `go.mod` version verified against current repo state before rewriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)