### PR TITLE
🏗️ feature(council): RoleBased — add DevilsAdvocate, rename Generator→Creator, named model assignment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -252,13 +252,13 @@ DEFAULT_RADA_TEMPERATURE=0.7
 # If models are set without the chairman, the server logs a warning and
 # skips registration.
 #
-# Roles are Generator / Critic / Verifier / Simplifier — fixed in code
-# (internal/council/roles.go), not configurable via env var. Models are
-# assigned to roles round-robin (models[i % len(models)]), so one model
-# covers all roles, four models give one per role, and any other count
+# Roles are Creator / Critic / Verifier / Simplifier / DevilsAdvocate — fixed
+# in code (internal/council/roles.go), not configurable via env var. Models
+# are assigned to the 5 roles round-robin (models[i % len(models)]), so one
+# model covers all roles, five models give one per role, and any other count
 # wraps around.
 #
-# QuorumMin is set to the number of roles (4) at registration — every role
+# QuorumMin is set to the number of roles (5) at registration — every role
 # is a unique concern, so a missing role silently drops coverage rather
 # than degrading gracefully like PeerReview's majority-quorum default.
 #

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -129,21 +129,33 @@ func main() {
 
 	// RoleBased registration is opt-in AND requires both env vars. Stage 3
 	// chairman always runs; no no-LLM path. Role content (names/instructions)
-	// is fixed as council.DefaultRoles, not env-configurable. QuorumMin is
-	// set to len(DefaultRoles) — every role is a unique concern, so a
-	// missing role silently drops coverage rather than degrading gracefully.
+	// is fixed as council.DefaultRoles, not env-configurable — only the
+	// per-role Model assignment comes from ROLE_BASED_MODELS, reproducing the
+	// historical i % len(models) round-robin (env vars carry a flat model
+	// list, not named role assignments; that's what a future YAML-based
+	// config unlocks). QuorumMin is set to len(DefaultRoles) — every role is
+	// a unique concern, so a missing role silently drops coverage rather
+	// than degrading gracefully.
 	if len(cfg.RoleBasedModels) > 0 {
 		if cfg.RoleBasedChairmanModel == "" {
 			logger.Warn("ROLE_BASED_MODELS set but ROLE_BASED_CHAIRMAN_MODEL is empty; skipping registration of \"role-based\" council type")
 		} else {
-			registry["role-based"] = council.CouncilType{
-				Name:          "role-based",
-				Strategy:      council.RoleBased,
-				Roles:         council.DefaultRoles,
-				Models:        cfg.RoleBasedModels,
-				ChairmanModel: cfg.RoleBasedChairmanModel,
-				Temperature:   cfg.DefaultCouncilTemperature,
-				QuorumMin:     len(council.DefaultRoles),
+			roleModels := make(map[string]string, len(council.DefaultRoleKeys))
+			for i, key := range council.DefaultRoleKeys {
+				roleModels[key] = cfg.RoleBasedModels[i%len(cfg.RoleBasedModels)]
+			}
+			roles, err := council.RolesWithModels(roleModels)
+			if err != nil {
+				logger.Warn("failed to assign models to role-based roles; skipping registration", "error", err)
+			} else {
+				registry["role-based"] = council.CouncilType{
+					Name:          "role-based",
+					Strategy:      council.RoleBased,
+					Roles:         roles,
+					ChairmanModel: cfg.RoleBasedChairmanModel,
+					Temperature:   cfg.DefaultCouncilTemperature,
+					QuorumMin:     len(council.DefaultRoles),
+				}
 			}
 		}
 	}

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -185,8 +185,8 @@ lenses, not configurable per-domain personas).
 
 Registration is opt-in AND requires both `ROLE_BASED_MODELS` and
 `ROLE_BASED_CHAIRMAN_MODEL`. Role content (names/instructions) is fixed as
-`council.DefaultRoles` — Generator, Critic, Verifier, Simplifier — not env-configurable;
-see [`strategies.md`](./strategies.md) for the registration contract.
+`council.DefaultRoles` — Creator, Critic, Verifier, Simplifier, DevilsAdvocate — not
+env-configurable; see [`strategies.md`](./strategies.md) for the registration contract.
 
 #### `Majority` pipeline (2 stages, no LLM Stage 2)
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -571,7 +571,7 @@ One model handles all roles; 4 models give one per role; any count wraps round-r
   { "role": "user",   "content": query } ]
 ```
 
-The `StageOneResult.Label` is set to the role's `Name` (`"Generator"`, `"Critic"`, etc.,
+The `StageOneResult.Label` is set to the role's `Name` (`"Creator"`, `"Critic"`, etc.,
 per `council.DefaultRoles`), not an anonymous `Response X` label.
 
 **Quorum:** `checkQuorum(results, ct.QuorumMin)`. The `"role-based"` registration sets

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -22,8 +22,8 @@ Stage 0 (clarification) runs **before** strategy dispatch and is strategy-indepe
 
 `RoleBased` was implemented and tested well before it was registered — see #302 for the
 gap and its resolution. It is registered under the `"role-based"` council type name with
-a fixed, generic role set (`council.DefaultRoles`: Generator, Critic, Verifier,
-Simplifier — see [`council-research-synthesis.md §2.7`](./council-research-synthesis.md)).
+a fixed, generic role set (`council.DefaultRoles`: Creator, Critic, Verifier, Simplifier,
+DevilsAdvocate — see [`council-research-synthesis.md §2.7`](./council-research-synthesis.md)).
 This is unrelated to the old code-review-specific `/review*` endpoints removed in PR #199
 (see [What's not here](#whats-not-here) below) — that was a different, narrower
 4-role set behind dedicated routes; this is a generic strategy reachable through the
@@ -52,7 +52,7 @@ Each registration in `cmd/server/main.go` and `cmd/eval/main.go` carries its own
 | Strategy | What `Models` represents | What `ChairmanModel` represents | Env var family | Fall-through |
 |----------|--------------------------|---------------------------------|----------------|--------------|
 | `PeerReview` | Rada members (generators + reviewers) | Stage 3 synthesiser | `RADA_MODELS` / `CHAIRMAN_MODEL` | — (these are the defaults) |
-| `RoleBased` | Pool assigned to roles by `i % len(Models)` | Synthesiser across role findings (required) | `ROLE_BASED_MODELS` / `ROLE_BASED_CHAIRMAN_MODEL` (both required) | none — registration is opt-in via both `ROLE_BASED_*` env vars; role content itself (`Roles []Role` — names/instructions) is fixed as `council.DefaultRoles`, not env-configurable |
+| `RoleBased` | **UNUSED** — each `Role` carries its own `Model`, assigned via `council.RolesWithModels`; `ROLE_BASED_MODELS` is distributed across the 5 fixed roles (`council.DefaultRoleKeys` order) by `i % len(models)`, reproducing the historical round-robin at the env layer only | Synthesiser across role findings (required) | `ROLE_BASED_MODELS` / `ROLE_BASED_CHAIRMAN_MODEL` (both required) | none — registration is opt-in via both `ROLE_BASED_*` env vars; role content itself (`Roles []Role` — names/instructions) is fixed as `council.DefaultRoles`, not env-configurable |
 | `Majority` | Voters | Tiebreaker / polish (optional; `""` = no tiebreak, ties error) | `MAJORITY_MODELS` (required to register) / `MAJORITY_CHAIRMAN_MODEL` (optional) | none — registration is opt-in via `MAJORITY_MODELS`; chairman stays empty when unset (so the no-chairman path is reachable) |
 | `GenerateRankRefine` | Generators | Ranker + refiner (single model today) | `GENERATE_RANK_REFINE_MODELS` / `GENERATE_RANK_REFINE_CHAIRMAN_MODEL` | `RADA_MODELS` / `CHAIRMAN_MODEL` |
 | `MultiAgentDebate` | Debaters | Synthesiser | `DEBATE_MODELS` / `DEBATE_CHAIRMAN_MODEL` | `RADA_MODELS` / `CHAIRMAN_MODEL` |

--- a/docs/strategy-showcase.md
+++ b/docs/strategy-showcase.md
@@ -20,12 +20,12 @@ deliberation strength. Machine-readable version: `eval/benchmarks/strategy-showc
 ## RoleBased
 
 *Best for multi-dimensional questions, where a broad-exploration draft, a self-critique
