### PR TITLE
chore(dreaming): refresh stale tech-lead agent-memory, bootstrap 2 missing (W32 §4)

### DIFF
--- a/.claude/agent-memory/MEMORY.md
+++ b/.claude/agent-memory/MEMORY.md
@@ -10,6 +10,8 @@ Each entry below is a link to a memory file with a one-line description.
 
 - [stage0-done-not-on-wire.md](stage0-done-not-on-wire.md) — stage0_done is EventFunc-internal only, never on the SSE wire; recurring doc-drift trap across api.md/user-guide.md/strategies.md
 
-- [rolebased-strategy-orphan.md](rolebased-strategy-orphan.md) — RoleBased resolved: registered standalone (opt-in ROLE_BASED_* env family); extraction-into-MoA overruled by user
+- [rolebased-strategy-orphan.md](rolebased-strategy-orphan.md) — HISTORICAL: RoleBased resolved (registered standalone, extraction-into-MoA overruled); see project_architecture.md for current shape
+- [code-generator/MEMORY.md](code-generator/MEMORY.md) — bootstrapped W32: no memories yet
+- [code-simplifier/MEMORY.md](code-simplifier/MEMORY.md) — bootstrapped W32: no memories yet
 
 <!-- Add pointers here as agents write memories. Keep under 200 lines. -->

--- a/.claude/agent-memory/code-generator/MEMORY.md
+++ b/.claude/agent-memory/code-generator/MEMORY.md
@@ -1,0 +1,9 @@
+# Memory Index
+
+Bootstrapped 2026-08-14 (dreaming pass W32, §4 M1) — `code-generator` runs on
+every PR in this repo but had no per-agent memory, unlike `tech-lead` and
+`go-security-reviewer`. Shared top-level memories (`.claude/agent-memory/*.md`)
+still apply; this index is for `code-generator`-specific notes as they
+accumulate.
+
+<!-- Add pointers here as this agent writes memories. -->

--- a/.claude/agent-memory/code-simplifier/MEMORY.md
+++ b/.claude/agent-memory/code-simplifier/MEMORY.md
@@ -1,0 +1,9 @@
+# Memory Index
+
+Bootstrapped 2026-08-14 (dreaming pass W32, §4 M1) — `code-simplifier` runs on
+every `/fix-review` round 2 but had no per-agent memory, unlike `tech-lead` and
+`go-security-reviewer`. Shared top-level memories (`.claude/agent-memory/*.md`)
+still apply; this index is for `code-simplifier`-specific notes as they
+accumulate.
+
+<!-- Add pointers here as this agent writes memories. -->

--- a/.claude/agent-memory/rolebased-strategy-orphan.md
+++ b/.claude/agent-memory/rolebased-strategy-orphan.md
@@ -1,8 +1,16 @@
 ---
 name: rolebased-strategy-orphan
-description: RoleBased resolved — registered as a standalone opt-in strategy (extraction-into-MoA plan overruled)
+description: "HISTORICAL (resolved 2026-07-21, both phases merged) — RoleBased registered as a standalone opt-in strategy; extraction-into-MoA plan overruled"
 type: project
+status: resolved-historical
 ---
