### PR TITLE
docs(fix-review): arbiter notes — shell false-positive class + verify-before-done pattern

### DIFF
--- a/.claude/agent-memory/tech-lead/MEMORY.md
+++ b/.claude/agent-memory/tech-lead/MEMORY.md
@@ -8,4 +8,3 @@
 - [docs-triad-sync-gate.md](docs-triad-sync-gate.md) — Strategy/config/wire-shape changes must ship their doc updates in the same PR; canonical doc target map
 - [agent-scope-boundary-pairs.md](agent-scope-boundary-pairs.md) — security-reviewer retired 2026-08-14; deleting a cross-referencing agent requires editing the survivor's description + grep without name-substring filters
 - [review-verify-checked-out-branch.md](review-verify-checked-out-branch.md) — Confirm HEAD matches the branch named in a review request; use `git show <branch>:<file>`, not the working tree
-- [memory-rename-reverify-gate.md](memory-rename-reverify-gate.md) — Renaming an agent-memory file: re-grep every retained claim against code before bumping last-verified

--- a/.claude/agent-memory/tech-lead/MEMORY.md
+++ b/.claude/agent-memory/tech-lead/MEMORY.md
@@ -4,7 +4,8 @@
 - [known_issues.md](known_issues.md) — Prioritized list of improvements identified in initial analysis (2026-03-14)
 - [context-essentials-inclusion-test.md](context-essentials-inclusion-test.md) — Bar for adding a line to context-essentials.md; why the W32 module-extraction rule was rejected as over-fit
 - [skill-doc-drift-fixreview.md](skill-doc-drift-fixreview.md) — Never restate /fix-review's pipeline or model names in other skill docs; reference it instead
