### PR TITLE
chore(config): retire minimax-m2.5 in RADA_MODELS example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,7 @@ AI_PROVIDER_API_KEY=<sk-or-v1-...>
 RADA_MODELS=anthropic/claude-sonnet-4.6,openai/gpt-5.4-mini,google/gemini-3.1-flash-lite-preview,qwen/qwen3.6-plus
 #
 # [3] Development (free) — UI/pipeline iteration only, ranking compliance will vary:
-# RADA_MODELS=google/gemma-4-31b-it:free,nvidia/nemotron-3-super-120b-a12b:free,minimax/minimax-m2.5:free,arcee-ai/trinity-large-preview:free
+# RADA_MODELS=google/gemma-4-31b-it:free,nvidia/nemotron-3-super-120b-a12b:free,minimax/minimax-m2.7:free,arcee-ai/trinity-large-preview:free
 
 # ── Chairman model ────────────────────────────────────────────────────────────────────────────────────────────────────────────
 # Model used to synthesise the Stage 3 final answer.


### PR DESCRIPTION
## Summary
- Ollama is retiring `minimax-m2.5` cloud model on 2026-07-31. Updates the commented-out free-tier `RADA_MODELS` example in `.env.example` to `minimax-m2.7` (the active `RADA_MODELS` line already uses the current models).
- Also fixed the same stale reference in `.env` locally (gitignored, not part of this PR) and in the sibling `context/00-prompts-backend.md` doc table (outside the repo, edited directly).

## Test plan
- [x] Comment-only change, no functional effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)