### PR TITLE
chore(agents): prune stale frontend/ invariants — 15-file sweep (Tech Lead audit)

### DIFF
--- a/.claude/agent-memory/frontend-extraction-stale-prompts.md
+++ b/.claude/agent-memory/frontend-extraction-stale-prompts.md
@@ -45,7 +45,24 @@ descriptive drift. The rest are descriptive-only and lower urgency.
   record that the judgment call is closed, in case a future sweep encounters the pre-#336 memory
   of this file via git history.
 
+**Missed by BOTH the dreaming inventory and my own 15-file audit — found at code review of
+issue #333 (2026-08-15):**
+- `.claude/hooks/eslint-fix.cjs` + its `PostToolUse` registration in `.claude/settings.json`
+  (`"Running eslint --fix on frontend file..."`). A *live executable hook*, not a prompt file —
+  it fires on every Write/Edit. Currently inert (it early-returns unless the path is `.js`/`.jsx`
+  AND resolves under `../../frontend`, which cannot exist), so it is dead weight rather than a
+  live failure. **Both greps missed it because the inventory scanned `.claude/agents/` and
+  `.claude/skills/` only.** Any future `.claude/` sweep must also cover `hooks/`, `settings.json`,
+  `plans/`, and `context-essentials.md`.
+- `.claude/plans/README.md` L40 — the `component:` enum still lists `frontend`. This is a
+  *shared vocabulary*: `pm-issue-writer.md`'s component-label table dropped its frontend rows in
+  #333, so the two now disagree on the same enum.
+- `.claude/context-essentials.md` L10-12 is the one place that *correctly* documents the removal
+  ("`frontend/` was removed from this repo (2026-07-19)"). Never prune it — it is the canonical
+  statement, and a naive grep flags it.
+
 **How to apply:** When reviewing or writing any "prune frontend refs" plan, check it against this
 inventory before approving. A plan asserting "grep returns no frontend hits afterwards" is
 unachievable unless it covers all 13 files AND allowlists the five legitimate-hit sites above.
-See [[frontend-prune-plan-corrections]] for the specific misreadings that plan 1 (2026-W32) shipped.
+See [[frontend-prune-plan-corrections]] for the specific misreadings that plan 1 (2026-W32) shipped,
+and [[prune-by-deletion-not-rewording]] for the failure mode that survived plan 2.

--- a/.claude/agent-memory/tech-lead/MEMORY.md
+++ b/.claude/agent-memory/tech-lead/MEMORY.md
@@ -8,3 +8,4 @@
 - [docs-triad-sync-gate.md](docs-triad-sync-gate.md) — Strategy/config/wire-shape changes must ship their doc updates in the same PR; canonical doc target map
 - [agent-scope-boundary-pairs.md](agent-scope-boundary-pairs.md) — security-reviewer retired 2026-08-14; deleting a cross-referencing agent requires editing the survivor's description + grep without name-substring filters
 - [review-verify-checked-out-branch.md](review-verify-checked-out-branch.md) — Confirm HEAD matches the branch named in a review request; use `git show <branch>:<file>`, not the working tree
+- [prune-by-deletion-not-rewording.md](prune-by-deletion-not-rewording.md) — In cleanup sweeps, reworded lines are riskier than deleted ones; a dropped qualifier can invert a rule

--- a/.claude/agent-memory/tech-lead/prune-by-deletion-not-rewording.md
+++ b/.claude/agent-memory/tech-lead/prune-by-deletion-not-rewording.md
@@ -1,0 +1,34 @@
+---
+name: prune-by-deletion-not-rewording
+description: In prompt-file cleanup PRs, a rule that is reworded rather than deleted can silently invert its meaning — check every surviving reworded line against the repo's actual state
+metadata:
+  type: feedback
+---
+
+When reviewing a "remove stale X references" sweep over `.claude/` prompt files, treat every
+**reworded** line as higher-risk than every **deleted** line. Deletions are self-evidently safe;
+a reword keeps the sentence's authority while quietly detaching it from its original subject.
+
+**Why:** These files are executable instructions consumed literally by small models (haiku/sonnet
+agents). A rule that was true and scoped ("no npm test step — the *frontend* has no test suite")
+becomes globally false when the qualifier is dropped ("no test step — no test suite in this repo"),
+and the agent then acts on the false version. Deleting the rule outright would have been correct;
+generalizing it inverted it.
+
+**Evidence:** PR for issue #333 (2026-08-15). `ci-build-agent.md` rule 9 was reworded from a
+frontend-scoped "no `npm run test` step" into "**No test step** — omit `npm run test` or similar
+(no test suite in this repo)". The repo has a `test:` Makefile target, `.github/workflows/ci.yml`
+runs `go test -race -count=1 ./...`, the same file's own `description:` advertises "make lint,
+make test", and its own workflow template at L80 emits `go test -race ./...`. The reworded rule
+told the CI-generating agent to omit the test step it elsewhere mandates. The PR's own commit
+message explicitly *allowlisted* this line as "generic ... doesn't reference frontend" — the
+rewording is exactly what made it look generic and safe.
+
+Same PR, same class, lower severity: `frontend/src/` in a Boundaries list was reworded to `src/`,
+a path that does not exist in this Go repo (`cmd/`, `internal/`).
+
+**How to apply:** In any prune/cleanup review, diff for `-`/`+` line *pairs* (a reword), not just
+`-` runs, and verify each survivor against the live repo — Makefile targets, `.github/workflows/`,
+actual directory layout. Reject "we kept it because it no longer mentions X" reasoning: if a line
+only existed to scope a now-removed subsystem, delete it. Related: [[frontend-prune-plan-corrections]]
+(coordinates wrong), this one (coordinates right, semantics wrong).

