### PR TITLE
chore(dreaming): route through Ollama to escape Anthropic weekly limit

### DIFF
--- a/.claude/dreaming/dreaming.sh
+++ b/.claude/dreaming/dreaming.sh
@@ -13,6 +13,13 @@ set -euo pipefail
 # Ensure claude/gh/jq are reachable when invoked from cron or other minimal env
 export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
+# Route claude-code through Ollama (localhost:11434, Device Key auth).
+# Avoids Anthropic weekly limits — see ~/wrk/common/dreaming/dreaming.sh
+# for the rationale and env-vars justification.
+export ANTHROPIC_AUTH_TOKEN=ollama
+export ANTHROPIC_API_KEY=""
+export ANTHROPIC_BASE_URL=http://localhost:11434
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 REPORTS_DIR="$SCRIPT_DIR/reports"
@@ -48,7 +55,8 @@ Write the report to stdout."
 # otherwise consume the positional prompt argument.
 echo "$PROMPT" | claude \
   --print \
-  --model opus \
+  --model minimax-m3:cloud \
+  --fallback-model kimi-k2.7-code:cloud \
   --allowed-tools "Read,Glob,Grep,Bash(ls:*),Bash(cat:*),Bash(wc:*),Bash(stat:*),Bash(find:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git rev-parse:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh issue list:*)" \
   > "$REPORT" 2>> "$LOG"
 


### PR DESCRIPTION
## Summary
- Anthropic Opus weekly limit was hit mid-2026, stopping dreaming-паси. Route through Ollama via localhost:11434 (Device Key auth) instead.
- Primary: `minimax-m3:cloud`; fallback: `kimi-k2.7-code:cloud`.
- Env-vars embedded in script so systemd services don't need EnvironmentFile.

## Why
- W26 and W30 reports contained only "You've hit your weekly limit" — dreaming-пase silent fail.
- Read-only structured output, well within reach of a mid-tier cloud model.

## Mirrors
- ~/wrk/common/dreaming/dreaming.sh (commit 396445f)

## Test plan
- [x] `bash -n` syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)