-pass, a fact-check pass, and a concise final distillation each surface something the
-others miss. The shipped role set (`council.DefaultRoles`: Generator/Critic/Verifier/
-Simplifier) is generic — these prompts are chosen so a genuinely thorough answer
-naturally needs to cover several angles, not because the system assigns one role per
-named domain (it doesn't have configurable domain-specialist roles like "legal" or
-"security").*
+pass, a fact-check pass, a concise final distillation, and a deliberate counter-argument
+each surface something the others miss. The shipped role set (`council.DefaultRoles`:
+Creator/Critic/Verifier/Simplifier/DevilsAdvocate) is generic — these prompts are chosen
+so a genuinely thorough answer naturally needs to cover several angles, not because the
+system assigns one role per named domain (it doesn't have configurable domain-specialist
+roles like "legal" or "security").*
 
 | # | Prompt |
 |---|--------|

--- a/internal/council/rolebased.go
+++ b/internal/council/rolebased.go
@@ -13,8 +13,10 @@ func (c *Rada) runRoleBased(ctx context.Context, query string, ct CouncilType, o
 	if len(ct.Roles) == 0 {
 		return fmt.Errorf("council type %q has no roles configured", ct.Name)
 	}
-	if len(ct.Models) == 0 {
-		return fmt.Errorf("council type %q has no models configured", ct.Name)
+	for _, r := range ct.Roles {
+		if r.Model == "" {
+			return fmt.Errorf("council type %q: role %q has no model configured", ct.Name, r.Name)
+		}
 	}
 
 	// Stage 1: parallel role execution.
@@ -59,7 +61,7 @@ func (c *Rada) runRoleBased(ctx context.Context, query string, ct CouncilType, o
 }
 
 // runRoleBasedStage1 executes all roles concurrently.
-// Model assignment: ct.Models[i % len(ct.Models)].
+// Model assignment: each Role's own Model field.
 func (c *Rada) runRoleBasedStage1(ctx context.Context, query string, ct CouncilType) []StageOneResult {
 	results := make([]StageOneResult, len(ct.Roles))
 	var wg sync.WaitGroup
@@ -68,7 +70,7 @@ func (c *Rada) runRoleBasedStage1(ctx context.Context, query string, ct CouncilT
 		wg.Add(1)
 		go func(idx int, r Role) {
 			defer wg.Done()
-			model := ct.Models[idx%len(ct.Models)]
+			model := r.Model
 			start := time.Now()
 
 			msgs := BuildRoleStage1Prompt(r, query)

--- a/internal/council/rolebased_test.go
+++ b/internal/council/rolebased_test.go
@@ -13,12 +13,11 @@ func roleCouncilFixture(complete func(ctx context.Context, req CompletionRequest
 		"roles": {
 			Name:          "roles",
 			Strategy:      RoleBased,
-			Models:        []string{"model-a", "model-b"},
 			ChairmanModel: "chairman",
 			Temperature:   0.7,
 			Roles: []Role{
-				{Name: "security", Instruction: "Find security issues."},
-				{Name: "logic", Instruction: "Find logic errors."},
+				{Name: "security", Instruction: "Find security issues.", Model: "model-a"},
+				{Name: "logic", Instruction: "Find logic errors.", Model: "model-b"},
 			},
 		},
 	}
@@ -162,19 +161,22 @@ func TestRunRoleBased_Stage2CompleteData_HasLabelToModel(t *testing.T) {
 	}
 }
 
-func TestRunRoleBased_ModelsAssignedByIndex(t *testing.T) {
-	// 3 roles, 2 models → models assigned: role0→model-a, role1→model-b, role2→model-a
+func TestRunRoleBased_EachRoleUsesItsOwnModel(t *testing.T) {
+	// 3 roles, each with a distinct, explicitly-assigned model — named
+	// assignment, not positional. A regression back to index-based lookup
+	// (e.g. hardcoding role[0]'s model for every role) would pass a
+	// call-count-only check but fail this one, since it asserts which
+	// specific model each role's system prompt was sent to.
 	registry := map[string]CouncilType{
 		"three-roles": {
 			Name:          "three-roles",
 			Strategy:      RoleBased,
-			Models:        []string{"model-a", "model-b"},
 			ChairmanModel: "chairman",
 			Temperature:   0.7,
 			Roles: []Role{
-				{Name: "r0", Instruction: "Role 0"},
-				{Name: "r1", Instruction: "Role 1"},
-				{Name: "r2", Instruction: "Role 2"},
+				{Name: "r0", Instruction: "Role 0", Model: "model-r0"},
+				{Name: "r1", Instruction: "Role 1", Model: "model-r1"},
+				{Name: "r2", Instruction: "Role 2", Model: "model-r2"},
 			},
 		},
 	}
@@ -196,14 +198,43 @@ func TestRunRoleBased_ModelsAssignedByIndex(t *testing.T) {
 
 	_ = c.RunFull(context.Background(), "q", "three-roles", func(string, any) {})
 
-	if modelUsed["Role 0"] != "model-a" {
-		t.Errorf("role 0 should use model-a, got %q", modelUsed["Role 0"])
+	if modelUsed["Role 0"] != "model-r0" {
+		t.Errorf("role 0 should use model-r0, got %q", modelUsed["Role 0"])
 	}
-	if modelUsed["Role 1"] != "model-b" {
-		t.Errorf("role 1 should use model-b, got %q", modelUsed["Role 1"])
+	if modelUsed["Role 1"] != "model-r1" {
+		t.Errorf("role 1 should use model-r1, got %q", modelUsed["Role 1"])
 	}
-	if modelUsed["Role 2"] != "model-a" {
-		t.Errorf("role 2 should cycle back to model-a, got %q", modelUsed["Role 2"])
+	if modelUsed["Role 2"] != "model-r2" {
+		t.Errorf("role 2 should use model-r2, got %q", modelUsed["Role 2"])
 	}
 }
 
+func TestRunRoleBased_EmptyModel_ErrorsBeforeAnyLLMCall(t *testing.T) {
+	registry := map[string]CouncilType{
+		"broken-role": {
+			Name:          "broken-role",
+			Strategy:      RoleBased,
+			ChairmanModel: "chairman",
+			Temperature:   0.7,
+			Roles: []Role{
+				{Name: "r0", Instruction: "Role 0", Model: "model-r0"},
+				{Name: "r1", Instruction: "Role 1", Model: ""}, // missing
+			},
+		},
+	}
+	calls := 0
+	c := NewCouncil(&mockLLMClient{
+		complete: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+			calls++
+			return makeResponse("[]"), nil
+		},
+	}, registry, nil)
+
+	err := c.RunFull(context.Background(), "q", "broken-role", func(string, any) {})
+	if err == nil {
+		t.Fatal("expected error for role with empty Model, got nil")
+	}
+	if calls != 0 {
+		t.Errorf("expected 0 LLM calls before the empty-Model error, got %d", calls)
+	}
+}

--- a/internal/council/roles.go
+++ b/internal/council/roles.go
@@ -1,18 +1,19 @@
 package council
 
+import "fmt"
+
 // DefaultRoles is the generic role set used by the "role-based" council type
-// registration. Roles are Generator/Critic/Verifier/Simplifier, per the
-// Role-Based Rada shape proposed in docs/council-research-synthesis.md §2.7
-// (Devil's Advocate and role rotation across rounds are explicitly left as
-// future work there, not included here).
+// registration. Roles are Creator/Critic/Verifier/Simplifier/DevilsAdvocate, per
+// the Role-Based Rada shape proposed in docs/council-research-synthesis.md §2.7.
 //
-// Role content is fixed in code, not env-configurable — see the "role-based"
-// registration in cmd/server/main.go and docs/strategies.md for the
-// registration contract.
+// This is a template: every Role's Model field is left empty here. A
+// registration is responsible for producing a fully-populated []Role (with
+// Model set per role) via RolesWithModels — see the "role-based" registration
+// in cmd/server/main.go and docs/strategies.md for the registration contract.
 var DefaultRoles = []Role{
 	{
-		Name: "Generator",
-		Instruction: "You are the Generator. Explore the question broadly and propose a " +
+		Name: "Creator",
+		Instruction: "You are the Creator. Explore the question broadly and propose a " +
 			"substantive answer. Favor breadth of consideration over caution — surface " +
 			"approaches or angles a narrower answer would miss. Do not hedge; commit to a " +
 			"concrete answer.",
@@ -37,4 +38,45 @@ var DefaultRoles = []Role{
 			"while remaining correct and complete. Cut qualification, repetition, and " +
 			"preamble. Prefer the shortest answer that fully addresses the question.",
 	},
+	{
+		Name: "DevilsAdvocate",
+		Instruction: "You are the Devil's Advocate. Take the strongest position against the " +
+			"most obvious answer to this question. Argue the case that the consensus reading is " +
+			"wrong, incomplete, or solving the wrong problem — even where you privately think it " +
+			"is right. Do not hedge into agreement at the end.",
+	},
+}
+
+// DefaultRoleKeys are the lowercase config keys used to assign a model to each
+// DefaultRoles entry (e.g. in a YAML "roles:" map). Order-matched to
+// DefaultRoles — DefaultRoleKeys[i] names DefaultRoles[i].
+var DefaultRoleKeys = []string{"creator", "critic", "verifier", "simplifier", "devils_advocate"}
+
+// RolesWithModels clones DefaultRoles and assigns each role's Model from
+// models, keyed by the role's entry in DefaultRoleKeys. Returns an error if
+// models is missing a key, has an unknown key, or maps a key to an empty
+// string — a role silently left without a model would otherwise fail much
+// later, inside a goroutine, with a less specific error.
+//
+// The length check plus the per-key presence check below are jointly
+// sufficient to also catch unknown keys: if len(models) == len(DefaultRoleKeys)
+// and every DefaultRoleKeys entry is present, there is no room left in models
+// for a key that isn't one of DefaultRoleKeys.
+func RolesWithModels(models map[string]string) ([]Role, error) {
+	if len(models) != len(DefaultRoleKeys) {
+		return nil, fmt.Errorf("expected exactly %d role models (%v), got %d", len(DefaultRoleKeys), DefaultRoleKeys, len(models))
+	}
+	roles := make([]Role, len(DefaultRoles))
+	for i, key := range DefaultRoleKeys {
+		model, ok := models[key]
+		if !ok {
+			return nil, fmt.Errorf("missing model for role %q", key)
+		}
+		if model == "" {
+			return nil, fmt.Errorf("empty model for role %q", key)
+		}
+		roles[i] = DefaultRoles[i]
+		roles[i].Model = model
+	}
+	return roles, nil
 }

--- a/internal/council/roles_test.go
+++ b/internal/council/roles_test.go
@@ -1,6 +1,9 @@
 package council
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestDefaultRoles(t *testing.T) {
 	if len(DefaultRoles) == 0 {
@@ -14,9 +17,93 @@ func TestDefaultRoles(t *testing.T) {
 		if r.Instruction == "" {
 			t.Errorf("DefaultRoles[%d] (%q): empty Instruction", i, r.Name)
 		}
+		if r.Model != "" {
+			t.Errorf("DefaultRoles[%d] (%q): Model must be empty in the template, got %q", i, r.Name, r.Model)
+		}
 		if seen[r.Name] {
 			t.Errorf("DefaultRoles: duplicate role name %q", r.Name)
 		}
 		seen[r.Name] = true
+	}
+}
+
+func TestDefaultRoles_ExactShape(t *testing.T) {
+	if len(DefaultRoles) != 5 {
+		t.Fatalf("len(DefaultRoles) = %d, want 5", len(DefaultRoles))
+	}
+	wantNames := []string{"Creator", "Critic", "Verifier", "Simplifier", "DevilsAdvocate"}
+	for i, want := range wantNames {
+		if DefaultRoles[i].Name != want {
+			t.Errorf("DefaultRoles[%d].Name = %q, want %q", i, DefaultRoles[i].Name, want)
+		}
+	}
+}
+
+func TestDefaultRoleKeys_MatchesDefaultRoles(t *testing.T) {
+	if len(DefaultRoleKeys) != len(DefaultRoles) {
+		t.Fatalf("len(DefaultRoleKeys) = %d, len(DefaultRoles) = %d, want equal", len(DefaultRoleKeys), len(DefaultRoles))
+	}
+	wantKeys := []string{"creator", "critic", "verifier", "simplifier", "devils_advocate"}
+	if !reflect.DeepEqual(DefaultRoleKeys, wantKeys) {
+		t.Errorf("DefaultRoleKeys = %v, want %v", DefaultRoleKeys, wantKeys)
+	}
+}
+
+func fullRoleModels() map[string]string {
+	return map[string]string{
+		"creator":         "model-creator",
+		"critic":          "model-critic",
+		"verifier":        "model-verifier",
+		"simplifier":      "model-simplifier",
+		"devils_advocate": "model-devils-advocate",
+	}
+}
+
+func TestRolesWithModels_Happy(t *testing.T) {
+	roles, err := RolesWithModels(fullRoleModels())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(roles) != len(DefaultRoles) {
+		t.Fatalf("len(roles) = %d, want %d", len(roles), len(DefaultRoles))
+	}
+	for i, want := range []string{"model-creator", "model-critic", "model-verifier", "model-simplifier", "model-devils-advocate"} {
+		if roles[i].Model != want {
+			t.Errorf("roles[%d].Model = %q, want %q", i, roles[i].Model, want)
+		}
+		if roles[i].Name != DefaultRoles[i].Name {
+			t.Errorf("roles[%d].Name = %q, want %q (template not preserved)", i, roles[i].Name, DefaultRoles[i].Name)
+		}
+	}
+	// DefaultRoles itself must remain untouched (roles is a clone, not an alias).
+	for i, r := range DefaultRoles {
+		if r.Model != "" {
+			t.Errorf("DefaultRoles[%d].Model = %q after RolesWithModels call, want empty (template mutated)", i, r.Model)
+		}
+	}
+}
+
+func TestRolesWithModels_MissingRole(t *testing.T) {
+	models := fullRoleModels()
+	delete(models, "devils_advocate")
+	if _, err := RolesWithModels(models); err == nil {
+		t.Fatal("expected error for missing role, got nil")
+	}
+}
+
+func TestRolesWithModels_UnknownKey(t *testing.T) {
+	models := fullRoleModels()
+	delete(models, "devils_advocate")
+	models["unknown_role"] = "some-model"
+	if _, err := RolesWithModels(models); err == nil {
+		t.Fatal("expected error for unknown role key, got nil")
+	}
+}
+
+func TestRolesWithModels_EmptyValue(t *testing.T) {
+	models := fullRoleModels()
+	models["critic"] = ""
+	if _, err := RolesWithModels(models); err == nil {
+		t.Fatal("expected error for empty model value, got nil")
 	}
 }

--- a/internal/council/types.go
+++ b/internal/council/types.go
@@ -39,7 +39,8 @@ const (
 // Role defines a named participant with a specific mandate in a role-based council.
 type Role struct {
 	Name        string `json:"name"`
-	Instruction string `json:"instruction"` // system-level prompt for this role
+	Instruction string `json:"instruction"`     // system-level prompt for this role
+	Model       string `json:"model,omitempty"` // LLM model this role runs on; set at registration time, not baked into DefaultRoles
 }
 
 // CouncilType describes a named council configuration.
@@ -48,7 +49,8 @@ type Role struct {
 // Field-usage matrix (which fields each strategy reads):
 //
 //	PeerReview         : Models, ChairmanModel, Temperature, QuorumMin
-//	RoleBased          : Models, Roles, ChairmanModel, Temperature, QuorumMin
+//	RoleBased          : Roles, ChairmanModel, Temperature, QuorumMin
+//	                     (Models is UNUSED — each Role carries its own Model)
 //	Majority           : Models, ChairmanModel (optional), Temperature, QuorumMin
 //	GenerateRankRefine : Models, ChairmanModel, Temperature, QuorumMin, RefineTopK
 //	MultiAgentDebate   : Models, ChairmanModel, Temperature, QuorumMin, MaxDebateRounds
@@ -59,15 +61,16 @@ type Role struct {
 //
 // MixtureOfAgents is the first strategy to skip both Models and ChairmanModel —
 // the runner reads the layer-specific ProposerModels / AggregatorModels /
-// RefinerModel fields directly. The Models/ChairmanModel fields stay zero-valued
-// for MoA registrations and are non-breaking for every other strategy.
+// RefinerModel fields directly. RoleBased similarly ignores Models — each Role's
+// own Model field is authoritative. Both patterns leave Models zero-valued/unused
+// without being breaking for other strategies.
 type CouncilType struct {
-	Name          string
-	Strategy      Strategy
-	Models        []string // Rada members. RoleBased assigns models to Roles by index mod len; other strategies use all.
-	Roles         []Role   // RoleBased only: role definitions with specialist instructions.
-	ChairmanModel string
-	Temperature   float64
+	Name            string
+	Strategy        Strategy
+	Models          []string // Rada members. Unused by RoleBased (see Roles[].Model); other strategies use all.
+	Roles           []Role   // RoleBased only: role definitions with specialist instructions and assigned models.
+	ChairmanModel   string
+	Temperature     float64
 	QuorumMin       int // 0 = strategy-specific default formula
 	RefineTopK      int // GenerateRankRefine only: how many ranked candidates advance to refinement; 0 = default (3)
 	MaxDebateRounds int // MultiAgentDebate only: number of debate rounds after Stage 1; 0 = default (2)
@@ -124,7 +127,7 @@ type EventFunc func(eventType string, data any)
 
 // StageOneResult holds a single council member's generated answer.
 type StageOneResult struct {
-	Label      string `json:"label"`      // anonymised label, e.g. "Response A"
+	Label      string `json:"label"` // anonymised label, e.g. "Response A"
 	Content    string `json:"content"`
 	Model      string `json:"model"`
 	DurationMs int64  `json:"duration_ms"` // elapsed milliseconds
@@ -246,10 +249,10 @@ type Debate struct {
 // whose drafts were fed into this aggregator (today: all-to-all fan-out, so
 // every aggregator sees every proposer).
 type AggregatorOutput struct {
-	Label      string   `json:"label"`        // anonymised, e.g. "Aggregator A"
-	Model      string   `json:"model"`        // OpenRouter ID, for transparency
-	Content    string   `json:"content"`      // aggregator's improved draft
-	Sources    []string `json:"sources"`      // proposer labels fed in (e.g. ["Response A", "Response B"])
+	Label      string   `json:"label"`   // anonymised, e.g. "Aggregator A"
+	Model      string   `json:"model"`   // OpenRouter ID, for transparency
+	Content    string   `json:"content"` // aggregator's improved draft
+	Sources    []string `json:"sources"` // proposer labels fed in (e.g. ["Response A", "Response B"])
 	DurationMs int64    `json:"duration_ms"`
 	Error      error    `json:"-"`
 }
@@ -267,9 +270,9 @@ type MoaAggregator struct {
 // SAME label as the rater's Stage 1 output (raters and proposers are the
 // same model pool in Delphi today; the label persists across rounds).
 type DelphiRating struct {
-	Label      string             `json:"label"`        // anonymised, e.g. "Response A"
-	Model      string             `json:"model"`        // OpenRouter ID
-	Scores     map[string]float64 `json:"scores"`       // criterion → 0.0–1.0
+	Label      string             `json:"label"`  // anonymised, e.g. "Response A"
+	Model      string             `json:"model"`  // OpenRouter ID
+	Scores     map[string]float64 `json:"scores"` // criterion → 0.0–1.0
 	Summary    string             `json:"summary,omitempty"`
 	DurationMs int64              `json:"duration_ms"`
 	Error      error              `json:"-"`


### PR DESCRIPTION
## Summary
- `RoleBased`'s role→model assignment was positional (`ct.Models[i % len(ct.Roles)]`); `Role` had no model field, and `DefaultRoles` had exactly 4 roles with a 5th (`DevilsAdvocate`) explicitly deferred in `roles.go`'s own doc comment.
- `Role` gets a `Model string` field. `DefaultRoles` renames `Generator`→`Creator` and adds `DevilsAdvocate` (5 roles total). `DefaultRoles` stays a template (`Model` empty); new `DefaultRoleKeys` + `RolesWithModels` produce a fully-populated `[]Role` per registration.
- `rolebased.go` drops the modulo lookup, uses each role's own `Model` directly; the old `len(ct.Models)==0` guard becomes a per-role empty-`Model` check.
- `cmd/server/main.go`'s `role-based` branch builds a positional `{role_key: model}` map from `ROLE_BASED_MODELS` (reproducing today's `i%len(models)` round-robin) and calls `council.RolesWithModels` — keeps the env-var path byte-for-byte behavior-compatible.
- `cmd/eval/main.go` intentionally **not** touched — its `buildRegistry` has no `role-based` branch at all (pre-existing bug, not introduced here); adding one now would be thrown away when #321 deletes the whole function for a shared `config.BuildRegistry`.
- Docs updated for accuracy everywhere the old 4-role `Generator/Critic/Verifier/Simplifier` set was named directly: `docs/strategies.md`, `docs/strategy-showcase.md`, `docs/architecture-v2.md`, `docs/pipeline.md`, `.env.example`. `docs/council-research-synthesis.md §2.7` needed no change — it already described the 5-role aspirational design this PR implements.

This is the prerequisite for #321 (YAML-based council registry config, blocked on this) — named per-role model assignment can't be expressed in YAML until `Role` itself carries a model.

Closes #320

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes (363 tests, 8 packages — +7 net new)
- [x] Regression check: hardcoded role index 0's model for every role, confirmed `TestRunRoleBased_EachRoleUsesItsOwnModel` fails; restored, confirmed clean pass
- [x] `TestAllStrategiesRegisteredOrExempted` (strategy_wiring_test.go) confirmed unaffected — that test's scope belongs to #321, not this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)