--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -54,28 +54,7 @@ These areas must not be modified without explicit user instruction — if the bu
 - **UUID validation regex in storage** — path traversal prevention, do not relax
 - **Atomic write pattern in `storage.go`** (write-to-tmp → rename) — crash safety, do not simplify
 
-## Frontend Bug Verification
-
-When the bug file is under `frontend/`, verification commands differ:
-
-```bash
-cd frontend && npm run lint
-```
-
-There is no test suite for the frontend — `npm run lint` is the only automated quality gate.
-
-**JS-specific patterns to watch:**
-
-| Category | Pattern | Diagnostic |
-|----------|---------|------------|
-| **Stale closure** | `useEffect` captures a variable that changes but dependency array is incomplete | Does the effect reference state/props not in `[]`? |
-| **Missing key prop** | Array rendered with `.map()` missing `key=` attribute | React warning in console; causes reconciliation bugs |
-| **Unsafe LLM output rendering** | LLM output injected as raw HTML instead of using react-markdown | Should route through `react-markdown`, never raw HTML injection |
-| **Forgotten await** | Async function called without `await`; promise silently dropped | Is the caller `async`? Is the return value used? |
-
 ## Self-Check Before Committing
-
-**For Go changes:**
 
 ```bash
 go build ./...
@@ -84,14 +63,6 @@ go test ./...
 ```
 
 All three must pass. If `go test` was already failing before your fix, note that explicitly — only fix the target bug, do not fix pre-existing failures.
-
-**For frontend changes:**
-
-```bash
-cd frontend && npm run lint
-```
-
-Must report zero errors. If lint was already failing before your fix, note that explicitly.
 
 ## Output Format
 

--- a/.claude/agents/ci-build-agent.md
+++ b/.claude/agents/ci-build-agent.md
@@ -11,7 +11,7 @@ You are the CI / Build Agent for **VMM Rada** — a specialist in GitHub Actions
 ## Boundaries
 
 You MAY only modify files in `.github/workflows/`. You MUST NOT touch:
-- `src/` (application code)
+- `cmd/`, `internal/` (application code)
 - Go source files (`*.go`)
 - Any source files
 
@@ -85,14 +85,17 @@ jobs:
 ## Workflow Best Practices (Always Apply)
 
 1. **Pin all actions** to a specific version (`@v4`, `@v5`, never `@latest`)
-2. **Enable caching**: `cache: true` for Go, `cache: 'npm'` for Node
+2. **Enable caching**: `cache: true` for Go
 3. **Concurrency cancellation**: always include the `concurrency` block
-4. **Node version**: `'20'` (matches `package.json` engines field)
+4. **Node**: only surviving use is `npx -y @redocly/cli@latest lint docs/openapi.yaml` —
+   no `setup-node` step needed (ubuntu-latest ships Node 20 pre-installed), nothing to
+   cache, no `package.json`/lockfile in this repo. Use `continue-on-error: true` on that
+   step (a tool failure shouldn't red-X the job — `internal/api/spec_test.go` is the
+   load-bearing drift check).
 5. **Go version**: use `go-version-file: go.mod` — never hardcode the version
 6. **NEVER hardcode secret values** — always use `${{ secrets.* }}`
 7. **Production gate**: always use `environment: production` for prod deploys
-8. **No `npm install`** in CI — always `npm ci`
-9. **No test step** — omit `npm run test` or similar (no test suite in this repo)
+8. **No test step needed beyond `go test -race ./...`** — no other test suite exists in this repo
 
 ---
 

--- a/.claude/agents/ci-build-agent.md
+++ b/.claude/agents/ci-build-agent.md
@@ -1,6 +1,6 @@
 ---
 name: ci-build-agent
-description: Use when a GitHub Actions workflow must be created or modified, a CI pipeline fails due to workflow configuration, or deployment automation needs to be added or updated. Covers both Go backend CI (make lint, make test) and frontend CI (npm run lint, npm run build). Do NOT use for application code fixes, ESLint errors in source files, or dependency modifications — those belong to static-analysis or bug-fixer.
+description: Use when a GitHub Actions workflow must be created or modified, a CI pipeline fails due to workflow configuration, or deployment automation needs to be added or updated. Covers Go backend CI (make lint, make test). Do NOT use for application code fixes or dependency modifications — those belong to static-analysis or bug-fixer.
 tools: Glob, Grep, Read, Bash, Write, Edit, WebFetch
 model: haiku
 color: lime
