### PR TITLE
docs: mark frontend/ deprecated — moved to vmm-rada-web-ui

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,11 +26,13 @@ configuration.
 ## Stack
 
 - **Backend:** Go 1.26.5
-- **Frontend:** React 19 + Vite 8, plain JavaScript (no TypeScript) — lives in `frontend/`
+- **Frontend:** React 19 + Vite 8, plain JavaScript (no TypeScript). **`frontend/` is deprecated** (2026-07-19) — active frontend development moved to [`vmm-rada-web-ui`](https://github.com/valpere/vmm-rada-web-ui); this copy is a historical snapshot, not a place for new changes.
 - **LLM Gateway:** configurable provider via `AI_PROVIDER_NAME` (default `openrouter`); URL override via `LLM_API_BASE_URL` for Ollama / vLLM
 - **API key:** `.env` → `AI_PROVIDER_API_KEY=<key>` (use any non-empty placeholder for keyless providers)
 
 ## Frontend architecture rules (immutable)
+
+> **`frontend/` is deprecated** — see [`vmm-rada-web-ui`](https://github.com/valpere/vmm-rada-web-ui) for active development. These rules still apply to this snapshot's code but new work does not belong here.
 
 These constraints are enforced by the `tech-lead` agent and must not be violated:
 

--- a/docs/frontend/development-workflow.md
+++ b/docs/frontend/development-workflow.md
@@ -1,5 +1,10 @@
 # Development Workflow
 
+> **⚠️ `frontend/` is deprecated.** Active frontend development moved to
+> [`vmm-rada-web-ui`](https://github.com/valpere/vmm-rada-web-ui)
+> (2026-07-19). This document describes the workflow for the historical
+> snapshot in this monorepo, not the current active repo.
+
 This document describes the full development process for the VMM Rada frontend — from idea to merged code. It covers the roles of humans, skills, and agents, how they interact, and which tool to reach for in each situation.
 
 ---

--- a/docs/frontend/user-guide.md
+++ b/docs/frontend/user-guide.md
@@ -1,5 +1,9 @@
 # VMM Rada — User Guide
 
+> **⚠️ `frontend/` is deprecated.** Active frontend development moved to
+> [`vmm-rada-web-ui`](https://github.com/valpere/vmm-rada-web-ui)
+> (2026-07-19), which has its own up-to-date user guide.
+
 VMM Rada is a deliberation tool that asks several AI models the same question, has them peer-review each other's answers, then produces a synthesized final answer. The goal is a response that is more considered, more balanced, and less prone to a single model's blind spots than any individual model could produce alone.
 
 ---

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,17 @@
+# ⚠️ Deprecated — moved to `vmm-rada-web-ui`
+
+This directory is **deprecated**. The frontend was extracted (2026-07-19)
+into its own standalone repository, which is now the sole ongoing home
+for frontend development:
+
+**https://github.com/valpere/vmm-rada-web-ui**
+
+This copy is kept in place for now (code and CI here are unchanged and
+still work) but should be treated as a historical snapshot, not a place
+to make new changes. New frontend work belongs in `vmm-rada-web-ui`.
+
+Whether/when this directory is removed from the monorepo is a separate,
+later decision — not yet made as of this notice.
+
+See `docs/frontend/` in this repo for the (now-historical) API contract,
+streaming spec, and workflow docs that describe this snapshot.


### PR DESCRIPTION
## Summary
- Frontend development was extracted into its own standalone repo ([vmm-rada-web-ui](https://github.com/valpere/vmm-rada-web-ui)) as a one-time migration.
- This is a **notice-only** change — `frontend/`'s code and CI are untouched and still work. New `frontend/README.md` (didn't exist before), plus a deprecation note in `CLAUDE.md` and both `docs/frontend/*.md` files.
- Whether/when `frontend/` is removed from this monorepo is a separate, later decision — not made here.

## Test plan
- N/A — documentation-only change, no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)