### PR TITLE
docs: sync architecture-v2.md and strategy-showcase.md with RoleBased registration

### DIFF
--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -172,10 +172,21 @@ The `default` arm is unreachable today (every strategy has a case), but is retai
 
 #### `RoleBased` pipeline (2 stages, Stage 2 stub)
 
+Implemented in `internal/council/rolebased.go`. Best for questions that benefit from
+genuinely distinct cognitive lenses on the same prompt — broad exploration, self-critique,
+fact-checking rigor, and concision — rather than independent full-answer competition
+(that's `PeerReview`) or domain-specialist role assignment (roles are fixed generic
+lenses, not configurable per-domain personas).
+
 1. **Stage 1** — `runRoleBasedStage1`: roles run concurrently; model assignment is `ct.Models[i % len(ct.Models)]`. Labels are role names, not anonymised.
 2. **Quorum check** — same `checkQuorum`. `QuorumMin` is typically set to `len(Roles)` so every specialist must succeed; the runner does not enforce this — it's a registration-time choice.
 3. **Stage 2** — skipped. A minimal `Stage2CompleteData{Results:[], Metadata:{AggregateRankings:[], ConsensusW:1.0}}` event is emitted for SSE compatibility.
 4. **Stage 3** — `runRoleBasedStage3`: chairman synthesises across all role findings.
+
+Registration is opt-in AND requires both `ROLE_BASED_MODELS` and
+`ROLE_BASED_CHAIRMAN_MODEL`. Role content (names/instructions) is fixed as
+`council.DefaultRoles` — Generator, Critic, Verifier, Simplifier — not env-configurable;
+see [`strategies.md`](./strategies.md) for the registration contract.
 
 #### `Majority` pipeline (2 stages, no LLM Stage 2)
 

--- a/docs/strategy-showcase.md
+++ b/docs/strategy-showcase.md
@@ -19,7 +19,13 @@ deliberation strength. Machine-readable version: `eval/benchmarks/strategy-showc
 
 ## RoleBased
 
-*Best when multiple specialist angles are needed on the same problem.*
+*Best for multi-dimensional questions, where a broad-exploration draft, a self-critique
+pass, a fact-check pass, and a concise final distillation each surface something the
+others miss. The shipped role set (`council.DefaultRoles`: Generator/Critic/Verifier/
+Simplifier) is generic — these prompts are chosen so a genuinely thorough answer
+naturally needs to cover several angles, not because the system assigns one role per
+named domain (it doesn't have configurable domain-specialist roles like "legal" or
+"security").*
 
 | # | Prompt |
 |---|--------|


### PR DESCRIPTION
## Summary
- `architecture-v2.md`'s RoleBased section was missing the "Implemented in... Best for..." intro and "Registration is opt-in..." closing note every other strategy section already has (#303 registered it, but this file's template wasn't updated). Added both.
- `strategy-showcase.md`'s RoleBased tagline implied domain-specialist role assignment (technical/legal/security/UX-style) — doesn't match the shipped generic Generator/Critic/Verifier/Simplifier role set. Corrected the tagline; example prompts are unchanged since the rubrics grade final answer substance, not literal role labels.

Follow-up from #303 — found while doing a post-merge docs sweep.

## Test plan
- [x] Docs-only change, no code touched — `go build`/`go vet`/`go test` unaffected (already green on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)