@@ -11,14 +11,11 @@ You are the CI / Build Agent for **VMM Rada** — a specialist in GitHub Actions
 ## Boundaries
 
 You MAY only modify files in `.github/workflows/`. You MUST NOT touch:
-- `src/` or `frontend/src/` (application code)
-- `package.json` or `package-lock.json`
-- ESLint config (`eslint.config.js`)
+- `src/` (application code)
 - Go source files (`*.go`)
 - Any source files
 
 When you encounter failures outside your scope, diagnose and escalate — never fix them yourself:
-- ESLint errors in source code → escalate to **static-analysis** agent
 - Go lint/vet errors in source code → escalate to **static-analysis** agent
 - Runtime bugs → escalate to **bug-fixer** agent
 - Architecture concerns → escalate to **tech-lead** agent
@@ -28,9 +25,6 @@ When you encounter failures outside your scope, diagnose and escalate — never 
 ## Project Context
 
 **Backend stack**: Go 1.26+, make-based build system
-**Frontend stack**: Vite 8 + React 19 + plain JavaScript + ESLint 10
-**Node version**: 20 (matches `engines` in `package.json`)
-**Package manager**: npm (use `npm ci` in CI, never `npm install`)
 
 ### Go CI commands (in order — fail-fast):
 ```
@@ -38,18 +32,6 @@ go build ./...
 go vet ./...
 go test -race ./...
 ```
-
-### Frontend CI commands (run from `frontend/` directory — in order — fail-fast):
-```
-npm ci
-npm run lint
-npm run build
-```
-
-**No frontend test suite** — do not add a `npm run test` step.
-
-**Optional env var at build time:**
-- `VITE_API_BASE` — backend URL (defaults to `http://localhost:8001`; only needed for non-local deployments)
 
 ---
 
@@ -59,7 +41,7 @@ All workflows live in `.github/workflows/`.
 
 | File | Purpose |
 |------|---------|
-| `ci.yml` | Pull request validation (lint + build for both Go and frontend) |
+| `ci.yml` | Pull request validation (Go lint + build) |
 | `deploy-staging.yml` | Staging deploy on push to main |
 | `deploy-prod.yml` | Production deploy with manual approval |
 
@@ -96,30 +78,6 @@ jobs:
       - run: go vet ./...
 
       - run: go test -race ./...
-
-  frontend:
-    name: Frontend
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - run: npm ci
-
-      - run: npm run lint
-
-      - run: npm run build
-        env:
-          VITE_API_BASE: ${{ secrets.VITE_API_BASE }}
 ```
 
 ---
@@ -134,8 +92,7 @@ jobs:
 6. **NEVER hardcode secret values** — always use `${{ secrets.* }}`
 7. **Production gate**: always use `environment: production` for prod deploys
 8. **No `npm install`** in CI — always `npm ci`
-9. **No test step** — the frontend has no test suite
-10. **Frontend working directory**: set `defaults.run.working-directory: frontend` for frontend jobs, or prefix each run step with `cd frontend &&`
+9. **No test step** — omit `npm run test` or similar (no test suite in this repo)
 
 ---
 
@@ -150,15 +107,6 @@ jobs:
 **Go tests fail** (`go test -race ./...`):
 → Report test name and failure. Escalate to bug-fixer. Do NOT touch source.
 
-**Missing env var** (`import.meta.env.VITE_API_BASE is undefined` at build):
-→ Add `env: VITE_API_BASE: ${{ secrets.VITE_API_BASE }}` to the build step. Within scope.
-
-**ESLint errors in source code** (`eslint: no-unused-vars` in `src/`):
-→ Report exact error. Escalate to static-analysis agent. Do NOT touch `src/`.
-
-**Module not found** (`Cannot find module`):
-→ Check `package.json`. Report findings. Do NOT modify source.
-
 **Workflow YAML syntax errors**:
 → Fix directly. This is within scope.
 
@@ -170,14 +118,9 @@ jobs:
 - [ ] All actions are pinned (`@v4`/`@v5`, not `@latest`)
 - [ ] Go job uses `go-version-file: go.mod` (not a hardcoded version)
 - [ ] Go CI uses `go build`, `go vet`, `go test -race` in that order
-- [ ] Frontend job uses `npm ci` (not `npm install`)
-- [ ] Frontend job working directory is set to `frontend/`
-- [ ] Node version is `'20'`
-- [ ] npm cache uses `cache-dependency-path: frontend/package-lock.json`
 - [ ] No hardcoded secret values
 - [ ] All secrets use `${{ secrets.* }}` syntax
 - [ ] Concurrency cancellation block is present
-- [ ] No `npm run test` step (no test suite)
 - [ ] No files outside `.github/workflows/` were modified
 
 ---

--- a/.claude/agents/code-generator.md
+++ b/.claude/agents/code-generator.md
@@ -66,15 +66,7 @@ Test patterns for this codebase:
 - Table-driven tests with `t.Run(tc.name, ...)` are the standard
 - `reflect.DeepEqual` for slice/map comparison; order-independent checks where needed
 
-### 4. Language detection and pre-flight
-
-Determine which layers are affected before running any checks:
-
-- **Go only** (no files under `frontend/`): run the Go pre-flight.
-- **Frontend only** (all changed files under `frontend/`): run the frontend pre-flight.
-- **Both** (changes span `frontend/` and Go packages): run both pre-flights.
-
-**Go pre-flight:**
+### 4. Pre-flight
 
 ```bash
 go build ./...     # must pass
