### PR TITLE
docs(ship): fix Step 7 — dead 3-round sequential review, actual is parallel+arbiter

### DIFF
--- a/.claude/agent-memory/tech-lead/MEMORY.md
+++ b/.claude/agent-memory/tech-lead/MEMORY.md
@@ -7,3 +7,4 @@
 - [governance-enforcement-point.md](governance-enforcement-point.md) — Review criteria live in .claude/agents/*.md; skill Step lists are summaries and must not grow a second copy
 - [docs-triad-sync-gate.md](docs-triad-sync-gate.md) — Strategy/config/wire-shape changes must ship their doc updates in the same PR; canonical doc target map
 - [agent-scope-boundary-pairs.md](agent-scope-boundary-pairs.md) — security-reviewer retired 2026-08-14; deleting a cross-referencing agent requires editing the survivor's description + grep without name-substring filters
+- [review-verify-checked-out-branch.md](review-verify-checked-out-branch.md) — Confirm HEAD matches the branch named in a review request; use `git show <branch>:<file>`, not the working tree

--- a/.claude/agent-memory/tech-lead/review-verify-checked-out-branch.md
+++ b/.claude/agent-memory/tech-lead/review-verify-checked-out-branch.md
@@ -1,0 +1,22 @@
+---
+name: review-verify-checked-out-branch
+description: Confirm HEAD equals the branch named in a code-review request before trusting any diff; this repo routinely has several task branches checked out at once
+type: feedback
+---
+
+Before reviewing, run `git rev-parse --abbrev-ref HEAD` and compare it to the branch
+named in the review request. If they differ, review via explicit refs —
+`git diff main...<branch>` and `git show <branch>:<path>` — never the working tree.
+
+**Why:** on 2026-08-14 a review request named `task/332-ship-skill-fix-fixreview-drift`,
+but HEAD was `task/336-retire-security-reviewer`. Grepping the working-tree file returned
+the *old* stale text and appeared to contradict the supplied diff, which would have
+produced a false REJECT. `git show <branch>:<file>` is also immune to diff-output
+post-processing hooks, which can reformat or mis-scope what `git diff` appears to print.
+
+**How to apply:** first two commands of any code review. When they mismatch, say so in
+the verdict (the ship/merge step may be operating on the wrong checkout) and pin every
+subsequent check to the explicit ref. `git show <branch>:<file> | grep -n` is the
+reliable way to assert "string X is absent from the file" for acceptance criteria.
+
+Related: [[skill-doc-drift-fixreview]].

--- a/.claude/agent-memory/tech-lead/skill-doc-drift-fixreview.md
+++ b/.claude/agent-memory/tech-lead/skill-doc-drift-fixreview.md
@@ -27,5 +27,13 @@ DEFER) — with a 3-tier failover (`reviewers.openrouter` → `reviewers.externa
 4. Note that `go-security-reviewer`, `code-simplifier`, and `tech-lead` agents still
    exist and are used by other skills — the correction is "`/fix-review` does not
    dispatch to them", never "these agents are gone".
+5. **A pointer paragraph must stay a pointer.** The replacement text is capped at
+   roughly "what it is + one sentence + link". Restating failover tier order,
+   vote-tally semantics, or the arbiter's ruling vocabulary re-creates the same
+   duplication under a fresher timestamp — those are the volatile parts
+   (`external_agents` was a tier-2 addition in #328/#329, days old). A paragraph
+   that ends with "don't duplicate detail here" while duplicating ten lines of
+   detail is self-refuting; flag it. Ruled on issue #332 (2026-08-14).
 
 Related: [[stage0-done-not-on-wire]] — same recurring doc-drift shape.
+Related: [[review-verify-checked-out-branch]] — verify the branch before reviewing it.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -4,9 +4,9 @@ description: Implement a GitHub issue end-to-end — branch, code, tests, PR, /f
 user-invocable: true
 argument-hint: "[issue-number | issue-title]"
 metadata:
-  version: "3.1"
+  version: "3.2"
   author: backend-claude
-  last_updated: "2026-04-16"
+  last_updated: "2026-08-14"
 ---
 
 # /ship
@@ -21,7 +21,7 @@ select issue → read issue + files → resolve uncertainties → branch → imp
 
 - **One issue at a time.** Never work on multiple issues in parallel.
 - **Branch protection** — no direct pushes to `main`. Always use a PR.
-- **Run `/fix-review` after PR creation.** Three-round review (security + simplifier + tech-lead) then arbiter. Address findings in one commit. Then merge.
+- **Run `/fix-review` after PR creation.** Concurrent multi-model dispatch (see `.claude/skills/fix-review/SKILL.md`) then a single Claude arbiter pass. Address findings in one commit. Then merge.
 - Only ship PRs created by Claude or explicitly named by the user. Never touch Dependabot PRs.
 - After merge: checkout main, pull, then present the next unblocked issue.
 
@@ -177,13 +177,19 @@ Debt emoji: `⚡` quick-fix · `⚖️` balanced · `🏗️` proper-refactor
 
 ## Step 7: Run /fix-review
 
-Invoke `/fix-review <number>` to run the three-round review pipeline:
-1. Round 1 — `go-security-reviewer` (security vulnerabilities)
-2. Round 2 — `code-simplifier` (complexity, redundancy)
-3. Round 3 — `tech-lead` (architectural compliance)
-4. Round 4 — Arbiter: CONFIRM / DISMISS / DEFER each finding
+Invoke `/fix-review <number>`. It dispatches the diff concurrently to the
+reviewer models configured in `.claude/skills/fix-review/config.yaml`
+(`reviewers.openrouter.round_1/2/3`, falling back to the `external_agents`
+or local `cli` tiers if the cloud endpoint is unreachable), tallies findings
+by `file:line` (vote count is informational, not a gate), then a single
+Claude arbiter pass rules CONFIRM / ESCALATE / DISMISS / DEFER on each
+finding. `go-security-reviewer`, `code-simplifier`, and `tech-lead` still
+exist as agents in this repo — `/fix-review` just doesn't dispatch to them by
+name. See `.claude/skills/fix-review/SKILL.md` for the full pipeline; that
+file is the source of truth, don't duplicate its detail here.
 
-Address all CONFIRM findings in one commit; push. `/fix-review` merges when no blockers remain.
+Address all CONFIRM/ESCALATE findings in one commit; push. `/fix-review`
+posts a PR comment summarising the pass and merges when no blockers remain.
 
 ---
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -177,25 +177,21 @@ Debt emoji: `⚡` quick-fix · `⚖️` balanced · `🏗️` proper-refactor
 
 ## Step 7: Run /fix-review
 
-Invoke `/fix-review <number>`. It dispatches the diff concurrently to the
-reviewer models configured in `.claude/skills/fix-review/config.yaml`
-(`reviewers.openrouter.round_1/2/3`, falling back to the `external_agents`
-or local `cli` tiers if the cloud endpoint is unreachable), tallies findings
-by `file:line` (vote count is informational, not a gate), then a single
-Claude arbiter pass rules CONFIRM / ESCALATE / DISMISS / DEFER on each
-finding. `go-security-reviewer`, `code-simplifier`, and `tech-lead` still
-exist as agents in this repo — `/fix-review` just doesn't dispatch to them by
-name. See `.claude/skills/fix-review/SKILL.md` for the full pipeline; that
-file is the source of truth, don't duplicate its detail here.
+Invoke `/fix-review <number>`. It runs a concurrent multi-model review
+dispatch, then a single Claude arbiter pass rules CONFIRM / ESCALATE /
+DISMISS / DEFER on each finding. `go-security-reviewer`, `code-simplifier`,
+and `tech-lead` still exist as agents in this repo — `/fix-review` just
+doesn't dispatch to them by name. See `.claude/skills/fix-review/SKILL.md`
+for the full pipeline; that file is the source of truth, don't duplicate its
+detail here.
 
-Address all CONFIRM/ESCALATE findings in one commit; push. `/fix-review`
-posts a PR comment summarising the pass and merges when no blockers remain.
+Address all CONFIRM/ESCALATE findings in one commit; push.
 
 ---
 
 ## Step 8: (handled by /fix-review)
 
-`/fix-review` posts a PR comment summarising all rounds and merges once clean.
+`/fix-review` posts a PR comment summarising the pass and merges once clean.
 No manual polling or comment-fetching needed.
 
 ---


### PR DESCRIPTION
## Summary
- `/ship/SKILL.md` Step 7 and Rules line 24 described a stale 3-round sequential review pipeline (go-security-reviewer -> code-simplifier -> tech-lead -> arbiter). Actual `/fix-review` is concurrent multi-model dispatch + single Claude arbiter pass.
- Rewrote both to point to `.claude/skills/fix-review/SKILL.md` as the source of truth instead of duplicating pipeline detail (Tech Lead's required correction — first draft still restated volatile internals like the `external_agents`/`cli` tier order, exactly the kind of detail that drifts).
- Frontmatter bumped.

Closes #332

## Test plan
- [x] No Go/frontend files changed — build/vet/test not applicable
- [x] `grep` confirms zero remaining "3-round sequential" references
- [x] Tech Lead post-implementation review: APPROVED WITH CHANGES, both required changes applied in a follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)