### PR TITLE
⚖️ bug(api): golden-file contract tests; fix conversation-closed bug and docs/api.md drift

### DIFF
--- a/.claude/agent-memory/MEMORY.md
+++ b/.claude/agent-memory/MEMORY.md
@@ -8,6 +8,8 @@ Each entry below is a link to a memory file with a one-line description.
 - [cors-allowed-methods.md](cors-allowed-methods.md) — CORS Access-Control-Allow-Methods must include every verb used by browser fetch (DELETE, PATCH); missing verbs cause preflight 405
 - [storage-title-handling.md](storage-title-handling.md) — SaveTitle already on Storer; maxTitleRunes=50 truncates (not rejects); no RenameConversation needed
 
+- [stage0-done-not-on-wire.md](stage0-done-not-on-wire.md) — stage0_done is EventFunc-internal only, never on the SSE wire; recurring doc-drift trap across api.md/user-guide.md/strategies.md
+
 - [rolebased-strategy-orphan.md](rolebased-strategy-orphan.md) — RoleBased resolved: registered standalone (opt-in ROLE_BASED_* env family); extraction-into-MoA overruled by user
 
 <!-- Add pointers here as agents write memories. Keep under 200 lines. -->

--- a/.claude/agent-memory/stage0-done-not-on-wire.md
+++ b/.claude/agent-memory/stage0-done-not-on-wire.md
@@ -1,0 +1,25 @@
+---
+name: stage0-done-not-on-wire
+description: stage0_done is an internal EventFunc-only event, never emitted on the SSE wire — recurring source of doc drift
+type: project
+---
+
+`stage0_done` fires on the `council.EventFunc` callback but is **never written to the SSE
+wire**. `internal/api/handler.go`'s `onEvent` handles `case "stage0_done"` by setting
+`stage0Event` for control flow only, with the comment "Do not emit to client — stage 1
+will follow immediately." Stage 1 begins directly after Stage 0 resolves.
+
+**Why:** this internal/wire distinction has produced identical drift in at least three
+docs (`docs/api.md` event sequence + a dedicated `### stage0_done` section,
+`docs/user-guide.md` SSE transcript, `docs/strategies.md` event table), because the event
+genuinely exists in the pipeline — it just never reaches a client.
+`docs/pipeline.md` is the one place the term is used *correctly*, since it describes
+callback-level flow, not the wire.
+
+**How to apply:** when reviewing any doc or frontend change that lists SSE events, check
+whether `stage0_done` is being presented as a wire event — if so, REJECT that line. When
+a plan proposes fixing this drift in one file, require the sweep across all wire-level
+docs; a single-file fix leaves the trap in place. Same rule for any future event handled
+in `onEvent` without a `sendSSE` call.
+
+Related: [[error-status-mapping]]

--- a/docs/api.md
+++ b/docs/api.md
@@ -66,6 +66,7 @@ is written), so a proper HTTP status code is always possible.
 | SSE streaming not supported by server | `500` | `"streaming not supported"` |
 | Round-N with already-answered round | `409` | `"clarification round already answered"` |
 | Round-N with no pending clarification round | `409` | `"no pending clarification round"` |
+| Message sent to a closed conversation | `409` | `"conversation is closed"` |
 
 ### SSE error events
 
@@ -254,7 +255,7 @@ Send a message and receive the full deliberation result in a single JSON respons
 > { "answers": [ {"id": "q1", "text": "MySQL 5.7"}, {"id": "q2", "text": ""} ] }
 > ```
 
-**Response `200 OK`** — `AssistantMessage`
+**Response `200 OK`** — `AssistantMessage`, once the pipeline reaches Stage 3:
 
 ```json
 {
@@ -289,7 +290,25 @@ Send a message and receive the full deliberation result in a single JSON respons
 }
 ```
 
-**Errors:** `400` (invalid body/UUID), `404` (not found), `503` (quorum not met), `500`.
+**Response `200 OK`** — different shape if Stage 0 fires (chairman has questions before
+generation): the pipeline pauses and this endpoint returns immediately with the round
+data instead of an `AssistantMessage`. Send another request to the same endpoint with
+`{"answers": [...]}` (not `content`) to continue.
+
+```json
+{
+  "stage0_round_complete": {
+    "round": 1,
+    "questions": [
+      {"id": "q1", "text": "What database are you currently using and at what scale?"}
+    ]
+  }
+}
+```
+
+**Errors:** `400` (invalid body/UUID), `404` (not found), `409` (conversation is closed,
+or round-N conflicts — see [error reference](#pre-sse-http-errors)), `503` (quorum not
+met), `500`.
 
 ---
 
@@ -326,10 +345,9 @@ There is no `event:` line — demux by the `"type"` field of the JSON payload.
 ## SSE event sequence
 
 ```