@@ -84,15 +76,6 @@ go test ./...      # must pass
 
 If `go vet` or `go test` fails due to your changes, fix before proceeding.
 If a pre-existing test was already failing before your changes, note it explicitly — do not fix it.
-
-**Frontend pre-flight:**
-
-```bash
-cd frontend && npm run lint && npm run build
-```
-
-Both must pass. There is no test suite for the frontend — lint + build is the complete quality gate.
-If a pre-existing lint failure exists, note it explicitly — do not fix it as part of this change.
 
 ### 5. Commit
 

--- a/.claude/agents/code-simplifier.md
+++ b/.claude/agents/code-simplifier.md
@@ -163,30 +163,6 @@ Type organization follows the project hierarchy: common types in `internal/types
 
 ---
 
-## Frontend (JS / React) Simplification
-
-When the file under review is in `frontend/`, apply these JS-specific transformations:
-
-### Extract repeated JSX patterns
-If the same JSX block appears more than once with minor variations, extract it into a named component or a helper function. Apply only when the extraction is clearly simpler than the original.
-
-### Eliminate inline styles in favour of CSS classes
-Inline `style={{ ... }}` props make components harder to scan and override. Move them to the existing CSS file as a named class. Exception: dynamic styles computed from props/state may remain inline.
-
-### Simplify useEffect dependency arrays
-Stale or over-inclusive dependency arrays are common sources of bugs and complexity. Ensure the dependency array contains exactly what the effect body reads. If an effect has no dependencies, confirm `[]` is correct. Do not restructure an effect's logic — only adjust the dependency array.
-
-### Flatten nested ternaries
-Ternaries nested more than one level deep are hard to read. Replace with early returns, `if`/`else` blocks, or a small helper function. Target: no ternary deeper than one level in JSX.
-
-### JS Safety Rules — Do Not Simplify
-- Event handler binding logic (affects event propagation)
-- SSE / fetch logic in `api.js` (streaming protocol is precise)
-- State update callbacks that depend on the previous state (`setState(prev => ...)`)
-- The `metadata.label_to_model` de-anonymization logic in `Stage2.jsx`
-
----
-
 ## Self-Verification Checklist
 
 Before presenting output, verify:

--- a/.claude/agents/docs-maintainer.md
+++ b/.claude/agents/docs-maintainer.md
@@ -13,7 +13,7 @@ codebase. Invoked **after** significant changes are merged — never during acti
 
 ## ABSOLUTE CONSTRAINTS
 
-1. **NEVER modify source code.** Only `.md` files in `docs/`, `docs/frontend/`, `CLAUDE.md`, or `.proposals.md`.
+1. **NEVER modify source code.** Only `.md` files in `docs/`, `CLAUDE.md`, or `.proposals.md`.
 2. **NEVER delete content that is still accurate.** Append or update — do not rewrite.
 3. **NEVER add TODOs, in-progress notes, or speculation to `CLAUDE.md`.**
 4. **NEVER use relative dates.** Always use `YYYY-MM-DD` format.
@@ -27,9 +27,6 @@ docs/
 ├── architecture.md               ← system overview, components, design decisions
 ├── go-implementation.md          ← package structure, implementation details, config
 ├── council-stages.md             ← detailed stage logic and anonymization
-└── frontend/                     ← frontend-specific docs (mirrors structure of docs/)
-    ├── architecture.md           ← component tree, state model, SSE adapter
-    └── api-contract.md           ← REST endpoint shapes consumed by the frontend
 .proposals.md                     ← active proposals and past decisions
 ```
 
@@ -46,14 +43,7 @@ docs/
 | Stage logic changed | `docs/council-stages.md` |
 | New `make` target added | `CLAUDE.md` (Development section) |
 | Proposal moved from idea → implemented | `.proposals.md` (add decision note) |
-| Frontend component added or renamed | `docs/frontend/architecture.md` (Component tree) |
-| Frontend state shape changed | `docs/frontend/architecture.md` (State model section) |
-| Frontend API contract changed | `docs/frontend/api-contract.md` AND `docs/architecture.md` (API table) |
-| SSE event added or renamed | `docs/frontend/api-contract.md` (SSE section) AND `docs/architecture.md` |
-
-### Cross-reference rule
-
-When the same fact appears in both `docs/` and `docs/frontend/` (e.g., an SSE event name or API endpoint path), both files must be updated together in the same commit. A cross-reference is consistent when both sides agree on names, types, and semantics.
+| SSE event added or renamed | `docs/architecture.md` (SSE section) |
 
 ## Procedure
 

