### PR TITLE
feat(fix-review): add external_agents as a genuine tier 2 in the failover cascade

### DIFF
--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -152,17 +152,19 @@ RUN_DIR=$(mktemp -d)
 PROMPT_FILE="$RUN_DIR/prompt.txt"
 printf '%s' "$PROMPT" > "$PROMPT_FILE"
 
+declare -a R
 for n in 1 2 3; do
   if try_external_agents "$n" "$PROMPT_FILE" .claude/skills/fix-review/config.yaml "$RUN_DIR"; then
-    eval "R${n}=\$(cat \"$RUN_DIR/round_${n}.raw.json\")"
+    R[$n]=$(cat "$RUN_DIR/round_${n}.raw.json")
     echo "round $n served by external_agents ($(cut -d: -f2 "$RUN_DIR/round_${n}.failover"))"
   else
     # Every external agent failed for this round — fall through to local Ollama.
     MODEL=$(yq -r ".reviewers.cli[$((n-1))].cmd" .claude/skills/fix-review/config.yaml)
-    eval "R${n}=\$(echo \"\$PROMPT\" | bash -c \"$MODEL\")"
+    R[$n]=$(echo "$PROMPT" | bash -c "$MODEL")
     echo "round $n served by cli (local Ollama) — external_agents exhausted"
   fi
 done
+# R[1], R[2], R[3] hold each round's raw output — same shape as $R1/$R2/$R3 above.
 ```
 
 Each call returns a JSON array (empty `[]` on parse failure — safe degradation).

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -54,8 +54,11 @@ Note: `config.yaml` uses `round_1/round_2/round_3` keys for historical reasons �
 are concurrent dispatches, not sequential rounds. The models to use are always read from
 `config.yaml`; do not hardcode model names here.
 
-CLI failover tier (config.yaml `reviewers.cli`) engages automatically when the Ollama
-cloud endpoint probe fails — same flow, local models instead of cloud.
+Three-tier failover when the Ollama cloud endpoint probe fails:
+1. **`reviewers.external_agents`** (tier 2) — external coding-agent CLIs (cursor-agent,
+   omp, codex, opencode, kilo), cascaded in config order via `.claude/skills/lib/agents.sh`.
+2. **`reviewers.cli`** (tier 3) — actually local Ollama (key name is historical), used
+   only if every external agent also fails/returns empty.
 
 ## Step-by-step execution
 
@@ -80,7 +83,10 @@ Store it as the **baseline diff** (used in dispatch and arbiter pass).
 Read `.claude/skills/fix-review/config.yaml`. Extract:
 - `reviewers.openrouter.round_1/2/3` — cloud reviewer models
 - `openrouter_api_url` — Ollama endpoint (`http://localhost:11434/v1/chat/completions`)
-- `reviewers.cli` — local failover models (used if cloud endpoint unreachable)
+- `reviewers.external_agents` — ordered list of external agent CLIs (tier 2, tried per
+  round before local Ollama, used if cloud endpoint unreachable)
+- `reviewers.cli` — local Ollama failover models (tier 3, key name is historical; used
+  only if every external agent also fails for that round)
 
 First, extract the actual model names you just read from `config.yaml`:
 ```bash
@@ -112,7 +118,8 @@ else
 fi
 ```
 
-If `TIER="cli"` for any reason → use CLI failover tier (`reviewers.cli`).
+If `TIER="cli"` for any reason, do NOT go straight to the local Ollama tier — try the
+external-agent tier first, per round.
 
 ### 3. Concurrent review dispatch
 
@@ -123,17 +130,44 @@ Build the review prompt combining the baseline diff with instructions:
 > \"error|warn|sugg\", \"description\": \"...\"}`. Flag only real issues per the Code
 > Review Pyramid. Layer 5 (style) is never flagged."
 
-Send the prompt to each reviewer model via `ollama-review.sh`:
-
 ```bash
 PROMPT="<diff + instructions>"
+```
 
