### PR TITLE
⚡ test(council): add build-time invariant — every Strategy registered or exempted

### DIFF
--- a/.claude/agent-memory/MEMORY.md
+++ b/.claude/agent-memory/MEMORY.md
@@ -8,4 +8,6 @@ Each entry below is a link to a memory file with a one-line description.
 - [cors-allowed-methods.md](cors-allowed-methods.md) — CORS Access-Control-Allow-Methods must include every verb used by browser fetch (DELETE, PATCH); missing verbs cause preflight 405
 - [storage-title-handling.md](storage-title-handling.md) — SaveTitle already on Storer; maxTitleRunes=50 truncates (not rejects); no RenameConversation needed
 
+- [rolebased-strategy-orphan.md](rolebased-strategy-orphan.md) — RoleBased strategy is implemented but unregistered; two-phase guard-then-extract plan (invariant test must derive enum via AST, not a hand list)
+
 <!-- Add pointers here as agents write memories. Keep under 200 lines. -->

--- a/.claude/agent-memory/rolebased-strategy-orphan.md
+++ b/.claude/agent-memory/rolebased-strategy-orphan.md
@@ -1,0 +1,27 @@
+---
+name: rolebased-strategy-orphan
+description: RoleBased Strategy is implemented+tested but has no registration path; two-phase plan to guard then extract it
+type: project
+---
+
+`council.RoleBased` (enum in `internal/council/types.go`, impl `rolebased.go`,
+dispatched `runner.go`) is implemented and tested but is **never registered** in
+`cmd/server/main.go` — no env-var family constructs `CouncilType{Strategy: RoleBased}`,
+so it is unreachable in production. Tracked as a gap in `docs/requirements.md#6-gap-analysis`
+and `docs/strategies.md` (issue #177).
+
+**Why:** Came out of an ideation session on what to do with the orphaned strategy.
+Decision is a two-phase plan:
+- Phase 1 (issue for plan `2-strategy-registration-invariant-test.md`): a test-only
+  build-time invariant — every `Strategy` constant must be registered in `main.go` or
+  explicitly exempted with a reason. `RoleBased` gets the sole exemption.
+- Phase 2 (not yet planned): extract RoleBased's mechanism into `MixtureOfAgents` as a
+  role-assignment mode and delete the standalone enum value; the exemption entry is
+  removed then.
+
+**How to apply:** When reviewing Phase-1 code, the invariant test must derive the strategy
+set from the enum via AST (parse the `Strategy = iota` block in types.go), NOT a
+hand-maintained slice — a hand list reintroduces the same drift the test exists to prevent.
+When Phase 2 lands, expect the `RoleBased` const and its exemption entry to be removed
+together. See [[usage-cost-aggregation]] for the layering rule that council impl details
+stay out of the handler/main wiring.

--- a/internal/council/strategy_wiring_test.go
+++ b/internal/council/strategy_wiring_test.go
@@ -1,0 +1,150 @@
+package council
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// registrationExemptions lists Strategy names that are intentionally
+// implemented but not registered in cmd/server/main.go, with the reason.
+// TestAllStrategiesRegisteredOrExempted treats these as satisfied without
+// requiring a main.go registration path.
+var registrationExemptions = map[string]string{
+	"RoleBased": "implemented but intentionally unregistered pending extraction " +
+		"into MixtureOfAgents as a role-assignment mode; see " +
+		"docs/requirements.md#gap-analysis and docs/strategies.md",
+}
+
+// TestAllStrategiesRegisteredOrExempted fails if a Strategy constant declared
+// in types.go has neither a registration path in cmd/server/main.go nor an
+// explicit entry in registrationExemptions. This makes "implemented but
+// silently unreachable" strategies structurally impossible to introduce
+// without a deliberate decision — the exact gap RoleBased fell into.
+func TestAllStrategiesRegisteredOrExempted(t *testing.T) {
+	root := projectRoot(t)
+
+	declared := strategyConstNames(t, filepath.Join(root, "internal", "council", "types.go"))
+	registered := registeredStrategyNames(t, filepath.Join(root, "cmd", "server", "main.go"))
+
+	for _, name := range declared {
+		if registered[name] {
+			continue
+		}
+		if reason, ok := registrationExemptions[name]; ok && reason != "" {
+			t.Logf("Strategy %q is exempted from registration: %s", name, reason)
+			continue
+		}
+		t.Errorf("Strategy %q has no registration path in cmd/server/main.go and no "+
+			"entry in registrationExemptions — either register it or add an exemption "+
+			"with a reason", name)
+	}
+
+	declaredSet := make(map[string]bool, len(declared))
+	for _, name := range declared {
+		declaredSet[name] = true
+	}
+	for name := range registrationExemptions {
+		if !declaredSet[name] {
+			t.Errorf("registrationExemptions has entry %q but no such Strategy constant "+
+				"exists in types.go — remove the stale exemption", name)
+		}
+	}
+}
+
+// projectRoot resolves the repository root relative to this test file, so
+// the test works regardless of the working directory `go test` is run from.
+func projectRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed to resolve this test file's path")
+	}
+	// thisFile: <root>/internal/council/strategy_wiring_test.go
+	return filepath.Join(filepath.Dir(thisFile), "..", "..")
+}
+
+// strategyConstNames parses the `Strategy = iota` const block in the given
+// types.go file and returns the declared constant names, in source order.
+// Deriving names from the source of truth (rather than a hand-maintained
+// list) means adding an 8th Strategy constant is automatically picked up —
+// no separate list to remember to update.
+func strategyConstNames(t *testing.T, path string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST || len(gd.Specs) == 0 {
+			continue
+		}
+		first, ok := gd.Specs[0].(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		typeIdent, ok := first.Type.(*ast.Ident)
+		if !ok || typeIdent.Name != "Strategy" {
+			continue
+		}
+
+		var names []string
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, n := range vs.Names {
+				names = append(names, n.Name)
+			}
+		}
+		return names
+	}
+
+	t.Fatalf("no `const (... Strategy = iota ...)` block found in %s", path)
+	return nil
+}
+
+// registeredStrategyNames parses cmd/server/main.go and returns the set of
+// strategy names referenced as a `Strategy: council.<Name>` field inside a
+// composite literal. Deliberately scoped to main.go's registry-building
+// code, never internal/council/runner.go's dispatch switch — that switch
+// references every strategy by construction, which would make this check a
+// tautology.
+func registeredStrategyNames(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	found := make(map[string]bool)
+	ast.Inspect(file, func(n ast.Node) bool {
+		kv, ok := n.(*ast.KeyValueExpr)
+		if !ok {
+			return true
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != "Strategy" {
+			return true
+		}
+		sel, ok := kv.Value.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkgIdent, ok := sel.X.(*ast.Ident)
+		if !ok || pkgIdent.Name != "council" {
+			return true
+		}
+		found[sel.Sel.Name] = true
+		return true
+	})
+	return found
+}


### PR DESCRIPTION
## Summary
- Adds `TestAllStrategiesRegisteredOrExempted` (`internal/council/strategy_wiring_test.go`) — AST-derives the full `Strategy` name set from `types.go`'s const block and checks each is either registered in `cmd/server/main.go` or explicitly exempted with a reason.
- No hand-maintained name list: the check derives strategy names directly from the source of truth, so an 8th `Strategy` constant is automatically covered without remembering to update a separate list (Tech Lead review requirement).
- `RoleBased` is exempted here, citing its planned resolution — extraction into `MixtureOfAgents` as a role-assignment mode (tracked as a follow-up issue).
- Test-only change — no production code moves.

Closes #300

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes (334 tests, 8 packages)
- [x] Manually confirmed the test fails when the `RoleBased` exemption is removed, then restored it — proves the check catches the gap it claims to catch

🤖 Generated with [Claude Code](https://claude.com/claude-code)