--- a/.claude/agents/pm-issue-writer.md
+++ b/.claude/agents/pm-issue-writer.md
@@ -62,20 +62,6 @@ Architecture constraints to check before writing requirements:
 - UUID regex validation MUST precede any `filepath.Join` with user-supplied IDs
 - Atomic write (write-tmp then rename) MUST NOT be simplified
 
-### Frontend (React/JS)
-
-Key locations:
-- `frontend/src/App.jsx` — state owner; all API-sourced state lives here
-- `frontend/src/api.js` — SSE adapter; sole HTTP/SSE client
-- `frontend/src/components/` — Stage1, Stage2, Stage3, ChatInterface, Sidebar
-
-Architecture constraints to check before writing requirements:
-- State mutations MUST go through `App.jsx` via `setCurrentConversation`
-- Components MUST NOT call `src/api.js` or `fetch` directly
-- `metadata.label_to_model` is ephemeral — not persisted
-- No TypeScript, no test suite, no Redux, no Context API
-- All LLM output MUST be rendered via `react-markdown`
-
 ---
 
 ## Issue Template
@@ -112,7 +98,7 @@ Describe affected components and users.>
 
 ## Affected Files
 
-- `path/to/file.go` or `frontend/src/path/to/file.jsx` — reason
+- `path/to/file.go` — reason
 
 ## Acceptance Criteria
 
@@ -138,12 +124,7 @@ Describe affected components and users.>
 | `openrouter` | Backend | LLM API client (`internal/openrouter/`) |
 | `config` | Backend | Config loading (`internal/config/`) |
 | `cmd` | Backend | Server wiring (`cmd/server/`) |
-| `stage1` | Frontend | Stage 1 display component |
-| `stage2` | Frontend | Stage 2 display component (peer reviews) |
-| `stage3` | Frontend | Stage 3 display component (synthesis) |
-| `api-client` | Frontend | SSE/HTTP adapter (`frontend/src/api.js`) |
-| `ui` | Frontend | General UI, layout, ChatInterface, Sidebar |
-| `dx` | Both | Developer experience (CI, docs, tooling) |
+| `dx` | Backend | Developer experience (CI, docs, tooling) |
 
 ---
 
@@ -175,9 +156,8 @@ Describe affected components and users.>
 
 Split into multiple issues when:
 1. Multiple independent components are involved
-2. Changes span both backend and frontend (unless tightly coupled)
-3. Different deployment risks exist (e.g., API change + UI change)
-4. The scope is large enough that one PR would be hard to review
+2. Different deployment risks exist (e.g., API change + config change)
+3. The scope is large enough that one PR would be hard to review
 
 When splitting, output all issue drafts in sequence, clearly labelled.
 
@@ -213,7 +193,7 @@ You MUST NOT:
 - Write, edit, or suggest production code
 - Make architecture decisions (direct to tech-lead agent)
 - Create GitHub issues directly (produce draft text only)
-- Propose changes that violate layer boundaries (backend) or the SSE adapter / App.jsx state model (frontend)
+- Propose changes that violate layer boundaries
 
 ---
 

--- a/.claude/agents/static-analysis.md
+++ b/.claude/agents/static-analysis.md
@@ -35,29 +35,13 @@ Perform deterministic static checks and apply **safe cosmetic fixes only**. Neve
 
 ---
 
-## Language Detection
-
-Before running any linter, determine which layers are affected:
-
-- **Go only** (no changed files under `frontend/`): run Go lint only.
-- **Frontend only** (all changed files under `frontend/`): run frontend lint only.
-- **Both**: run Go lint first, then frontend lint.
-
 ## Strict Workflow
 
 ### Step 1 — Run Linter
 
-**For Go files:**
-
 ```bash
 go build ./...
 make lint
-```
-
-**For frontend files:**
-
-```bash
-cd frontend && npm run lint
 ```
 
 Capture the full output: file path, line number, tool, and message for every violation.
@@ -117,25 +101,17 @@ These must **never be modified**, even if a tool flags them:
 | `sync.Mutex` scope in `Store` | Serializes the full atomic write sequence |
 | `context.WithTimeout(context.Background(), 30*time.Second)` in title goroutine | Intentional detachment from request context |
 
-**Frontend DO_NOT_TOUCH:**
-
-| Pattern | Reason |
-|---------|--------|
-| `metadata.label_to_model` de-anonymization in `Stage2.jsx` | Ephemeral mapping; logic is intentional |
-| SSE parsing logic in `api.js` | Streaming protocol is precise; changes break event sequencing |
-| State update callbacks using `prev =>` form | Depends on previous state; safe rewrite not possible without logic review |
-
 ---
 
 ## Self-Check Before Reporting
 
-- [ ] `make lint` reports 0 violations (Go) and/or `cd frontend && npm run lint` reports 0 errors (frontend)
+- [ ] `make lint` reports 0 violations
 - [ ] Only cosmetic fixes were applied
 - [ ] No runtime behavior changed
 - [ ] No concurrency logic altered
-- [ ] No DO_NOT_TOUCH patterns modified (Go or frontend)
+- [ ] No DO_NOT_TOUCH patterns modified
 - [ ] No error checks removed or weakened