+**If `TIER="cloud"`** — send to each reviewer model via `ollama-review.sh`:
+
+```bash
 R1=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_1_model>)
 R2=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_2_model>)
 R3=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_3_model>)
 ```
 
+**If `TIER="cli"`** — try the external-agent cascade first, per round, falling back to
+local Ollama only for whichever round(s) every external agent fails on:
+
+```bash
+source .claude/skills/lib/agents.sh
+
+RUN_DIR=$(mktemp -d)
+PROMPT_FILE="$RUN_DIR/prompt.txt"
+printf '%s' "$PROMPT" > "$PROMPT_FILE"
+
+for n in 1 2 3; do
+  if try_external_agents "$n" "$PROMPT_FILE" .claude/skills/fix-review/config.yaml "$RUN_DIR"; then
+    eval "R${n}=\$(cat \"$RUN_DIR/round_${n}.raw.json\")"
+    echo "round $n served by external_agents ($(cut -d: -f2 "$RUN_DIR/round_${n}.failover"))"
+  else
+    # Every external agent failed for this round — fall through to local Ollama.
+    MODEL=$(yq -r ".reviewers.cli[$((n-1))].cmd" .claude/skills/fix-review/config.yaml)
+    eval "R${n}=\$(echo \"\$PROMPT\" | bash -c \"$MODEL\")"
+    echo "round $n served by cli (local Ollama) — external_agents exhausted"
+  fi
+done
+```
+
 Each call returns a JSON array (empty `[]` on parse failure — safe degradation).
+Note which tier actually served each round (`cloud` / `external_agents:<tool>` / `cli`)
+— the PR summary in step 6 reports it per round.
 
 ### 4. Tally findings
 
@@ -189,7 +223,7 @@ Post a single collapsible summary:
 | path/file.go:42 | 2/3 | 2 | error | CONFIRM | nil dereference on empty slice |
 | path/file.go:87 | 1/3 | 5 | sugg | DISMISS | style — not flagged by pyramid |
 
-Models: <round_1_model>, <round_2_model>, <round_3_model> (from config.yaml)
+Models: <round_1_model> (<tier>), <round_2_model> (<tier>), <round_3_model> (<tier>)
 Arbiter: Claude Sonnet 4.6
 
 </details>
@@ -225,7 +259,8 @@ git checkout main && git pull
 | State | Action |
 |-------|--------|
 | All findings arbitrated, no blockers | Merge |
-| Cloud endpoint unreachable | Fall back to CLI tier, proceed |
+| Cloud endpoint unreachable | Fall back to `external_agents` tier per round, proceed |
+| Every `external_agents` tool fails for a round | Fall back to local `cli` (Ollama) for that round, proceed |
 | Model returns non-JSON | Treat as 0 findings for that model, proceed |
 | Round fails to push | Stop, report error to user |
 | PR already merged | Report and exit |

--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -15,8 +15,21 @@ reviewers:
     round_2: { model: minimax-m2.7:cloud }          # MiniMax, non-thinking, long-ctx
     round_3: { model: gemma4:31b-cloud }            # Gemma code model, non-thinking
 
-  # Local failover tier — tools-capable models, no network dependency.
-  # Engages automatically when the Ollama cloud endpoint probe fails.
+  # External coding-agent CLIs — tier 2. Engages when the cloud probe fails,
+  # tried before the local Ollama tier below. Cascades in list order; first
+  # tool returning non-empty output wins. See .claude/skills/lib/agents.sh.
+  external_agents:
+    - { tool: cursor-agent, model: auto }
+    - { tool: omp }
+    - { tool: codex }
+    - { tool: opencode, model: "opencode/nemotron-3-ultra-free" }
+    - { tool: kilo }
+
+  # Local failover tier (tier 3) — tools-capable models, no network
+  # dependency. Key is named "cli" for historical reasons; it is actually
+  # local Ollama, not an external CLI tier (that's external_agents above).
+  # Engages automatically when the Ollama cloud endpoint probe fails AND
+  # every external_agents tool has also failed/returned empty.
   # ollama-review.sh reads the prompt from stdin, calls the OpenAI-compat
   # endpoint, and returns the model's raw content (JSON array expected).
   cli:

