### PR TITLE
feat(fix-review): add agy to external_agents tier (tier 2)

### DIFF
--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -20,6 +20,7 @@ reviewers:
   # tool returning non-empty output wins. See .claude/skills/lib/agents.sh.
   external_agents:
     - { tool: cursor-agent, model: auto }
+    - { tool: agy, model: "Gemini 3.5 Flash (Low)" }
     - { tool: omp }
     - { tool: codex }
     - { tool: opencode, model: "opencode/nemotron-3-ultra-free" }
@@ -57,3 +58,5 @@ pricing:
   "qwen3-coder:30b":  { input: 0.00, output: 0.00 }
   "qwen2.5-coder:7b": { input: 0.00, output: 0.00 }
   "granite3.3:8b":    { input: 0.00, output: 0.00 }
+  # External agents (reviewers.external_agents)
+  "agy":  { input: 0.00, output: 0.00 }

--- a/.claude/skills/lib/agents.sh
+++ b/.claude/skills/lib/agents.sh
@@ -35,6 +35,17 @@ agent_cursor_agent() {
     | jq -r '.result // empty'
 }
 
+agent_agy() {
+  local model="$1" prompt_file="$2"
+  # Unlike every other adapter here, the prompt MUST be a positional
+  # argument, not stdin/file-ref — verified 2026-07-30. --prompt is an
+  # alias for the --print boolean flag, not a value-taking option; the
+  # actual prompt text goes after -p as a trailing positional argument.
+  agy -p "$(cat "$prompt_file")" --model "${model:-Gemini 3.5 Flash (Low)}" \
+    --mode plan --output-format json 2>/dev/null \
+    | jq -r '.response // empty'
+}
+
 agent_omp() {
   local model="$1" prompt_file="$2"
   # omp's own "@file" syntax for message content (not stdin).
@@ -79,6 +90,7 @@ run_external_agent() {
   local tool="$1" model="$2" prompt_file="$3"
   case "$tool" in
     cursor-agent) agent_cursor_agent "$model" "$prompt_file" ;;
+    agy)          agent_agy          "$model" "$prompt_file" ;;
     omp)          agent_omp          "$model" "$prompt_file" ;;
     codex)        agent_codex        "$model" "$prompt_file" ;;
     opencode)     agent_opencode     "$model" "$prompt_file" ;;


### PR DESCRIPTION
## Summary
- Adds `agy` as a tier-2 external agent in the `/fix-review` cascade, per `~/wrk/common/tmp/fix-review-agy-rollout-shared.md`.
- Root cause for the original miss: `agy --prompt "text"` silently drops the prompt — `--prompt` is an alias for the `--print` *boolean* flag, not a value-taking option. The fix passes the prompt via `agy -p "$(cat file)" ...` (positional after `-p`). Verified working in canonical `dd5f904` including `--mode plan` (read-only).
- **Patch 1** — `agent_agy()` added to `.claude/skills/lib/agents.sh` (between `agent_cursor_agent` and `agent_omp`), registered in the `run_external_agent()` dispatcher at the matching position.
- **Patch 2** — `agy` entry in `reviewers.external_agents` with model `"Gemini 3.5 Flash (Low)"`, plus zero-cost pricing row for telemetry completeness (other external agents have no pricing rows today — out of scope here, mirror the same pattern separately if/when you want to add them).

## Test plan
- [x] `bash -n .claude/skills/lib/agents.sh` passes
- [x] `yq -c '.reviewers.external_agents[]'` shows `agy` in expected position with `model: "Gemini 3.5 Flash (Low)"`
- [x] `yq -c '.pricing."agy"'` returns `{input: 0.00, output: 0.00}`
- [ ] Live end-to-end check (optional per doc) — not run

🤖 Generated with [Claude Code](https://claude.com/claude-code)