+
+> **Status: RESOLVED.** Both phases below are merged (#301, and RoleBased's
+> registration + later #322/#323 evolution). Kept as the historical decision
+> record — the "why standalone, not MoA" reasoning stays load-bearing (don't
+> resurrect the extraction plan) — but there is no open work here. See
+> [[project_architecture]] for RoleBased's current shape (5 roles, YAML-first
+> registration).
 
 `council.RoleBased` (enum in `internal/council/types.go`, impl `rolebased.go`,
 dispatched via `runner.go`) is a real, tested 2-stage pipeline (parallel specialist

--- a/.claude/agent-memory/tech-lead/known_issues.md
+++ b/.claude/agent-memory/tech-lead/known_issues.md
@@ -1,8 +1,8 @@
 ---
 name: known_issues
-description: Known issues and open debt in the vmm-rada v2 codebase (updated 2026-07-19)
+description: Known issues and open debt in the vmm-rada v2 codebase (updated 2026-08-14)
 type: project
-last-verified: 2026-07-19
+last-verified: 2026-08-14
 ---
 
 **Why:** Helps future sessions skip re-analysis and focus on actual open debt.
@@ -15,14 +15,19 @@ The codebase was fully rewritten from v1 to v2 (clean-slate). The previous
 now either resolved or irrelevant to the new architecture. Dead issue refs
 (#9, #13, #53, #54) were removed; those issues no longer exist.
 
-## Open (as of 2026-07-19)
+## Open (as of 2026-08-14)
 
-None. Repo has been in pure maintenance mode for ~7 weeks — tooling/deps
-only, no feature work. The Go-toolchain-CVE recurrence (W23→W25→W28) is
-now structurally closed, not just re-flagged: a scheduled daily
-`govulncheck.yml` CI gate (PR #286, issue #283) auto-opens a `p1`/
-`security` issue on future toolchain CVEs — no watch-item to track here
-anymore.
+None known. **Correction to the previous version of this file:** it claimed
+"pure maintenance mode for ~7 weeks, no feature work" — that was false even
+at the time and has been false since. Real feature work shipped between
+2026-07-19 and now: `RoleBased` registered as a live opt-in strategy (#303),
+`DevilsAdvocate` role + `Creator` rename + named per-role model assignment
+(#322), YAML-based council registry replacing per-strategy env vars as the
+primary config path (#323), `external_agents` tier 2 added to `/fix-review`
+(#328, #329). The Go-toolchain-CVE recurrence (W23→W25→W28) is still
+structurally closed: a scheduled daily `govulncheck.yml` CI gate (PR #286,
+issue #283) auto-opens a `p1`/`security` issue on future toolchain CVEs — no
+watch-item to track here for that.
 
 ## Resolved (W25 → W29)
 
@@ -31,6 +36,20 @@ anymore.
 - ✅ Stage2.jsx bypassing `<Markdown>` — all render sites now route through it (PR #252): `Stage2.jsx:139,239,333,337,427,456`
 - ✅ `/fix-review` skill vs practice divergence — SKILL.md rewritten to canonical `config.yaml`-driven flow (PR #257)
 - ✅ 5 Dependabot PRs (#241–#245) — all merged/closed by 2026-06-24; `/review-deps` skill itself later deleted (PR #249), superseded by `dependabot-reviewer` agent
+
+## Resolved (W30 → W32)
+
+- ✅ `RoleBased` orphan strategy (unreachable for months) — registered standalone,
+  opt-in (#303); see [[rolebased-strategy-orphan]] — archived, not deleted, since it's
+  the resolution record
+- ✅ RoleBased expanded 4→5 roles (`DevilsAdvocate` added, `Generator`→`Creator`
+  renamed), named per-role model assignment replacing positional `Models[i % len]`
+  (#322)
+- ✅ YAML-based council registry (`configs/council.yaml`, `COUNCIL_CONFIG_PATH`)
+  replacing per-strategy env vars as the primary config path; also fixed `cmd/eval`'s
+  duplicated registry silently missing `role-based` (#323)
+- ✅ `/fix-review` `external_agents` tier 2 (cursor-agent, agy, omp, codex, opencode,
+  kilo) added to the failover cascade (#328, #329)
 
 ## Resolved (v2 baseline)
 

--- a/.claude/agent-memory/tech-lead/project_architecture.md
+++ b/.claude/agent-memory/tech-lead/project_architecture.md
@@ -2,7 +2,7 @@
 name: project_architecture
 description: VMM Rada Go backend — module map, key design decisions, established conventions
 type: project
-last-verified: 2026-05-10
+last-verified: 2026-08-14
 ---
 
 Go backend for VMM Rada, a 3-stage multi-LLM deliberation system.
@@ -20,11 +20,21 @@ internal/openrouter/client.go — Concrete LLM gateway; implements council.LLMCl
 internal/council/interfaces.go — LLMClient / Runner / Stage0Runner interfaces (DI seam)
 internal/council/types.go     — Domain types: CouncilType, Stage*Result, EventFunc, CompletionRequest/Response
 internal/council/council.go   — Rada struct; main 3-stage pipeline (peer review)
-internal/council/runner.go    — Runner orchestration + Strategy dispatch switch (3 implemented, 4 planned); structured logging via slog
-internal/council/rolebased.go — Role-based 2-stage pipeline (Stage 1 + Stage 3, no peer review)
-internal/council/majority.go  — Majority strategy (vote-tally, opt-in via MAJORITY_MODELS); Stage 2 emits kind="vote_tally"
+internal/council/runner.go    — Runner orchestration + Strategy dispatch switch (all 7 strategies implemented); structured logging via slog
+internal/council/rolebased.go — Role-based 2-stage pipeline (Stage 1 + Stage 3, no peer review); 5 named roles
+internal/council/roles.go     — DefaultRoles (Creator/Critic/Verifier/Simplifier/DevilsAdvocate), RolesWithModels()
+internal/council/majority.go  — Majority strategy (vote-tally, no LLM Stage 2); Stage 2 emits kind="vote_tally"
+internal/council/generaterankrefine.go — GenerateRankRefine strategy
+internal/council/debate.go    — MultiAgentDebate strategy
+internal/council/moa.go       — MixtureOfAgents strategy (proposers → aggregators → refiner)
+internal/council/delphi.go    — Delphi strategy (multi-round convergence)
+internal/council/strategy_wiring_test.go — AST-derived invariant: every Strategy const must be
+  registered or exempted; also asserts configs/council.yaml covers all 7
 internal/council/prompts.go   — Prompt templates (per-stage, per-strategy)
 internal/council/rankings.go  — Stage 2 ranking aggregation (PeerReview's Kendall's W)
+internal/config/registry.go      — BuildRegistry(): YAML-first, env-fallback, shared by cmd/server + cmd/eval
+internal/config/registry_yaml.go — configs/council.yaml parser (yaml.v3, KnownFields strict)
+internal/config/registry_env.go  — legacy per-strategy env-var registry (fallback only)
 internal/storage/storage.go   — JSON file store; atomic writes; per-conv mutex via sync.Map; UUID validation via regex
 internal/api/handler.go       — HTTP handlers + SSE streaming; CORS + security middleware via wrap()
 internal/eval/                — Eval harness: judge, report, eval runner; LLM-as-judge for council quality
@@ -51,7 +61,8 @@ internal/eval/                — Eval harness: judge, report, eval runner; LLM-
   Real file I/O (temp dirs), not mocks per `copilot-instructions.md`. Frontend
   has a Vitest harness as well (2 spec files).
 - **Linting:** `go vet ./...` is the gate; staticcheck/golangci-lint not yet integrated.
-- **External deps:** only `github.com/joho/godotenv v1.5.1`. Go 1.26.3.
+- **External deps:** `github.com/joho/godotenv v1.5.1` and `gopkg.in/yaml.v3` (council
+  registry config, promoted to direct dep in PR #323). Go 1.26.5.
 
 ## Key design decisions
 
@@ -60,15 +71,22 @@ internal/eval/                — Eval harness: judge, report, eval runner; LLM-
   use real implementations against temp dirs.
 - **labelToModel mapping is ephemeral** — not persisted, only in API response
 - **Stage 2 capped at 26 council members** (A-Z label limit)
-- **Strategy enum** (`internal/council/types.go`) declares 7 constants. **Three
-  implemented today:** `PeerReview` (3-stage Karpathy peer review), `RoleBased`
-  (2-stage roles → chairman; emits a minimal `Stage2CompleteData` stub), and
-  `Majority` (parallel generation → vote tally, no LLM Stage 2; opt-in registration
-  via `MAJORITY_MODELS`). **Four reserved/planned:** `GenerateRankRefine`,
-  `MultiAgentDebate`, `MixtureOfAgents`, `Delphi` — runner returns
-  `"strategy %d not implemented"`. Stage 2 carries a `kind` discriminator
-  (`peer_ranking`, `role_stub`, `vote_tally`, plus reserved kinds for the planned
-  strategies) so future strategies ship without touching shared SSE code.
+- **Strategy enum** (`internal/council/types.go`) declares 7 constants — **all 7
+  implemented and registered** (as of PR #323, closing a gap PR #303 had already
+  started closing for `RoleBased`): `PeerReview` (3-stage Karpathy peer review),
+  `RoleBased` (2-stage, 5 named roles → chairman), `Majority` (parallel generation →
+  vote tally, no LLM Stage 2), `GenerateRankRefine`, `MultiAgentDebate`,
+  `MixtureOfAgents` (proposers → aggregators → refiner), `Delphi` (multi-round
+  convergence). Registration is **YAML-first** — `configs/council.yaml` (parsed by
+  `internal/config/registry_yaml.go`, path via `COUNCIL_CONFIG_PATH`) builds the
+  entire registry when present; per-strategy env vars (`MAJORITY_MODELS`,
+  `ROLE_BASED_MODELS`, etc.) are fallback-only, used only when the YAML file is
+  absent. `TestAllStrategiesRegisteredOrExempted` (AST-derived from the enum) and
+  `TestShippedConfigCoversAllStrategies` both gate against silent registration gaps
+  — the class of bug that left `RoleBased` unreachable for months and `cmd/eval`
+  missing it even longer. Stage 2 carries a `kind` discriminator (`peer_ranking`,
+  `role_stub`, `vote_tally`, plus one kind per remaining strategy) so strategies ship
+  without touching shared SSE code.
 - **Stage 0 clarification loop** (configurable via `CLARIFICATION_*` env vars).
   `ClarificationMaxRounds=0` disables the feature.
   Stage 0 model overrides are intentionally NOT pre-filled from default council
@@ -100,3 +118,15 @@ CORS hardcoding was also flagged as "false (PR #31 made it configurable)" by
 dreaming, but verification against actual code shows the hardcoded map is still
 in place. Treat dreaming reports as evidence, not as truth — verify against
 current code before believing claims.
+
+## What changed since 2026-05-10 (previous version of this file)
+
+Rewritten 2026-08-14 (dreaming pass W32, §4) — this file had drifted badly:
+strategy count (claimed 3 implemented + 4 planned; verified 7/7 via
+`internal/council/types.go` Strategy enum + `configs/council.yaml`'s 7
+`strategy:` entries), Go version (claimed 1.26.3; `go.mod` says 1.26.5), and
+module layout (missing `strategy_wiring_test.go`, `roles.go`,
+`generaterankrefine.go`, `debate.go`, `moa.go`, `delphi.go`,
+`internal/config/registry*.go`). All facts above re-verified against current
+code/`go.mod`/`configs/council.yaml` at rewrite time, not carried forward from
+the stale version.


### PR DESCRIPTION
## Summary
Direct-edit batch from `/apply-dreaming 2026-W32` §4 (agent-memory health). All memory-only, no runtime/agent-prompt changes.

- **H3** `tech-lead/project_architecture.md` — strategy count corrected (7/7 implemented, was "3 implemented + 4 planned"), Go version corrected (1.26.5, was 1.26.3), module layout brought current.
- **H4** `tech-lead/known_issues.md` — removed false "pure maintenance mode" claim, added Resolved (W30→W32) section.
- **H5** `rolebased-strategy-orphan.md` — tagged RESOLVED/historical, kept as decision record.
- **M1** `code-generator/`, `code-simplifier/` — bootstrapped empty per-agent memory (both heavily-used, previously had none).

L1 (low severity) skipped per triage.

## Test plan
- [x] All facts re-verified against current code/`go.mod`/`configs/council.yaml`, not carried forward from stale source
- [x] No code changes — memory files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)