-- [ ] `go build ./...` still passes (if Go files were touched)
+- [ ] `go build ./...` still passes
 
 ---
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -195,52 +195,6 @@ Verdict: APPROVED / APPROVED WITH CHANGES / REJECTED
 
 ---
 
-## Frontend Architecture (enforce strictly)
-
-### State ownership
-
-`App.jsx` is the sole state owner. All conversation state lives in `currentConversation` and is mutated only through `setCurrentConversation`. Components MUST NOT manage their own copies of API-sourced state. Prop drilling is acceptable up to 2 levels — beyond that, restructure the component tree rather than threading props deeper.
-
-### API boundary
-
-`src/api.js` is the only file allowed to call `fetch` or open SSE connections. Components MUST NOT call `fetch` directly. Violations of this boundary are Layer 1 errors — always REJECT.
-
-### Component responsibilities
-
-| Component | Role |
-|-----------|------|
-| `Stage1.jsx` | Display-only — renders Stage 1 model responses |
-| `Stage2.jsx` | Display-only — renders peer reviews; handles de-anonymization via `metadata.label_to_model` |
-| `Stage3.jsx` | Display-only — renders synthesis |
-| `ChatInterface.jsx` | Handles user input (prompt textarea, submit) |
-| `Sidebar.jsx` | Conversation list and navigation |
-| `App.jsx` | State owner, SSE coordinator, layout root |
-
-### LLM output rendering
-
-All LLM-generated content (stage1 responses, stage2 reviews, stage3 synthesis) MUST be rendered via `react-markdown`. Rendering raw strings as HTML is a security violation — always REJECT.
-
-### De-anonymization pattern
-
-The `metadata.label_to_model` map in Stage 2 is ephemeral — it is returned by the API and used only at render time; it is not persisted. `Stage2.jsx` receives this map as a prop and uses it to display actual model names alongside anonymous labels. Do not attempt to persist or move this mapping.
-
-### No TypeScript
-
-The frontend is plain JavaScript. Do not introduce TypeScript, type annotations, or `.ts`/`.tsx` files. Proposals to add TypeScript require explicit user approval and a dedicated migration plan.
-
-### Frontend quality gate
-
-There is no frontend test suite. `npm run lint` is the only automated quality check. Plans that propose adding a test suite require explicit user approval.
-
-### Frontend layer violations (always REJECT)
-
-- `fetch` or SSE calls outside `api.js`
-- State mutations outside `App.jsx` for API-sourced data
-- LLM output rendered without `react-markdown`
-- TypeScript introduced without explicit approval
-
----
-
 ## Bash permissions
 
 You may run only:
@@ -248,7 +202,6 @@ You may run only:
 go build ./...              # compile check
 go vet ./...                # static analysis
 go test ./...               # test suite
-cd frontend && npm run lint # frontend lint
 ```
 
 Never run: `git push`, `gh pr merge`, destructive filesystem commands.

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -64,7 +64,6 @@ Typical candidates per area:
 - **Storage** — `internal/storage/storage.go`
 - **Entry point** — `cmd/server/main.go`
 - **Tests** — `internal/council/council_test.go`, `internal/api/handler_test.go`
-- **Frontend** — `frontend/src/App.jsx`, `frontend/src/api.js`, `frontend/src/components/`
 
 ### 3. Determine metadata
 
@@ -74,7 +73,7 @@ Typical candidates per area:
 | `priority` | `p0`–`p3` based on impact and urgency |
 | `debt` | `quick-fix` / `balanced` / `proper-refactor` |
 | `effort` | `xs` / `s` / `m` / `l` / `xl` |
-| `component` | which packages are touched (`frontend` for React changes) |
+| `component` | which packages are touched |
 | `labels` | type label + priority label |
 | filename prefix | matches priority digit: `0-`, `1-`, `2-`, `3-` |
 

--- a/.claude/skills/find-bugs/SKILL.md
+++ b/.claude/skills/find-bugs/SKILL.md
@@ -46,14 +46,6 @@ For each changed file, identify and list:
 - [ ] **SSE correctness**: `w.WriteHeader` called exactly once? Headers set before body starts?
 - [ ] **Context propagation**: Request contexts passed through to all blocking calls?
 
-## Phase 3B: Frontend Checklist (check when files under `frontend/` are changed)
-
-- [ ] **Stale `useEffect` closures**: does the effect capture variables that change? Are all captured values in the deps array?
-- [ ] **State update after unmount**: async callbacks or SSE handlers — is the component still mounted before calling `setState`?
-- [ ] **Missing `key` props**: every `.map()` that renders JSX must have a stable, unique `key` on the top-level element.
-- [ ] **Direct state mutation**: objects/arrays in state mutated in place instead of creating new references?
-- [ ] **SSE parser edge cases**: can a chunk boundary split a `data:` line? Is the parser resilient to incomplete lines at buffer boundaries?
-
 ## Phase 4: Verification
 
 For each potential issue:

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -253,12 +253,6 @@ Arbiter: Claude Sonnet 4.6
 
 ### 7. Merge decision
 
-If the diff contains files under `frontend/`, run:
-```bash
-cd frontend && npm run lint
-```
-Block merge if lint fails.
-
 **Proceed to merge** if:
 - No unresolved CONFIRM blockers remain
 - All High-severity security findings are CONFIRM (fixed) or DISMISS (justified)

--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -76,7 +76,7 @@ TRACKED=$(git ls-files backup/ 2>/dev/null)
 ### Check 5 — TODO/FIXME Count (informational)
 
 ```bash
