### PR TITLE
docs: cross-reference docs/openapi.yaml from api.md, CLAUDE.md, architecture-v2.md, README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ codebase; the rewrite is well past the research phase.
 See `docs/` for the current source of truth:
 - `docs/architecture-v2.md` — package layout, layer boundaries, composition root, pipeline behaviour
 - `docs/strategies.md` — the 7 deliberation strategies (all implemented), per-registration model config, quorum defaults, SSE protocol
-- `docs/api.md` — REST + SSE event reference
+- `docs/api.md` — REST + SSE event reference (narrative companion to `docs/openapi.yaml`)
+- `docs/openapi.yaml` — OpenAPI 3.2 machine-readable API contract; kept drift-proof against `internal/api/handler.go` by `internal/api/spec_test.go` and linted in CI via `redocly lint`
 - `docs/pipeline.md` — Stage 0/1/2/3 internals
 - `docs/council-research-synthesis.md` — aggregated design research
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ make clean      # Remove bin/vmm-rada
 | `POST` | `/api/conversations/{id}/message` | Send a message, wait for the full result |
 | `POST` | `/api/conversations/{id}/message/stream` | Send a message, receive stage results via SSE |
 
+Full request/response shapes, error codes, and the SSE event catalog: see
+[`docs/api.md`](docs/api.md) (narrative) or [`docs/openapi.yaml`](docs/openapi.yaml)
+(OpenAPI 3.2, machine-readable).
+
 ### Streaming events (`/message/stream`)
 
 Uses [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,12 @@
 # VMM Rada — HTTP API Reference
 
+**Machine-readable contract:** [`docs/openapi.yaml`](./openapi.yaml) is the OpenAPI 3.2
+spec for this API, kept drift-proof against `internal/api/handler.go` via
+`internal/api/spec_test.go` (route↔spec agreement, SSE event discriminator, `$ref`
+resolution) and linted in CI via `redocly lint`. This document is the narrative
+companion — the same contract, in prose, with request/response examples and the
+per-endpoint error reference tables the spec's `description` fields summarise.
+
 ## Base URL
 
 The server listens on port `PORT` (default `8001`) and binds on all interfaces (`0.0.0.0`)

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -335,6 +335,8 @@ Key design constraints:
 | **SSE format** | `data: {...}\n\n` — no `event:` line; demux by `"type"` field |
 | **CORS** | Allowed origins hardcoded: `http://localhost:5173`, `http://localhost:3000` — both localhost-only dev origins, vestigial since the frontend extraction; `Vary: Origin` set when reflecting. See [`requirements.md`](./requirements.md#gap-analysis). |
 | **Security headers** | `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Content-Security-Policy: default-src 'none'` applied to every route |
+| **Route table** | `routes []route` (package-level slice) is the single source of truth for registered endpoints; `RegisterRoutes` and the `handlerByOp` dispatch table both read from it — `internal/api/spec_test.go` walks the same slice to assert `docs/openapi.yaml` stays in lock-step |
+| **OpenAPI contract** | `docs/openapi.yaml` (OpenAPI 3.2) — machine-readable mirror of this table; SSE events modeled as a `oneOf`/`discriminator` union via `itemSchema` on the `text/event-stream` content |
 
 ---
 


### PR DESCRIPTION
## Summary
- `docs/openapi.yaml` landed in #312 but nothing else in the repo pointed to it — flagged during Tech Lead review of the redocly-lint-in-ci plan (#315/#316) as a docs-discipline gap (this repo's `CLAUDE.md` requires `CLAUDE.md`/`architecture-v2.md`/`strategies.md` stay in sync when a feature lands; `docs/openapi.yaml` counts as exactly that kind of landing).
- `docs/api.md`: added a "machine-readable contract" note at the top, framing it as the narrative companion to the spec rather than a competing source of truth.
- `CLAUDE.md`: added `docs/openapi.yaml` to the `docs/` source-of-truth list.
- `docs/architecture-v2.md`: added two rows to the HTTP-layer table — the `routes`/`handlerByOp` dispatch pattern (added in #312 specifically to make the spec-vs-handler drift test possible) and the OpenAPI contract itself.
- `README.md`: added a pointer from the API reference table to both `docs/api.md` and `docs/openapi.yaml`.

Docs-only change — no code touched.

## Test plan
- [x] `go build ./...` passes (unaffected — docs-only)
- [x] `go test -race -count=1 ./...` passes (356 tests, unaffected)
- [x] Manually reviewed all four diffs for accuracy against current code

🤖 Generated with [Claude Code](https://claude.com/claude-code)