### PR TITLE
docs: remove dead **Plan:** footer reference from plans/README.md example

### DIFF
--- a/.claude/plans/README.md
+++ b/.claude/plans/README.md
@@ -158,8 +158,6 @@ gh issue create \
 
 ## Acceptance Criteria
 - [ ] ...
-
-**Plan:** \`.claude/plans/{N}-{slug}.md\`
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary
- The `gh issue create` example in `.claude/plans/README.md` ended with a `**Plan:** \`.claude/plans/{N}-{slug}.md\`` footer — but `/backlog`'s actual step 6 issue-creation flow doesn't include it, and step 7 deletes the plan file immediately after issue creation. If used literally, the footer would reference a file that no longer exists by the time anyone reads the issue.
- The line directly contradicted the very next sentence in the doc: "The issue body uses only `## Summary` and `## Acceptance Criteria` from the plan — implementation details stay internal."
- Flagged during an earlier CLAUDE.md compaction pass (out of scope at the time), fixed now.

## Test plan
- [x] Docs-only change, no code/behavior impact
- [x] `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)