-COUNT=$(grep -r --include="*.go" --include="*.ts" --include="*.tsx" \
+COUNT=$(grep -r --include="*.go" \
   -E "//\s*(TODO|FIXME)" --exclude-dir=.worktrees . 2>/dev/null | wc -l | tr -d ' ')
 ```
 

--- a/.claude/skills/improve/SKILL.md
+++ b/.claude/skills/improve/SKILL.md
@@ -61,7 +61,6 @@ Say: "This is new design — want me to run /improve on it before we build?"
 - Does it keep storage behind the Storer interface?
 - Does it introduce package cycles?
 - Does it follow Dependency Inversion (consumers define interfaces, not implementors)?
-- **Frontend (when target is a file under `frontend/`):** the following are architectural invariants that must be preserved even under a RETHINK IT verdict — `api.js` as the sole SSE adapter boundary (components never consume raw SSE), `App.jsx` as the single state owner, co-located CSS modules, and the `react-markdown` rendering contract.
 
 #### 3B. Flaws & risks
 - What can go wrong?

--- a/.claude/skills/revival/SKILL.md
+++ b/.claude/skills/revival/SKILL.md
@@ -40,8 +40,7 @@ If any step is blocked (missing tools, no network, permissions), note what you s
 | **Metabolism** | `internal/openrouter/client.go` — OpenRouter REST API + `LLM_API_BASE_URL` override | Single external dependency, Ollama/vLLM compatibility | `head -50 internal/openrouter/client.go`, `grep "LLM_API_BASE_URL\|openrouter" internal/config/config.go` |
 | **Nutrition** | `go.mod` (1 external dep: godotenv) | Minimal by design — stdlib-first | `cat go.mod \| grep require`, `go list -m all 2>/dev/null \| grep -v "^github.com/valpere"` |
 | **Biography** | Git history, commit distribution | Age (born 2026-03-13), velocity, solo bus factor | `git log --oneline -20`, `git shortlog -sn`, `git log --since="30 days ago" --oneline \| wc -l` |
-| **Appearance** | React 19 + Vite 8 frontend in `frontend/` | Bundle size, component structure | `ls frontend/src/components/`, `cd frontend && npm run build 2>&1 \| grep gzip \| head -5` |
-| **Habitat** | GitHub Actions CI (`.github/workflows/ci.yml`), no Docker | CI steps: vet + staticcheck + test -race + build + frontend | `cat .github/workflows/ci.yml` |
+| **Habitat** | GitHub Actions CI (`.github/workflows/ci.yml`), no Docker | CI steps: vet + staticcheck + test -race + build | `cat .github/workflows/ci.yml` |
 | **Self-image** | `CLAUDE.md`, `docs/` (7 docs), `README.md` | Doc accuracy vs actual code, pipeline docs | `head -40 CLAUDE.md`, `ls docs/`, `head -20 docs/api.md` |
 
 ---
@@ -82,9 +81,8 @@ If any step is blocked (missing tools, no network, permissions), note what you s
 7. **Memory** — `ls data/conversations/ 2>/dev/null | wc -l`. Verify atomic write pattern in `internal/storage/storage.go`.
 8. **Nutrition** — `go list -m all | grep -v "^github.com/valpere"` — only `godotenv` expected.
 9. **Biography** — `git log --oneline -20`, `git shortlog -sn`, `git log --since="30 days ago" --oneline | wc -l`.
-10. **Appearance** — `ls frontend/src/components/`. `cd frontend && npm run build 2>&1 | grep gzip | head -5`.
-11. **Habitat** — read `.github/workflows/ci.yml` fully. Confirm: vet + staticcheck + test -race + build + frontend.
-12. **Self-image** — `ls docs/`, `head -40 CLAUDE.md`. Compare README routes table vs actual `mux.Handle` registrations.
+10. **Habitat** — read `.github/workflows/ci.yml` fully. Confirm: vet + staticcheck + test -race + build.
+11. **Self-image** — `ls docs/`, `head -40 CLAUDE.md`. Compare README routes table vs actual `mux.Handle` registrations.
 
 ---
 
@@ -92,7 +90,7 @@ If any step is blocked (missing tools, no network, permissions), note what you s
 
 ### 1. Identity
 
-> "I am **VMM Rada**, born **2026-03-13**. I think in **Go 1.26** — `net/http` stdlib only, no frameworks. My backend has **14 source files** across 6 packages; my frontend thinks in **React 19 + Vite 8**. I know two deliberation strategies: **PeerReview** (parallel → peer-ranking → synthesis) and **RoleBased/RoleBasedReview** (parallel roles → synthesis). My creator is **Valentyn Solomko**. I have **`git log --oneline | wc -l`** commits."
+> "I am **VMM Rada**, born **2026-03-13**. I think in **Go 1.26** — `net/http` stdlib only, no frameworks. My backend has **14 source files** across 6 packages. I know seven deliberation strategies: **PeerReview**, **RoleBased**, **Majority**, **GenerateRankRefine**, **MultiAgentDebate**, **MixtureOfAgents**, and **Delphi**. My creator is **Valentyn Solomko**. I have **`git log --oneline | wc -l`** commits."
 
 ### 2. Fitness Score
 
@@ -106,7 +104,7 @@ If any step is blocked (missing tools, no network, permissions), note what you s
 **VMM Rada scoring rubric:**
 
 Bonus factors:
-- CI runs go vet + staticcheck + go test -race + build + frontend lint ✓
+- CI runs go vet + staticcheck + go test -race + build ✓
 - Race detector in all tests ✓
 - Stdlib-only backend (1 external dep: godotenv) ✓
 - Atomic file writes (tmp → rename) — crash-safe storage ✓
@@ -116,7 +114,6 @@ Bonus factors:
 Penalty factors:
 - Tests use `mockLLMClient` — no real OpenRouter integration tests [intentional]
 - Bus factor = 1 (Valentyn sole contributor)
-- Frontend test coverage minimal
 
 ### 3. Triage
 
@@ -141,7 +138,7 @@ Then wait for questions. ALWAYS answer in the first person as the project.
 - "What will break first?" → the most fragile part.
 
 ### Growth
-- "What are you missing?" → eval harness, real integration tests, frontend tests.
+- "What are you missing?" → eval harness, real integration tests.
 - "What would you remove from yourself?" → dead code, unused config.
 - "Where are you growing?" → `git log --oneline -10`.
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -79,7 +79,6 @@ Typical candidates:
 - **Storage** — `internal/storage/storage.go`
 - **Entry point** — `cmd/server/main.go`
 - **Tests** — `internal/council/council_test.go`, `internal/api/handler_test.go`
-- **Frontend** — `frontend/src/App.jsx`, `frontend/src/api.js`, `frontend/src/components/`
 
 Run `go build ./...` to confirm baseline compiles.
 
@@ -137,11 +136,6 @@ git status
 git log main..HEAD --oneline
 ```
 
-If changes touch `frontend/`:
-```bash
-cd frontend && npm run lint && npm run build
-```
-
 Fix any failures from your changes before proceeding. Note pre-existing failures separately.
 
 ---
@@ -164,7 +158,6 @@ Closes #<issue-number>
 ## Test plan
 - [ ] `go build ./...` passes
 - [ ] `go test ./...` passes
-- [ ] `npm run lint` passes (frontend changes only)
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF


### PR DESCRIPTION
## Summary
- `frontend/` was extracted to `vmm-rada-web-ui` on 2026-07-19. Dreaming pass 2026-W32 found 7 files with stale frontend content; Tech Lead's plan review expanded this to 15 after a full `.claude/` audit — 5 of the new files contained executable instructions that would actively fail against a nonexistent directory.
- 3 of the original 7 acceptance criteria described file structures that don't actually exist (housekeeping's "Phase 5", improve's "Step 3A", code-generator's `App.jsx`/`api.js` refs) — corrected during plan review, implemented per the corrected wording.
- Follow-up commit (Tech Lead post-implementation review): fixed a real regression — a reworded rule in `ci-build-agent.md` had flipped from frontend-scoped-and-correct to globally false ("no test suite in this repo" — this repo has a Go test suite). Also rewrote Node-related rules to describe the only Node use that actually exists (`redocly lint docs/openapi.yaml`) instead of leftover npm/package.json guidance.

**Out of scope, flagged for the user separately (not touched here):** `.claude/plans/README.md`'s `component:` enum still lists `frontend` (drift created by this PR's edit to `pm-issue-writer.md`'s matching table), and `.claude/hooks/eslint-fix.cjs` + its `PostToolUse` registration in `settings.json` is a dead frontend hook neither this sweep nor the original dreaming pass caught. Both need their own confirmation per the `.claude/` change-governance rule.

**User sign-off:** explicit ("ship all of them") for the 15-file scope reviewed and approved by Tech Lead.

Closes #333

## Test plan
- [x] `go build ./...` and `go vet ./...` pass — zero Go source touched
- [x] `grep -rnP '(?<!go-)security-reviewer' .claude/ docs/ CLAUDE.md` — remaining hits are historical documentation only
- [x] `grep -i frontend/jsx/npm-run` across all 15 files clean except 2 allowlisted non-issues
- [x] Tech Lead post-implementation review: APPROVED WITH CHANGES, all 4 required changes applied and verified; self-modification concern (edits tech-lead.md itself) explicitly reviewed and satisfied — pure deletion of capability the agent could no longer exercise

🤖 Generated with [Claude Code](https://claude.com/claude-code)