### PR TITLE
fix(gitignore): actually exclude .claude/_patterns/ pattern-store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,14 @@ bin/
 .claude/worktrees/
 # agent-memory is version-controlled (project-scope memories shared with team)
 
+# Self-learning pattern store, project-local variant (.claude/_patterns/, not
+# the repo-root _patterns/ the rules further below cover). !.claude/** above
+# re-includes everything under .claude/ — including these — so they need
+# their own explicit exclusion, same policy as the repo-root pair: track the
+# directory, not the per-machine raw logs.
+.claude/_patterns/mistakes.jsonl
+.claude/_patterns/wins.jsonl
+
 data/
 
 # Eval harness — golden inputs ARE checked in (internal/eval/testdata/).


### PR DESCRIPTION
## Summary
- The existing `_patterns/mistakes.jsonl`/`_patterns/wins.jsonl` gitignore rules are anchored to the repo root, so they never applied to `.claude/_patterns/` — where this project's self-learn skill actually writes.
- Combined with the earlier `!.claude/**` re-inclusion (needed to track `.claude/` config despite a global `_*` ignore rule), `.claude/_patterns/{mistakes,wins}.jsonl` were **not ignored at all**: `git check-ignore -v` resolved them against the `!.claude/**` negation, and `git status` showed them as plain untracked files.
- Verified before the fix and after: `git check-ignore -v .claude/_patterns/wins.jsonl` now correctly resolves against the new explicit rule instead of the `!.claude/**` negation; `git status --ignored` reports the directory as ignored.
- Same policy as the repo-root pair this mirrors: track the directory structure, never the raw per-machine pattern logs.

Caught via user follow-up after PR #324 merged — `git status` kept showing `.claude/_patterns/` as untracked, and a closer look confirmed my earlier assumption ("already covered by existing rules") was wrong.

## Test plan
- [x] `git check-ignore -v .claude/_patterns/mistakes.jsonl .claude/_patterns/wins.jsonl` now resolves against the new rules (previously resolved against `!.claude/**`, i.e. not ignored)
- [x] `git status --ignored --short .claude/_patterns/` reports `!!` (ignored), not `??` (untracked)
- [x] `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...` unaffected (no Go code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)