### PR TITLE
docs: compact CLAUDE.md, fix stale /plan and Copilot references

### DIFF
--- a/.claude/plans/README.md
+++ b/.claude/plans/README.md
@@ -2,7 +2,7 @@
 
 Implementation plans for the VMM Rada backend.
 
-Plans are created by the `/plan` skill. Each plan can be promoted to a GitHub issue.
+Plans are created by the `/backlog` skill. Each plan can be promoted to a GitHub issue.
 
 ---
 
@@ -145,7 +145,7 @@ fix(scope): description ⚡
 
 ## GitHub Issue Creation
 
-After the plan is confirmed, `/plan` offers to create a GitHub issue:
+After Tech Lead approval, `/backlog` creates a GitHub issue:
 
 ```bash
 gh issue create \

--- a/.claude/skills/apply-dreaming/SKILL.md
+++ b/.claude/skills/apply-dreaming/SKILL.md
@@ -191,9 +191,8 @@ Plans pending: <list>
 Backup: /tmp/dreaming-W##-vmm-rada-backup-HHMM/
 
 Next steps:
-1. Watch PRs for Copilot review (one round).
-2. Run /backlog on each plan to gate through Tech Lead.
-3. Run /ship on approved plans.
+1. Run /backlog on each plan to gate through Tech Lead.
+2. Run /ship on approved plans — /fix-review runs automatically as part of /ship.
 ```
 
 ## Constraints (CRITICAL)
@@ -220,7 +219,7 @@ Next steps:
 
 - `/backlog` — gate plans through Tech Lead.
 - `/ship` — implement approved plan + create PR.
-- `/fix-review` — handle Copilot/Tech Lead review rounds.
+- `/fix-review` — parallel multi-model review + Claude arbiter.
 - `/revival` — health snapshot (synchronous, complementary to dreaming).
 
 ## See also

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,45 +7,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 VMM Rada — a multi-LLM deliberation system. Rada models independently answer a query,
 anonymously peer-review each other, and a Chairman model synthesises a final answer.
 
-**Status: v2 shipping.** The v1 implementation is archived on `archive/v1`. v2 is the active
-codebase; the rewrite is well past the research phase.
+**Status: v2 shipping.** The v1 implementation is archived on `archive/v1`.
 
 See `docs/` for the current source of truth:
 - `docs/architecture-v2.md` — package layout, layer boundaries, composition root, pipeline behaviour
-- `docs/strategies.md` — the 7 deliberation strategies (all implemented), per-registration model config, quorum defaults, SSE protocol
-- `docs/api.md` — REST + SSE event reference (narrative companion to `docs/openapi.yaml`)
-- `docs/openapi.yaml` — OpenAPI 3.2 machine-readable API contract; kept drift-proof against `internal/api/handler.go` by `internal/api/spec_test.go` and linted in CI via `redocly lint`
+- `docs/strategies.md` — the 7 deliberation strategies (all implemented and registered), per-strategy config, quorum defaults, SSE protocol
+- `docs/api.md` — REST + SSE narrative reference; `docs/openapi.yaml` is the machine-readable OpenAPI 3.2 contract, kept drift-proof by `internal/api/spec_test.go` and linted in CI
 - `docs/pipeline.md` — Stage 0/1/2/3 internals
 - `docs/council-research-synthesis.md` — aggregated design research
 
-All seven strategies are implemented (`PeerReview`, `RoleBased`, `Majority`,
-`GenerateRankRefine`, `MultiAgentDebate`, `MixtureOfAgents`, `Delphi`). Stage 0
-(clarification) runs before strategy dispatch and is strategy-independent.
-See [`docs/strategies.md`](docs/strategies.md) for the full enum, status, and per-strategy
-configuration.
-
 ## Stack
 
