### PR TITLE
⚡ fix(storage,api): reject round-N clarification answers on a closed conversation

### DIFF
--- a/internal/api/contract_test.go
+++ b/internal/api/contract_test.go
@@ -117,6 +117,24 @@ func closedConversationStorer() *mockStorer {
 	}
 }
 
+// roundNClosedConversationStorer returns a mockStorer simulating a
+// round-2+ answers submission against a closed conversation: a pending
+// clarification round exists, but UpdateClarificationAnswers reports the
+// conversation as closed (regression coverage for #309).
+func roundNClosedConversationStorer() *mockStorer {
+	return &mockStorer{
+		getLastClarificationRound: func(string) (*council.ClarificationRound, error) {
+			return &council.ClarificationRound{
+				Round:     1,
+				Questions: []council.ClarificationQuestion{{ID: "q1", Text: "What database?"}},
+			}, nil
+		},
+		updateClarificationAnswers: func(string, int, []council.ClarificationAnswer) error {
+			return storage.ErrConversationClosed
+		},
+	}
+}
+
 // ── POST /message ────────────────────────────────────────────────────────
 
 func TestContract_SendMessage_HappyPath(t *testing.T) {
@@ -150,6 +168,23 @@ func TestContract_SendMessage_Stage0Fires(t *testing.T) {
 func TestContract_SendMessage_ConversationClosed(t *testing.T) {
 	h := newTestHandler(closedConversationStorer(), &mockRunner{})
 	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message", bytes.NewBufferString(`{"content":"hello"}`))
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+
+	h.sendMessage(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	checkGolden(t, "message_conversation_closed", prettyJSON(t, w.Body.Bytes()))
+}
+
+// TestContract_SendMessage_RoundNConversationClosed is a regression test
+// for #309: round-N answers submissions must be rejected the same way
+// round-1 content submissions already are, not just silently accepted.
+func TestContract_SendMessage_RoundNConversationClosed(t *testing.T) {
+	h := newTestHandler(roundNClosedConversationStorer(), &mockRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message", bytes.NewBufferString(`{"answers":[{"id":"q1","text":"Postgres"}]}`))
 	req.SetPathValue("id", testConvID)
 	w := httptest.NewRecorder()
 
@@ -196,6 +231,22 @@ func TestContract_SendMessageStream_Stage0Fires(t *testing.T) {
 func TestContract_SendMessageStream_ConversationClosed(t *testing.T) {
 	h := newTestHandler(closedConversationStorer(), &mockRunner{})
 	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message/stream", bytes.NewBufferString(`{"content":"hello"}`))
+	req.SetPathValue("id", testConvID)
+	w := httptest.NewRecorder()
+
+	h.sendMessageStream(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	checkGolden(t, "message_stream_conversation_closed", prettyJSON(t, w.Body.Bytes()))
+}
+
+// TestContract_SendMessageStream_RoundNConversationClosed is the streaming
+// counterpart of TestContract_SendMessage_RoundNConversationClosed (#309).
+func TestContract_SendMessageStream_RoundNConversationClosed(t *testing.T) {
+	h := newTestHandler(roundNClosedConversationStorer(), &mockRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/api/conversations/"+testConvID+"/message/stream", bytes.NewBufferString(`{"answers":[{"id":"q1","text":"Postgres"}]}`))
 	req.SetPathValue("id", testConvID)
 	w := httptest.NewRecorder()
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -128,6 +128,19 @@ func (h *Handler) writeError(w http.ResponseWriter, status int, msg string) {
 	h.writeJSON(w, status, map[string]string{"error": msg})
 }
 
+// handleClosedConversation writes a 409 "conversation is closed" response
+// and returns true if err wraps storage.ErrConversationClosed. Callers
+// return immediately when this reports true. Centralised so the four call
+// sites (round-1/round-N on both endpoints) can't drift the way the
+// original SaveUserMessage-only check did (see #309).
+func (h *Handler) handleClosedConversation(w http.ResponseWriter, err error) bool {
+	if errors.Is(err, storage.ErrConversationClosed) {
+		h.writeError(w, http.StatusConflict, "conversation is closed")
+		return true
+	}
+	return false
+}
+
 func (h *Handler) healthLive(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
@@ -294,8 +307,7 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 	if isRound1 {
 		originalQuery = body.Content
 		if err := h.storage.SaveUserMessage(id, body.Content); err != nil {
-			if errors.Is(err, storage.ErrConversationClosed) {
-				h.writeError(w, http.StatusConflict, "conversation is closed")
+			if h.handleClosedConversation(w, err) {
 				return
 			}
 			if _, ok := errors.AsType[*storage.NotFoundError](err); ok {
@@ -357,8 +369,7 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := h.storage.UpdateClarificationAnswers(id, lastRound.Round, body.Answers); err != nil {
-			if errors.Is(err, storage.ErrConversationClosed) {
-				h.writeError(w, http.StatusConflict, "conversation is closed")
+			if h.handleClosedConversation(w, err) {
 				return
 			}
 			h.logger.Error("update clarification answers", "id", id, "error", err)
@@ -485,8 +496,7 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := h.storage.UpdateClarificationAnswers(id, lastRound.Round, body.Answers); err != nil {
-			if errors.Is(err, storage.ErrConversationClosed) {
-				h.writeError(w, http.StatusConflict, "conversation is closed")
+			if h.handleClosedConversation(w, err) {
 				return
 			}
 			h.logger.Error("update clarification answers", "id", id, "error", err)
@@ -506,8 +516,7 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 	} else {
 		originalQuery = body.Content
 		if err := h.storage.SaveUserMessage(id, body.Content); err != nil {
-			if errors.Is(err, storage.ErrConversationClosed) {
-				h.writeError(w, http.StatusConflict, "conversation is closed")
+			if h.handleClosedConversation(w, err) {
 				return
 			}
 			if _, ok := errors.AsType[*storage.NotFoundError](err); ok {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -357,6 +357,10 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := h.storage.UpdateClarificationAnswers(id, lastRound.Round, body.Answers); err != nil {
+			if errors.Is(err, storage.ErrConversationClosed) {
+				h.writeError(w, http.StatusConflict, "conversation is closed")
+				return
+			}
 			h.logger.Error("update clarification answers", "id", id, "error", err)
 			h.writeError(w, http.StatusInternalServerError, "internal server error")
 			return
@@ -481,6 +485,10 @@ func (h *Handler) sendMessageStream(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := h.storage.UpdateClarificationAnswers(id, lastRound.Round, body.Answers); err != nil {
+			if errors.Is(err, storage.ErrConversationClosed) {
+				h.writeError(w, http.StatusConflict, "conversation is closed")
+				return
+			}
 			h.logger.Error("update clarification answers", "id", id, "error", err)
 			h.writeError(w, http.StatusInternalServerError, "internal server error")
 			return

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -299,6 +299,9 @@ func (s *Store) UpdateClarificationAnswers(id string, round int, answers []counc
 	if err != nil {
 		return err
 	}
+	if c.Closed {
+		return ErrConversationClosed
+	}
 	// Find the last message with role="clarification" and matching round.
 	for i := len(c.Messages) - 1; i >= 0; i-- {
 		var cm clarificationMessage

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -431,6 +431,24 @@ func TestStore_SaveUserMessage_RejectsAfterClose(t *testing.T) {
 	}
 }
 
+func TestStore_UpdateClarificationAnswers_RejectsAfterClose(t *testing.T) {
+	s := newTestStore(t)
+	c, err := s.CreateConversation()
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if err := s.SaveClarificationRound(c.ID, 1, []council.ClarificationQuestion{{ID: "q1", Text: "First?"}}, "default"); err != nil {
+		t.Fatalf("SaveClarificationRound: %v", err)
+	}
+	if err := s.CloseConversation(c.ID); err != nil {
+		t.Fatalf("CloseConversation: %v", err)
+	}
+	err = s.UpdateClarificationAnswers(c.ID, 1, []council.ClarificationAnswer{{ID: "q1", Text: "should fail"}})
+	if !errors.Is(err, storage.ErrConversationClosed) {
+		t.Errorf("expected ErrConversationClosed, got %v", err)
+	}
+}
+
 func TestStore_CloseConversation_RaceWithSaveUserMessage(t *testing.T) {
 	s := newTestStore(t)
 	c, err := s.CreateConversation()


### PR DESCRIPTION
## Summary
- `UpdateClarificationAnswers` never checked `Conversation.Closed`, unlike `SaveUserMessage` — round-N answer submissions (`{"answers": [...]}`) could proceed against a closed conversation with no error on either endpoint, while round-1 was already correctly blocked with `409`.
- Fixed by mirroring `SaveUserMessage`'s `Closed` check in `UpdateClarificationAnswers`, and adding the same `ErrConversationClosed` handling to both `sendMessage`'s and `sendMessageStream`'s round-N branches that round-1 already had.

Found by `gemma4:31b-cloud` during `/fix-review` on #308; pre-existing on `main`, unrelated to that PR's scope.

Closes #309

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes (350 tests, 8 packages)
- [x] New storage-level regression test (`TestStore_UpdateClarificationAnswers_RejectsAfterClose`) — manually reverted the `storage.go` check, confirmed it fails, restored
- [x] Two new handler-level regression tests (round-N + closed, both endpoints) reusing the existing 409-parity golden files — manually reverted the `handler.go` checks, confirmed both fail (500 instead of 409), restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)