--- a/.claude/skills/lib/agents.sh
+++ b/.claude/skills/lib/agents.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# lib/agents.sh — external coding-agent CLI adapters for /fix-review tier 2
+#
+# Usage:
+#   source .claude/skills/lib/agents.sh
+#
+#   OUT=$(run_external_agent "cursor-agent" "auto" "$PROMPT_FILE")
+#   try_external_agents 1 "$PROMPT_FILE" "$CONFIG"   # cascades the ordered
+#                                                     # reviewers.external_agents
+#                                                     # list from config.yaml
+#
+# Each of cursor-agent/omp/codex/opencode/kilo is invoked read-only
+# (no edits, no shell execution) and already unwraps its own tool-specific
+# output envelope, so callers get plain text back — the SAME code-fence-strip
+# + JSON-array-validate logic already used for Ollama responses (see
+# fix-review/SKILL.md STEP 4 parse_round()) works unchanged downstream.
+#
+# All prompt content is piped via stdin/file-ref, never a shell argument —
+# PR diffs can be large enough to risk ARG_MAX.
+#
+# `agy` was evaluated and dropped: even with the full review prompt (not
+# just a throwaway one-liner) it consistently explores the filesystem/
+# environment instead of answering directly, in both --mode plan and
+# unrestricted modes. Not a prompt-wording problem — verified 2026-07-29.
+
+# ---------------------------------------------------------------------------
+# Per-tool adapters — read-only invocation + envelope extraction, verified
+# against real calls with a realistic review prompt (not just --help docs).
+# ---------------------------------------------------------------------------
+
+agent_cursor_agent() {
+  local model="$1" prompt_file="$2"
+  cursor-agent --print --output-format json --mode plan \
+    ${model:+--model "$model"} < "$prompt_file" \
+    | jq -r '.result // empty'
+}
+
+agent_omp() {
+  local model="$1" prompt_file="$2"
+  # omp's own "@file" syntax for message content (not stdin).
+  omp -p --mode json --no-tools ${model:+--model "$model"} "@$prompt_file" \
+    | jq -rs '[.[] | select(.type=="message_update") | .assistantMessageEvent
+               | select(.type=="text_end") | .content] | last // empty'
+}
+
+agent_codex() {
+  local model="$1" prompt_file="$2"
+  # Plain-text output with a banner + echoed prompt around the answer;
+  # take the last line that looks like a JSON array (codex prints the
+  # final answer twice — once inline, once in a closing summary).
+  codex exec --sandbox read-only ${model:+-m "$model"} - < "$prompt_file" 2>/dev/null \
+    | awk '/^\[/' | tail -1
+}
+
+agent_opencode() {
+  local model="$1" prompt_file="$2"
+  # No default model on this install — always pass one explicitly or the
+  # call errors out (verified 2026-07-29). config.yaml must set a model
+  # for this tool.
+  opencode run --format json ${model:+--model "$model"} < "$prompt_file" \
+    | jq -rs '[.[] | select(.type=="text")] | last | .part.text // empty'
+}
+
+agent_kilo() {
+  local model="$1" prompt_file="$2"
+  # Same CLI/event shape as opencode (fork/whitelabel of the same project),
+  # but has a working default model — --model stays optional.
+  kilo run --format json ${model:+--model "$model"} < "$prompt_file" \
+    | jq -rs '[.[] | select(.type=="text")] | last | .part.text // empty'
+}
+
+# ---------------------------------------------------------------------------
+# Dispatcher + cascade
+# ---------------------------------------------------------------------------
+
+# Usage: run_external_agent "<tool>" "<model-or-empty>" "<prompt-file>"
+# Prints extracted text to stdout. Empty output == failure for this tool.
+run_external_agent() {
+  local tool="$1" model="$2" prompt_file="$3"
+  case "$tool" in
+    cursor-agent) agent_cursor_agent "$model" "$prompt_file" ;;
+    omp)          agent_omp          "$model" "$prompt_file" ;;
+    codex)        agent_codex        "$model" "$prompt_file" ;;
+    opencode)     agent_opencode     "$model" "$prompt_file" ;;
+    kilo)         agent_kilo         "$model" "$prompt_file" ;;
+    *)
+      echo "warn: unknown external agent tool '$tool' — skipping" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Usage: try_external_agents <round-n> <prompt-file> <config-path> <run-dir>
+# Walks reviewers.external_agents in config.yaml order; first tool that
+# returns non-empty output wins. Writes round_${n}.raw.json / .meta /
+# .failover on success (same marker-file convention SKILL.md STEP 3/11
+# already use for the ollama_local tier). Returns 1 if every tool failed
+# (or the config key is absent) so the caller falls through to ollama_local.
+try_external_agents() {
+  local n="$1" prompt_file="$2" config="$3" run_dir="$4"
+  local entry tool model out
+
+  # Read the config list on fd 3, not stdin — several adapters (cursor-agent,
+  # codex, opencode) read their prompt from stdin, and a `while read` loop
+  # driven by stdin would otherwise race/interleave with those inner reads
+  # (confirmed empirically: without this, a tool mid-loop got truncated
+  # input because it silently shared the loop's stdin stream).
+  while IFS= read -r entry <&3; do
+    [ -z "$entry" ] && continue
+    tool=$(jq -r '.tool' <<<"$entry")
+    model=$(jq -r '.model // empty' <<<"$entry")
+    echo "warn: round ${n} trying external agent ${tool}${model:+ ($model)}" >&2
+    out=$(run_external_agent "$tool" "$model" "$prompt_file" 2>/dev/null </dev/null)
+    if [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then
+      printf '%s' "$out" > "$run_dir/round_${n}.raw.json"
+      printf '%s\n0' "$tool" > "$run_dir/round_${n}.meta"
+      printf 'external_agents:%s' "$tool" > "$run_dir/round_${n}.failover"
+      return 0
+    fi
+    echo "warn: round ${n} external agent ${tool} failed/empty — trying next" >&2
+  done 3< <(yq -c '.reviewers.external_agents[]' "$config" 2>/dev/null)
+
+  return 1
+}


### PR DESCRIPTION
## Summary
- Adds `reviewers.external_agents` (cursor-agent, omp, codex, opencode, kilo) as a real tier 2 in `/fix-review`'s failover cascade, between the cloud primary (`openrouter`) and the local Ollama tier (misleadingly named `cli`).
- Copies `.claude/skills/lib/agents.sh` verbatim from the canonical `~/wrk/common/skills/fix-review` (per-tool adapters + `try_external_agents` cascade helper).
- Updates `SKILL.md`'s dispatch step to try the external-agent cascade per round when the cloud probe fails, falling through to local Ollama only for whichever round(s) every external agent also fails on.

Follows `~/wrk/common/tmp/fix-review-group-b-vmm-rada.md` (audit note: this repo's "cli" tier is actually local Ollama in disguise, not an external-agent tier — left as-is, just documented more clearly).

## Test plan
- [x] `bash -n .claude/skills/lib/agents.sh` — syntax OK
- [x] Verified `.claude/skills/lib/agents.sh` is byte-identical to the canonical copy
- [x] Verified `config.yaml` YAML is valid and `reviewers.external_agents` parses correctly with `yq`
- [x] Ran `try_external_agents` against a real review prompt: cursor-agent failed, cascade correctly fell through to omp, which returned a valid response and wrote the `round_N.failover` marker (`external_agents:omp`)
- [x] Ran `try_external_agents` with every external tool forced to fail: correctly returned exit 1 with no success markers, so the caller falls through to the local `cli` tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)