-- **Backend:** Go 1.26.5
-- **Frontend:** removed from this repo (2026-07-19) — active development is at [`vmm-rada-web-ui`](https://github.com/valpere/vmm-rada-web-ui) (React 19 + Vite 8, plain JavaScript). This repo is the backend API only.
-- **LLM Gateway:** configurable provider via `AI_PROVIDER_NAME` (default `openrouter`); URL override via `LLM_API_BASE_URL` for Ollama / vLLM
-- **API key:** `.env` → `AI_PROVIDER_API_KEY=<key>` (use any non-empty placeholder for keyless providers)
-
-## Frontend (moved out)
-
-`frontend/` was removed from this repo (2026-07-19) — see
-[`vmm-rada-web-ui`](https://github.com/valpere/vmm-rada-web-ui) for the
-current codebase, architecture rules, and its own CLAUDE.md.
-
-`docs/api.md` remains the authoritative REST + SSE contract this backend
-serves, regardless of which frontend consumes it.
+- **Backend:** Go 1.26.5. Frontend was extracted (2026-07-19) to [`vmm-rada-web-ui`](https://github.com/valpere/vmm-rada-web-ui) (React 19 + Vite 8) — this repo is backend API only; `docs/api.md`/`docs/openapi.yaml` remain the authoritative contract regardless of which frontend consumes it.
+- **LLM Gateway:** configurable provider via `AI_PROVIDER_NAME` (default `openrouter`); URL override via `LLM_API_BASE_URL` for Ollama / vLLM.
+- **API key:** `.env` → `AI_PROVIDER_API_KEY=<key>` (any non-empty placeholder for keyless providers).
 
 ## Workflow
 
-Full pipeline:
 ```
 /backlog → Tech Lead (APPROVED) → gh issue create → plan file deleted
-    → /ship → code-generator → [/fix-review rounds] → squash merge
+    → /ship → code-generator → /fix-review → squash merge → git checkout main && git pull
 ```
 
 ### Skills
@@ -53,8 +34,8 @@ Full pipeline:
 | Skill | Invoke | Purpose |
 |-------|--------|---------|
 | `/backlog` | `/backlog <task or issue#>` | Plan → Tech Lead gate → creates GitHub issue → deletes plan file |
-| `/ship` | `/ship` | Select issue → implement → PR → Copilot → `/fix-review` → squash merge |
-| `/fix-review` | `/fix-review [pr#]` | 3-round review (security + simplifier + tech-lead) + arbiter |
+| `/ship` | `/ship [issue#]` | Select issue → implement → PR → `/fix-review` → squash merge |
+| `/fix-review` | `/fix-review [pr#]` | Parallel multi-model review (`config.yaml`) + Claude arbiter |
 | `/find-bugs` | `/find-bugs` | Audit current branch changes for bugs/security — report only |
 | `/improve` | `/improve <target>` | Critic pass: SHIP IT / IMPROVE IT / RETHINK IT / KILL IT |
 
@@ -69,13 +50,13 @@ Full pipeline:
 | `ci-build-agent` | sonnet | Generates GitHub Actions CI workflows for Go + npm |
 | `pm-issue-writer` | sonnet | Drafts RFC 2119 GitHub issues with structured frontmatter |
 
+Model shown here for quick reference — each agent's own frontmatter in `.claude/agents/*.md` is authoritative.
+
 ### Plans
 
-Implementation plans live in `.claude/plans/`. Naming: `{N}-{slug}.md` where N is the
-priority digit (0=critical, 3=low). Each plan has frontmatter with type, priority,
-labels, and `github_issue` filled after issue creation.
-
-See `.claude/plans/README.md` for the full schema.
+Implementation plans live in `.claude/plans/`; naming convention, frontmatter schema,
+and the priority↔label mapping are documented in `.claude/plans/README.md`. After
+issue creation, the plan file is deleted — the GitHub issue is the canonical record.
 
 ### Debt levels
 
@@ -85,14 +66,8 @@ See `.claude/plans/README.md` for the full schema.
 | ⚖️ | balanced | Core paths | Update if public API changed |
 | 🏗️ | proper-refactor | Full unit + integration | Full update |
 
-### Labels (GitHub)
+### GitHub labels
 
 **Type:** `bug` · `feature` · `task` · `test` · `docs`
-**Priority:** `p0: critical` · `p1: high` · `p2: medium` · `p3: low`
 **Status:** `blocked` · `wontfix` · `duplicate`
-
-### PR workflow
-
-1. Branch → implement → `go build/vet/test` all pass
-2. `/ship` → creates PR → waits for Copilot review
-3. Address comments → `/fix-review` → squash merge → `git checkout main && git pull`
+**Priority:** `p0`–`p3` — see `.claude/plans/README.md` for the full priority↔label mapping.


### PR DESCRIPTION
## Summary
- `CLAUDE.md` compacted 98 → 73 lines (-25%): removed two sections that fully duplicated other parts of the file (Frontend note, PR workflow), fixed a stale "waits for Copilot review" claim (Copilot was dropped from this repo's review workflow 2026-05-13; `/fix-review` replaced it), and pointed the priority↔label table at `.claude/plans/README.md` instead of restating a partial copy of it.
- `.claude/plans/README.md`: fixed two "/plan" references — there is no `/plan` skill in this repo, only `/backlog`.
- `.claude/skills/apply-dreaming/SKILL.md`: removed a dead "watch PRs for Copilot review" next-step, and corrected the `/fix-review` companion-skill description to match its actual mechanism (parallel multi-model dispatch + Claude arbiter).

Docs-only change — no code touched.

## Test plan
- [x] `go build ./...` passes (unaffected — docs-only)
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes (356 tests, 8 packages)
- [x] Verified `/backlog` is the correct skill name (`ls .claude/skills/`) and `/fix-review`'s actual review mechanism against its own SKILL.md before rewriting the descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)