-- [governance-enforcement-point.md](governance-enforcement-point.md) — Review criteria live in .claude/agents/*.md; skill Step lists are summaries and must not grow a second copy
+- [governance-enforcement-point.md](governance-enforcement-point.md) — Review criteria live in .claude/agents/*.md, not skill Steps — except the /fix-review arbiter, which has no agent file
 - [docs-triad-sync-gate.md](docs-triad-sync-gate.md) — Strategy/config/wire-shape changes must ship their doc updates in the same PR; canonical doc target map
 - [agent-scope-boundary-pairs.md](agent-scope-boundary-pairs.md) — security-reviewer retired 2026-08-14; deleting a cross-referencing agent requires editing the survivor's description + grep without name-substring filters
 - [review-verify-checked-out-branch.md](review-verify-checked-out-branch.md) — Confirm HEAD matches the branch named in a review request; use `git show <branch>:<file>`, not the working tree
+- [memory-rename-reverify-gate.md](memory-rename-reverify-gate.md) — Renaming an agent-memory file: re-grep every retained claim against code before bumping last-verified

--- a/.claude/agent-memory/tech-lead/governance-enforcement-point.md
+++ b/.claude/agent-memory/tech-lead/governance-enforcement-point.md
@@ -26,5 +26,15 @@ into both files creates exactly the drift class this project keeps paying for (s
 3. Same rule for the skill-vs-agent split generally: `/backlog`, `/ship`, `/fix-review`
    own *sequencing*; agent prompts own *judgment criteria*.
 
+**Exception — the /fix-review arbiter has no agent file.** Step 5 is titled
+"Arbiter pass (Claude, main instance)": the arbiter is the main instance executing the
+skill, not a dispatched subagent. There is no `.claude/agents/arbiter.md` to retarget to,
+and `tech-lead.md` governs plan/code review — a different reviewer on a different trigger.
+So **arbiter judgment criteria legitimately live in `fix-review/SKILL.md` Step 5**, and
+rule 1 above does not fire. Do not reflexively reject that shape. Test before applying
+rule 1: *is there an agent prompt actually loaded at the moment this criterion must
+fire?* If no, the skill file is the enforcement point. Confirmed on issue #335
+(2026-08-14, shell false-positive class + verify-before-done notes).
+
 Ruling issued 2026-08-14 while reviewing plan `1-dreaming-w32-backlog-docs-triad.md`
 (docs-triad pre-flight gate, dreaming pass 2026-W32).

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -187,6 +187,17 @@ Re-fetch the full diff post-dispatch (should be unchanged, but confirms branch s
 gh pr diff $PR
 ```
 
+**Recurring false-positive class:** for findings about shell parameter
+expansion (`${var:+alt}` substitutes when set+non-empty; `${var:-default}` is
+the default-value form — models frequently conflate the two), redirect
+precedence (`< "$f"` on a command overrides an outer `</dev/null`), or stderr
+suppression (`2>/dev/null` on a command whose exit status is checked or has a
+fallback is fine; on an unchecked command it's a real Layer 2 finding): run a
+literal reproduction before ruling **either way**. Required to CONFIRM *and*
+to DISMISS. If you cannot construct one, rule DEFER — never DISMISS an
+unreproduced finding in this class. (Confirmed false positives in PRs #328,
+#329, #324 — always verify with a reproduction, don't pattern-match.)
+
 For each finding (ordered Layer 1 first), apply the Code Review Pyramid:
 
 | Ruling | Meaning | Action |
@@ -200,7 +211,12 @@ Also run an **independent scan** of the full diff — look for anything the mode
 
 For CONFIRM/ESCALATE findings:
 1. Apply the fix using Edit.
-2. Commit + push:
+2. Before considering the fix done, verify it — write a standalone
+   reproduction or minimal test, don't just trust plausible reasoning. PR
+   #324's arbiter caught its own bug (`grep -q '^['` — an unterminated POSIX
+   bracket class) this way, after already writing the fix; this is the
+   pattern to repeat, not a one-off.
+3. Commit + push:
 ```bash
 git add <files>
 git commit -m "fix(pr#$PR): arbiter — address confirmed findings"

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -191,8 +191,12 @@ gh pr diff $PR
 expansion (`${var:+alt}` substitutes when set+non-empty; `${var:-default}` is
 the default-value form — models frequently conflate the two), redirect
 precedence (`< "$f"` on a command overrides an outer `</dev/null`), or stderr
-suppression (`2>/dev/null` on a command whose exit status is checked or has a
-fallback is fine; on an unchecked command it's a real Layer 2 finding): run a
+suppression (`2>/dev/null` is fine when the exit status is checked *and* the
+command's failure modes are indistinguishable from success without stderr —
+e.g. a plain nonzero-on-error command with a fallback path; it's a real
+Layer 2 finding on an unchecked command, or on one like `grep -q` where
+distinct exit codes carry meaning — `grep` exits 2 on a real error and 1 on
+a plain no-match, and `2>/dev/null` hides which one happened): run a
 literal reproduction before ruling **either way**. Required to CONFIRM *and*
 to DISMISS. If you cannot construct one, rule DEFER — never DISMISS an
 unreproduced finding in this class. (Confirmed false positives in PRs #328,


### PR DESCRIPTION
## Summary
- Adds a Step 5 arbiter note: reproduction required to CONFIRM *and* DISMISS shell parameter-expansion/redirect-precedence/stderr-suppression findings (symmetric burden — Tech Lead's required correction to the original one-sided draft, which would have made DISMISS the cheap ruling for exactly the findings needing scrutiny).
- Adds PR #324's arbiter self-catch as the canonical verify-before-done example, placed in the CONFIRM/ESCALATE action list.
- Follow-up commit folds the `grep -q` exit-2 case into the `2>/dev/null` rule per Tech Lead's post-implementation review (the note's own canonical example was in mild tension with its "checked exit status is fine" clause).

**User sign-off:** explicit ("ship all of them") for this and the other 4 approved W32-dreaming issues, given per the global `.claude/` change-governance rule this issue's plan review flagged.

Closes #335

## Test plan
- [x] No Go/frontend files changed — build/vet/test not applicable
- [x] Tech Lead post-implementation review: APPROVED WITH CHANGES, all 4 required plan-review corrections verified present; suggested (non-blocking) tightening applied in a follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)