-data: {"type":"stage0_round_complete","data":{"round":1,"questions":[...]}}   ← stream closes here (Stage 0 enabled)
+data: {"type":"stage0_round_complete","data":{"round":1,"questions":[...]}}
+data: {"type":"complete"}                                                     ← stream ends here (Stage 0 enabled)
   … client submits answers via new POST …
-data: {"type":"stage0_done"}                                                  ← Stage 1 follows
-
 data: {"type":"stage1_complete","data":[...StageOneResult]}
 data: {"type":"stage2_complete","data":[...StageTwoResult],"metadata":{...Metadata}}
 data: {"type":"stage3_complete","data":{...StageThreeResult}}
@@ -370,7 +388,9 @@ After an error event the stream ends. No `complete` event follows.
 
 ### `stage0_round_complete`
 
-Emitted when the chairman has questions for the user. The SSE stream **closes** after this event. The client must open a new stream with `{answers:[...]}` to continue.
+Emitted when the chairman has questions for the user. A `complete` event is sent
+immediately after (no title — Stage 3 hasn't run yet), then the stream ends. The client
+must open a new stream with `{answers:[...]}` to continue.
 
 ```json
 {
@@ -385,13 +405,11 @@ Emitted when the chairman has questions for the user. The SSE stream **closes** 
 }
 ```
 
-### `stage0_done`
-
-Emitted when the Stage 0 loop ends — chairman said "enough", limits were reached, or the user submitted all-empty answers. `stage1_complete` follows immediately on the same stream.
-
-```json
-{ "type": "stage0_done" }
-```
+There is no `stage0_done` event on the wire. Internally, the Stage 0 loop tracks a
+"done" state (chairman said "enough", limits were reached, or the user submitted
+all-empty answers) to decide whether to proceed to Stage 1 — but that transition is
+silent from the client's perspective: the stream simply continues straight into
+`stage1_complete` with no event marking the boundary.
 
 ### `stage1_complete`
 
@@ -428,6 +446,7 @@ on the event object, not nested inside `data`.
 ```json
 {
   "type": "stage2_complete",
+  "kind": "peer_ranking",
   "data": [
     {
       "reviewer_label": "Response B",
@@ -448,6 +467,9 @@ on the event object, not nested inside `data`.
   }
 }
 ```
+
+`kind` is always present on the wire (no `omitempty`) — see [Stage 2 `kind`
+values](./strategies.md#stage-2-kind-values) for the full discriminator table.
 
 `aggregate_rankings` are sorted by `score` ascending (lower = better rank).
 `consensus_w` is a 0–1 weight indicating agreement across reviewers.

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -95,7 +95,8 @@ Every strategy emits the same event family:
 
 | Slot | Meaning | Mandatory? |
 |------|---------|------------|
-| `stage0_round_complete` / `stage0_done` | Clarification round-trips | No (skipped if `MaxRounds == 0`) |
+| `stage0_round_complete` | Clarification round-trips | No (skipped if `MaxRounds == 0`) |
+| `stage0_done` | Internal state marker only — **not sent on the wire**. Tracked by the handler to decide whether to proceed to Stage 1; a client never sees this event. | N/A |
 | `stage1_complete` | Initial generation results | Yes |
 | `stage2_complete` | Intermediate processing | Yes (may be a stub) |
 | `stage3_complete` | Final synthesis | Yes |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -216,9 +216,9 @@ The streaming endpoint emits [Server-Sent Events](https://developer.mozilla.org/
 ```
 → POST /api/conversations/{id}/message/stream
 
-← data: {"type":"stage0_round_complete","data":{"round":1,"questions":[...]}}   ← default-on; stream closes
+← data: {"type":"stage0_round_complete","data":{"round":1,"questions":[...]}}   ← default-on
+← data: {"type":"complete"}                                                     ← stream ends here
   → POST /api/conversations/{id}/message/stream  {"answers":[...]}              ← client re-opens
-← data: {"type":"stage0_done"}                                                  ← Stage 1 follows
 
 ← data: {"type":"stage1_complete","data":[...]}
 

--- a/internal/api/contract_test.go
+++ b/internal/api/contract_test.go
@@ -1,0 +1,309 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/valpere/vmm-rada/internal/council"
+	"github.com/valpere/vmm-rada/internal/storage"
+)
+
+// updateGolden regenerates testdata/*.golden from current handler output.
+// Regenerated files are reviewed via `git diff` like any other source
+// change — that review is the drift check this test suite exists to
+// provide. Run: go test ./internal/api/... -run TestContract -update
+var updateGolden = flag.Bool("update", false, "update golden files")
+
+// checkGolden compares got against testdata/<name>.golden, or writes it
+// when -update is passed. JSON bodies should be pretty-printed by the
+// caller before calling this, for stable, readable diffs.
+func checkGolden(t *testing.T, name string, got []byte) {
+	t.Helper()
+	path := filepath.Join("testdata", name+".golden")
+
+	if *updateGolden {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatalf("mkdir testdata: %v", err)
+		}
+		if err := os.WriteFile(path, got, 0o644); err != nil {
+			t.Fatalf("write golden %s: %v", path, err)
+		}
+		return
+	}
+
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v (run with -update to create it)", path, err)
+	}
+	if !bytes.Equal(want, got) {
+		t.Errorf("golden mismatch for %s (run with -update to review and accept the diff):\n--- want (%s) ---\n%s\n--- got ---\n%s",
+			name, path, want, got)
+	}
+}
+
+// prettyJSON re-indents a JSON body for stable, readable golden diffs.
+func prettyJSON(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("prettyJSON: invalid JSON: %v\nraw: %s", err, raw)
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("prettyJSON: marshal: %v", err)
+	}
+	return append(out, '\n')
+}
+
+// contractStage0RoundRunner returns a mockStage0Runner whose
+// RunClarificationRound always fires stage0_round_complete with a fixed
+// round/question, never delegating to RunFullWithClarifications. Used for
+// the "Stage 0 fires" golden scenarios.
+func contractStage0RoundRunner() *mockStage0Runner {
+	return &mockStage0Runner{
+		runClarificationRound: func(_ context.Context, _ string, _ []council.ClarificationRound, _ council.ClarificationConfig, _ string, onEvent council.EventFunc) error {
+			if onEvent != nil {
+				onEvent("stage0_round_complete", council.Stage0RoundData{
+					Round: 1,
+					Questions: []council.ClarificationQuestion{
+						{ID: "q1", Text: "What database are you currently using?"},
+					},
+				})
+			}
+			return nil
+		},
+	}
+}
+
+// contractRunFull emits a fixed, deterministic PeerReview-shaped sequence —
+// no time.Now(), no random labels; DurationMs is a fixed fixture value.
+func contractRunFull(_ context.Context, _, _ string, onEvent council.EventFunc) error {
+	onEvent("stage1_complete", []council.StageOneResult{
+		{Label: "Response A", Content: "Go is a compiled language.", Model: "openai/gpt-4o-mini", DurationMs: 100},
+		{Label: "Response B", Content: "Go was created at Google.", Model: "anthropic/claude-haiku-4-5", DurationMs: 120},
+	})
+	onEvent("stage2_complete", council.Stage2CompleteData{
+		Kind: "peer_ranking",
+		Results: []council.StageTwoResult{
+			{ReviewerLabel: "Response A", Rankings: []string{"Response A", "Response B"}},
+			{ReviewerLabel: "Response B", Rankings: []string{"Response A", "Response B"}},
+		},
+		Metadata: council.Metadata{
+			CouncilType:  "standard",
+			LabelToModel: map[string]string{"Response A": "openai/gpt-4o-mini", "Response B": "anthropic/claude-haiku-4-5"},
+			AggregateRankings: []council.RankedModel{
+				{Model: "openai/gpt-4o-mini", Score: 1.0},
+				{Model: "anthropic/claude-haiku-4-5", Score: 2.0},
+			},
+			ConsensusW: 1.0,
+		},
+	})
+	onEvent("stage3_complete", council.StageThreeResult{Content: "Go is a compiled language created at Google.", Model: "openai/gpt-4o-mini", DurationMs: 200})
+	return nil
+}
+
+// closedConversationStorer returns a mockStorer whose SaveUserMessage
+// always reports the conversation as closed, for the 409-parity scenario.
+func closedConversationStorer() *mockStorer {
+	return &mockStorer{
+		saveUserMessage: func(string, string) error { return storage.ErrConversationClosed },
+	}
+}
+
+// ── POST /message ────────────────────────────────────────────────────────
+
+func TestContract_SendMessage_HappyPath(t *testing.T) {
+	h := newTestHandler(okStorer(), &mockRunner{runFull: contractRunFull})
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message", bytes.NewBufferString(`{"content":"What is Go?"}`))
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+
+	h.sendMessage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	checkGolden(t, "message_happy_path", prettyJSON(t, w.Body.Bytes()))
+}
+
+func TestContract_SendMessage_Stage0Fires(t *testing.T) {
+	h := NewHandler(&mockRunner{runFull: contractRunFull}, contractStage0RoundRunner(), okStorer(), nil, "standard", council.ClarificationConfig{MaxRounds: 2, MaxTotalQuestions: 5, MaxQuestionsPerRound: 3})
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message", bytes.NewBufferString(`{"content":"Should I migrate to Postgres?"}`))
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+
+	h.sendMessage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	checkGolden(t, "message_stage0_fires", prettyJSON(t, w.Body.Bytes()))
+}
+
+func TestContract_SendMessage_ConversationClosed(t *testing.T) {
+	h := newTestHandler(closedConversationStorer(), &mockRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message", bytes.NewBufferString(`{"content":"hello"}`))
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+
+	h.sendMessage(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	checkGolden(t, "message_conversation_closed", prettyJSON(t, w.Body.Bytes()))
+}
+
+// ── POST /message/stream ─────────────────────────────────────────────────
+
+func TestContract_SendMessageStream_HappyPath(t *testing.T) {
+	h := newTestHandler(okStorer(), &mockRunner{runFull: contractRunFull})
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message/stream", bytes.NewBufferString(`{"content":"What is Go?"}`))
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+
+	h.sendMessageStream(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	checkGolden(t, "message_stream_happy_path", stripVolatileSSEFields(t, w.Body.Bytes()))
+}
+
+func TestContract_SendMessageStream_Stage0Fires(t *testing.T) {
+	h := NewHandler(&mockRunner{runFull: contractRunFull}, contractStage0RoundRunner(), okStorer(), nil, "standard", council.ClarificationConfig{MaxRounds: 2, MaxTotalQuestions: 5, MaxQuestionsPerRound: 3})
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message/stream", bytes.NewBufferString(`{"content":"Should I migrate to Postgres?"}`))
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+
+	h.sendMessageStream(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	// Confirms drift #1/#3: stage0_done never appears on the wire, and a
+	// complete event IS sent after stage0_round_complete.
+	checkGolden(t, "message_stream_stage0_fires", stripVolatileSSEFields(t, w.Body.Bytes()))
+}
+
+func TestContract_SendMessageStream_ConversationClosed(t *testing.T) {
+	h := newTestHandler(closedConversationStorer(), &mockRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message/stream", bytes.NewBufferString(`{"content":"hello"}`))
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+
+	h.sendMessageStream(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	checkGolden(t, "message_stream_conversation_closed", prettyJSON(t, w.Body.Bytes()))
+}
+
+func TestContract_SendMessageStream_MultiAgentDebate(t *testing.T) {
+	h := newTestHandler(okStorer(), &mockRunner{runFull: func(_ context.Context, _, _ string, onEvent council.EventFunc) error {
+		onEvent("stage1_complete", []council.StageOneResult{
+			{Label: "Response A", Content: "ans-a", Model: "openai/gpt-4o-mini", DurationMs: 100},
+			{Label: "Response B", Content: "ans-b", Model: "anthropic/claude-haiku-4-5", DurationMs: 110},
+		})
+		onEvent("stage2_round_complete", council.Stage2CompleteData{
+			Kind:  "debate_round",
+			Round: 1,
+			Metadata: council.Metadata{
+				CouncilType:  "debate",
+				LabelToModel: map[string]string{"Response A": "openai/gpt-4o-mini", "Response B": "anthropic/claude-haiku-4-5"},
+				Debate: &council.Debate{
+					Rounds:     []council.DebateRound{{Round: 1, Revisions: []council.DebaterRevision{{Label: "Response A", Critique: "c", Content: "rev-a-1"}}}},
+					FinalRound: 1,
+				},
+			},
+		})
+		onEvent("stage2_complete", council.Stage2CompleteData{
+			Kind: "debate_round",
+			Metadata: council.Metadata{
+				CouncilType:  "debate",
+				LabelToModel: map[string]string{"Response A": "openai/gpt-4o-mini", "Response B": "anthropic/claude-haiku-4-5"},
+				Debate: &council.Debate{
+					Rounds:     []council.DebateRound{{Round: 1, Revisions: []council.DebaterRevision{{Label: "Response A", Content: "rev-a-1"}}}},
+					FinalRound: 1,
+				},
+			},
+		})
+		onEvent("stage3_complete", council.StageThreeResult{Content: "synthesis", Model: "chairman-z", DurationMs: 150})
+		return nil
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message/stream", bytes.NewBufferString(`{"content":"q","council_type":"debate"}`))
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+
+	h.sendMessageStream(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	checkGolden(t, "message_stream_multi_agent_debate", stripVolatileSSEFields(t, w.Body.Bytes()))
+}
+
+// stripVolatileSSEFields removes the title_complete event, which is
+// produced by a real goroutine racing a 30s timer against title-derivation
+// logic and is exercised separately in handler_test.go; keeping it out of
+// golden files avoids a source of flakiness unrelated to what these
+// contract tests check (route/stage-event wire shape).
+func stripVolatileSSEFields(t *testing.T, body []byte) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		if bytes.Contains(line, []byte(`"type":"title_complete"`)) {
+			continue
+		}
+		out.Write(line)
+		out.WriteByte('\n')
+	}
+	return out.Bytes()
+}
+
+// TestContract_ConversationClosedParity is the drift-#-none regression:
+// both endpoints must produce the same status code and error body shape
+// for the same underlying error, proving the sendMessage fix actually
+// closes the gap with sendMessageStream.
+func TestContract_ConversationClosedParity(t *testing.T) {
+	blocking := newTestHandler(closedConversationStorer(), &mockRunner{})
+	breq := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message", bytes.NewBufferString(`{"content":"hello"}`))
+	breq.SetPathValue("id", testConvID)
+	bw := httptest.NewRecorder()
+	blocking.sendMessage(bw, breq)
+
+	streaming := newTestHandler(closedConversationStorer(), &mockRunner{})
+	sreq := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message/stream", bytes.NewBufferString(`{"content":"hello"}`))
+	sreq.SetPathValue("id", testConvID)
+	sw := httptest.NewRecorder()
+	streaming.sendMessageStream(sw, sreq)
+
+	if bw.Code != sw.Code {
+		t.Errorf("status parity: blocking got %d, streaming got %d — want equal", bw.Code, sw.Code)
+	}
+	if bw.Code != http.StatusConflict {
+		t.Errorf("blocking status: got %d, want 409", bw.Code)
+	}
+	if !errors.Is(storage.ErrConversationClosed, storage.ErrConversationClosed) {
+		t.Fatal("sanity: storage.ErrConversationClosed must be comparable via errors.Is")
+	}
+	var blockingBody, streamBody map[string]string
+	if err := json.Unmarshal(bw.Body.Bytes(), &blockingBody); err != nil {
+		t.Fatalf("blocking body not JSON: %v", err)
+	}
+	if err := json.Unmarshal(sw.Body.Bytes(), &streamBody); err != nil {
+		t.Fatalf("streaming body not JSON: %v", err)
+	}
+	if blockingBody["error"] != streamBody["error"] {
+		t.Errorf("error message parity: blocking %q, streaming %q", blockingBody["error"], streamBody["error"])
+	}
+}

--- a/internal/api/contract_test.go
+++ b/internal/api/contract_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"net/http"
 	"net/http/httptest"
@@ -292,9 +291,6 @@ func TestContract_ConversationClosedParity(t *testing.T) {
 	}
 	if bw.Code != http.StatusConflict {
 		t.Errorf("blocking status: got %d, want 409", bw.Code)
-	}
-	if !errors.Is(storage.ErrConversationClosed, storage.ErrConversationClosed) {
-		t.Fatal("sanity: storage.ErrConversationClosed must be comparable via errors.Is")
 	}
 	var blockingBody, streamBody map[string]string
 	if err := json.Unmarshal(bw.Body.Bytes(), &blockingBody); err != nil {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -267,11 +267,7 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 		switch eventType {
 		case "stage0_round_complete":
 			stage0Event = eventType
-			type roundData struct {
-				Round     int                            `json:"round"`
-				Questions []council.ClarificationQuestion `json:"questions"`
-			}
-			if d, ok := data.(roundData); ok {
+			if d, ok := data.(council.Stage0RoundData); ok {
 				stage0Round = d.Round
 				stage0Questions = d.Questions
 			}
@@ -298,6 +294,10 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 	if isRound1 {
 		originalQuery = body.Content
 		if err := h.storage.SaveUserMessage(id, body.Content); err != nil {
+			if errors.Is(err, storage.ErrConversationClosed) {
+				h.writeError(w, http.StatusConflict, "conversation is closed")
+				return
+			}
 			if _, ok := errors.AsType[*storage.NotFoundError](err); ok {
 				h.writeError(w, http.StatusNotFound, "not found")
 				return
@@ -635,11 +635,7 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 		switch eventType {
 		case "stage0_round_complete":
 			stage0Event = eventType
-			type roundData struct {
-				Round     int                             `json:"round"`
-				Questions []council.ClarificationQuestion `json:"questions"`
-			}
-			if d, ok := data.(roundData); ok {
+			if d, ok := data.(council.Stage0RoundData); ok {
 				stage0Round = d.Round
 				stage0Questions = d.Questions
 			}
@@ -690,7 +686,9 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 				sendErrorSSE("internal server error")
 				return
 			}
-			// Stream closes after stage0_round_complete — no complete event, no title.
+			// Stream closes after stage0_round_complete. A complete event IS still
+			// sent (the client needs it to know the stream ended cleanly) — but no
+			// title, since Stage 3 hasn't run yet.
 			fmt.Fprintf(w, "data: {\"type\":\"complete\"}\n\n")
 			flusher.Flush()
 			return

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -844,19 +844,19 @@ func TestSendMessageStream(t *testing.T) {
 			},
 			wantCode: http.StatusOK,
 			checkSSE: func(t *testing.T, body string) {
-				// 1. A stage2_round_complete event MUST appear with `round: 1`
-				//    present on the wire (not omitempty).
-				// 2. The terminal stage2_complete event MUST carry the full
-				//    transcript with metadata.debate populated.
+				// Narrow wire-contract invariants only — the full response shape
+				// (including the terminal stage2_complete transcript) is covered
+				// byte-for-byte by TestContract_SendMessageStream_MultiAgentDebate's
+				// golden file (contract_test.go). This check exists to document
+				// *why* `round` must stay required (not omitempty): it's a
+				// deliberate wire-contract decision, not incidental current
+				// behavior, and that intent doesn't show up in a raw diff.
 				var sawRoundEvent bool
-				var sawTerminalDebate bool
 				for _, line := range strings.Split(body, "\n") {
 					if !strings.HasPrefix(line, "data: ") {
 						continue
 					}
 					raw := []byte(line[6:])
-
-					// Detect round events by Type+Round-key presence in raw JSON.
 					var keys map[string]json.RawMessage
 					if err := json.Unmarshal(raw, &keys); err != nil {
 						continue
@@ -878,37 +878,9 @@ func TestSendMessageStream(t *testing.T) {
 							t.Errorf("stage2_round_complete kind: got %q, want %q", kind, "debate_round")
 						}
 					}
-
-					// Detect the terminal event with full transcript.
-					if err := json.Unmarshal(keys["type"], &typ); err == nil && typ == "stage2_complete" {
-						var env struct {
-							Kind     string           `json:"kind"`
-							Metadata council.Metadata `json:"metadata"`
-						}
-						if err := json.Unmarshal(raw, &env); err != nil {
-							continue
-						}
-						if env.Kind != "debate_round" {
-							t.Errorf("terminal kind: got %q, want %q", env.Kind, "debate_round")
-						}
-						if env.Metadata.Debate == nil {
-							t.Errorf("terminal stage2_complete: metadata.debate is nil")
-							continue
-						}
-						if env.Metadata.Debate.FinalRound != 2 {
-							t.Errorf("FinalRound: got %d, want 2", env.Metadata.Debate.FinalRound)
-						}
-						if len(env.Metadata.Debate.Rounds) != 2 {
-							t.Errorf("transcript rounds: got %d, want 2", len(env.Metadata.Debate.Rounds))
-						}
-						sawTerminalDebate = true
-					}
 				}
 				if !sawRoundEvent {
 					t.Error("stage2_round_complete event not seen on the wire")
-				}
-				if !sawTerminalDebate {
-					t.Error("terminal stage2_complete with debate transcript not seen on the wire")
 				}
 			},
 		},

--- a/internal/api/testdata/message_conversation_closed.golden
+++ b/internal/api/testdata/message_conversation_closed.golden
@@ -1,0 +1,3 @@
+{
+  "error": "conversation is closed"
+}

--- a/internal/api/testdata/message_happy_path.golden
+++ b/internal/api/testdata/message_happy_path.golden
@@ -1,0 +1,56 @@
+{
+  "metadata": {
+    "aggregate_rankings": [
+      {
+        "model": "openai/gpt-4o-mini",
+        "score": 1
+      },
+      {
+        "model": "anthropic/claude-haiku-4-5",
+        "score": 2
+      }
+    ],
+    "consensus_w": 1,
+    "council_type": "standard",
+    "label_to_model": {
+      "Response A": "openai/gpt-4o-mini",
+      "Response B": "anthropic/claude-haiku-4-5"
+    }
+  },
+  "role": "assistant",
+  "stage1": [
+    {
+      "content": "Go is a compiled language.",
+      "duration_ms": 100,
+      "label": "Response A",
+      "model": "openai/gpt-4o-mini"
+    },
+    {
+      "content": "Go was created at Google.",
+      "duration_ms": 120,
+      "label": "Response B",
+      "model": "anthropic/claude-haiku-4-5"
+    }
+  ],
+  "stage2": [
+    {
+      "rankings": [
+        "Response A",
+        "Response B"
+      ],
+      "reviewer_label": "Response A"
+    },
+    {
+      "rankings": [
+        "Response A",
+        "Response B"
+      ],
+      "reviewer_label": "Response B"
+    }
+  ],
+  "stage3": {
+    "content": "Go is a compiled language created at Google.",
+    "duration_ms": 200,
+    "model": "openai/gpt-4o-mini"
+  }
+}

--- a/internal/api/testdata/message_stage0_fires.golden
+++ b/internal/api/testdata/message_stage0_fires.golden
@@ -1,0 +1,11 @@
+{
+  "stage0_round_complete": {
+    "questions": [
+      {
+        "id": "q1",
+        "text": "What database are you currently using?"
+      }
+    ],
+    "round": 1
+  }
+}

--- a/internal/api/testdata/message_stream_conversation_closed.golden
+++ b/internal/api/testdata/message_stream_conversation_closed.golden
@@ -1,0 +1,3 @@
+{
+  "error": "conversation is closed"
+}

--- a/internal/api/testdata/message_stream_happy_path.golden
+++ b/internal/api/testdata/message_stream_happy_path.golden
@@ -1,0 +1,10 @@
+data: {"type":"stage1_complete","data":[{"label":"Response A","content":"Go is a compiled language.","model":"openai/gpt-4o-mini","duration_ms":100},{"label":"Response B","content":"Go was created at Google.","model":"anthropic/claude-haiku-4-5","duration_ms":120}]}
+
+data: {"type":"stage2_complete","kind":"peer_ranking","data":[{"reviewer_label":"Response A","rankings":["Response A","Response B"]},{"reviewer_label":"Response B","rankings":["Response A","Response B"]}],"metadata":{"council_type":"standard","label_to_model":{"Response A":"openai/gpt-4o-mini","Response B":"anthropic/claude-haiku-4-5"},"aggregate_rankings":[{"model":"openai/gpt-4o-mini","score":1},{"model":"anthropic/claude-haiku-4-5","score":2}],"consensus_w":1}}
+
+data: {"type":"stage3_complete","data":{"content":"Go is a compiled language created at Google.","model":"openai/gpt-4o-mini","duration_ms":200}}
+
+
+data: {"type":"complete"}
+
+

--- a/internal/api/testdata/message_stream_multi_agent_debate.golden
+++ b/internal/api/testdata/message_stream_multi_agent_debate.golden
@@ -1,0 +1,12 @@
+data: {"type":"stage1_complete","data":[{"label":"Response A","content":"ans-a","model":"openai/gpt-4o-mini","duration_ms":100},{"label":"Response B","content":"ans-b","model":"anthropic/claude-haiku-4-5","duration_ms":110}]}
+
+data: {"type":"stage2_round_complete","kind":"debate_round","round":1,"data":null,"metadata":{"council_type":"debate","label_to_model":{"Response A":"openai/gpt-4o-mini","Response B":"anthropic/claude-haiku-4-5"},"aggregate_rankings":null,"consensus_w":0,"debate":{"rounds":[{"round":1,"revisions":[{"label":"Response A","critique":"c","content":"rev-a-1","model":"","duration_ms":0}]}],"final_round":1}}}
+
+data: {"type":"stage2_complete","kind":"debate_round","data":null,"metadata":{"council_type":"debate","label_to_model":{"Response A":"openai/gpt-4o-mini","Response B":"anthropic/claude-haiku-4-5"},"aggregate_rankings":null,"consensus_w":0,"debate":{"rounds":[{"round":1,"revisions":[{"label":"Response A","content":"rev-a-1","model":"","duration_ms":0}]}],"final_round":1}}}
+
+data: {"type":"stage3_complete","data":{"content":"synthesis","model":"chairman-z","duration_ms":150}}
+
+
+data: {"type":"complete"}
+
+

--- a/internal/api/testdata/message_stream_stage0_fires.golden
+++ b/internal/api/testdata/message_stream_stage0_fires.golden
@@ -1,0 +1,5 @@
+data: {"type":"stage0_round_complete","data":{"round":1,"questions":[{"id":"q1","text":"What database are you currently using?"}]}}
+
+data: {"type":"complete"}
+
+

--- a/internal/council/runner.go
+++ b/internal/council/runner.go
@@ -358,12 +358,8 @@ func (c *Rada) RunClarificationRound(
 	}
 
 	// Emit questions to client.
-	type roundCompleteData struct {
-		Round     int                     `json:"round"`
-		Questions []ClarificationQuestion `json:"questions"`
-	}
 	if onEvent != nil {
-		onEvent("stage0_round_complete", roundCompleteData{Round: round, Questions: questions})
+		onEvent("stage0_round_complete", Stage0RoundData{Round: round, Questions: questions})
 	}
 	return nil
 }

--- a/internal/council/runner_test.go
+++ b/internal/council/runner_test.go
@@ -740,3 +740,60 @@ func TestRunClarificationRound_Resolution_NoGenerators_ReturnsLoudError(t *testi
 		t.Errorf("error message: got %q, want it to mention 'generator models'", err.Error())
 	}
 }
+
+// TestRunClarificationRound_EmitsStage0RoundData is a regression test for a
+// bug where "stage0_round_complete" carried a function-local type that
+// internal/api's onEvent closures could never successfully type-assert
+// against (Go requires exact named-type identity), silently zeroing
+// Round/Questions in both the blocking response body and the persisted
+// clarification round. The emitted value must be the exported
+// council.Stage0RoundData so cross-package type assertions actually work.
+func TestRunClarificationRound_EmitsStage0RoundData(t *testing.T) {
+	client := &mockLLMClient{
+		complete: func(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+			body := req.Messages[0].Content
+			if strings.Contains(body, "You are helping clarify") {
+				return makeResponse(`{"questions":[{"text":"What database are you using?"}]}`), nil
+			}
+			if strings.Contains(body, "You are deciding whether to ask") {
+				return makeResponse(`{"questions":[{"id":"q1","text":"What database are you using?"}],"enough":false}`), nil
+			}
+			return makeResponse("{}"), nil
+		},
+	}
+	registry := map[string]CouncilType{
+		"test": {Name: "test", Strategy: PeerReview, Models: []string{"gen-1"}, ChairmanModel: "chair-1", Temperature: 0.7},
+	}
+	c := NewCouncil(client, registry, nil)
+
+	cfg := ClarificationConfig{MaxRounds: 2, MaxTotalQuestions: 5, MaxQuestionsPerRound: 3}
+
+	var (
+		gotEventType string
+		gotData      any
+	)
+	onEvent := func(eventType string, data any) {
+		if eventType == "stage0_round_complete" {
+			gotEventType = eventType
+			gotData = data
+		}
+	}
+
+	if err := c.RunClarificationRound(context.Background(), "q", nil, cfg, "test", onEvent); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotEventType != "stage0_round_complete" {
+		t.Fatalf("stage0_round_complete event not emitted (chairman returned enough:false)")
+	}
+	d, ok := gotData.(Stage0RoundData)
+	if !ok {
+		t.Fatalf("event data type: got %T, want council.Stage0RoundData", gotData)
+	}
+	if d.Round != 1 {
+		t.Errorf("Round: got %d, want 1", d.Round)
+	}
+	if len(d.Questions) != 1 || d.Questions[0].Text != "What database are you using?" {
+		t.Errorf("Questions: got %+v, want one question with the chairman's text", d.Questions)
+	}
+}

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -368,6 +368,15 @@ type ClarificationQuestion struct {
 	Text string `json:"text"`
 }
 
+// Stage0RoundData is the payload passed to EventFunc for the
+// "stage0_round_complete" event. Must be an exported type — internal/api's
+// handlers type-assert against it directly to extract Round/Questions for
+// both the SSE wire payload and clarification-round persistence.
+type Stage0RoundData struct {
+	Round     int                     `json:"round"`
+	Questions []ClarificationQuestion `json:"questions"`
+}
+
 // ClarificationAnswer is the user's response to a single clarification question.
 type ClarificationAnswer struct {
 	ID   string `json:"id"`


### PR DESCRIPTION
## Summary

An investigation into whether to adopt OpenAPI Spec found the real problem isn't spec choice — `docs/api.md` drifts from `handler.go`'s actual behavior even under active maintenance. What catches drift is an executable check: golden-file contract tests over both `/message` and `/message/stream`, snapshotted to `testdata/` and diffed on every test run (`-update` flag regenerates; the `git diff` review IS the drift check).

Building the goldens surfaced **two real bugs**, not just doc gaps:

1. **`sendMessage` (blocking) never checked `storage.ErrConversationClosed`** — `sendMessageStream` did, correctly returning `409`; blocking fell through to a generic `500`. Fixed to match.
2. **`stage0_round_complete`'s `round`/`questions` data was silently lost.** `internal/council/runner.go` built an unexported, function-local `roundCompleteData` type that `internal/api/handler.go`'s own separately-declared local type could never successfully type-assert against (Go requires exact named-type identity, not structural match). The blocking endpoint always returned `round:0, questions:null` to the client; the streaming endpoint's wire event was fine (raw marshal) but the *persisted* clarification round was zeroed. Fixed by exporting `council.Stage0RoundData` and asserting against it from both handler closures — this is exactly the type the "Stage 0 fires" golden scenario exists to lock in, so leaving it unfixed would have meant shipping a golden that codifies broken behavior as correct.

Also fixed (verified against current source with file:line citations, re-verified by Tech Lead review):
- `stage0_done` documented as an SSE wire event (`docs/api.md`, `docs/user-guide.md`) — never sent, internal state tracking only.
- Error reference table missing the `409` conversation-closed case.
- "Stream closes after `stage0_round_complete` — no complete event" was wrong in both the doc and the code's own comment; a `complete` event is always sent (only "no title" was correct).
- `POST /message`'s round-1-with-Stage-0-firing response shape was entirely undocumented.
- Canonical `stage2_complete` example omitted `kind`, implying it's optional — it's always on the wire.

`docs/pipeline.md` is deliberately untouched — it describes the `EventFunc` callback layer, where `stage0_done` genuinely fires; only the wire-level docs were wrong.

Existing hand-written `MultiAgentDebate` sequence assertions in `handler_test.go` were trimmed to the narrow wire-contract invariants a golden diff wouldn't self-document, now that a golden covers the full transcript shape. `Delphi`'s assertions are untouched — no golden covers that scenario, so its test remains the sole source of truth for that shape.

Closes #306

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes (347 tests, 8 packages)
- [x] New `internal/council` regression test confirms `RunClarificationRound` emits the exported `Stage0RoundData` type — manually reverted to the old local-type bug and confirmed the test fails, then restored
- [x] New `internal/api` golden-file contract tests (8 scenarios) confirm correct wire/response shapes for both endpoints, including 409-parity between blocking and streaming for the same error

🤖 Generated with [Claude Code](https://claude.com/claude-code)