### PR TITLE
chore(tech-lead): add docs-triad sync gate to plan + code review criteria

### DIFF
--- a/.claude/agent-memory/tech-lead/MEMORY.md
+++ b/.claude/agent-memory/tech-lead/MEMORY.md
@@ -8,4 +8,5 @@
 - [docs-triad-sync-gate.md](docs-triad-sync-gate.md) — Strategy/config/wire-shape changes must ship their doc updates in the same PR; canonical doc target map
 - [agent-scope-boundary-pairs.md](agent-scope-boundary-pairs.md) — security-reviewer retired 2026-08-14; deleting a cross-referencing agent requires editing the survivor's description + grep without name-substring filters
 - [review-verify-checked-out-branch.md](review-verify-checked-out-branch.md) — Confirm HEAD matches the branch named in a review request; use `git show <branch>:<file>`, not the working tree
+- [review-criteria-need-output-slot.md](review-criteria-need-output-slot.md) — New tech-lead.md criteria need a line in the printed Output format block + explicit blocking semantics
 - [prune-by-deletion-not-rewording.md](prune-by-deletion-not-rewording.md) — In cleanup sweeps, reworded lines are riskier than deleted ones; a dropped qualifier can invert a rule

--- a/.claude/agent-memory/tech-lead/docs-triad-sync-gate.md
+++ b/.claude/agent-memory/tech-lead/docs-triad-sync-gate.md
@@ -27,5 +27,13 @@ docs above, or an explicit "docs: N/A — <reason>". At *code review*, check the
 Keep the trigger narrow: pure internal refactors, test-only, and dependency PRs are
 exempt — do not turn this into a blanket "every PR touches docs" tax.
 
+**Status 2026-08-15:** shipped into `.claude/agents/tech-lead.md` via issue #334 —
+plan-review criterion 6 (plan-time wording) + a `## Docs Sync Checklist` section
+(diff-time wording). `backlog/SKILL.md` deliberately not touched. The map now exists in
+*two* agent prompts: tech-lead's (current) and `docs-maintainer.md`'s (stale — still
+routes to `docs/architecture.md`, `go-implementation.md`, `council-stages.md`, none of
+which exist). Treat tech-lead's map as canonical until docs-maintainer is fixed.
+
 Related: [[governance-enforcement-point]] (this gate lives in `tech-lead.md`, not
-`backlog/SKILL.md`), [[stage0-done-not-on-wire]] (a concrete instance of this drift).
+`backlog/SKILL.md`), [[review-criteria-need-output-slot]] (the mechanical follow-ons any
+new criterion needs), [[stage0-done-not-on-wire]] (a concrete instance of this drift).

--- a/.claude/agent-memory/tech-lead/review-criteria-need-output-slot.md
+++ b/.claude/agent-memory/tech-lead/review-criteria-need-output-slot.md
@@ -1,0 +1,31 @@
+---
+name: review-criteria-need-output-slot
+description: A review criterion added to tech-lead.md must also get a line in the printed Output format block, or it silently degrades — and blocking semantics must be stated if the gate is meant to block
+type: project
+---
+
+When adding a criterion to `.claude/agents/tech-lead.md`, two mechanical follow-ons are
+part of the change, not polish:
+
+1. **Add a matching line to the printed Output format block.** The block is the template
+   the reviewer actually fills in; a criterion with no slot there is reported only when
+   the reviewer happens to remember it.
+2. **State the verdict consequence.** The Code review block says *"Required changes
+   before ship — Layer 1 findings only block"*. A criterion whose findings land at
+   Layer 2–4 therefore cannot block a ship unless the criterion says so explicitly.
+   A gate that cannot block is advisory.
+
+**Why:** criterion 5 (**Risk**) is the control case — it has existed for a long time,
+has *no* line in the Plan review Output format block, and is precisely the one criterion
+that `backlog/SKILL.md`'s downstream summary dropped (see
+[[governance-enforcement-point]]). Unprinted criterion → invisible in output → omitted
+from every derived summary. Observed again on issue #334 (docs-triad sync gate, reviewed
+2026-08-15): the added criterion 6 reproduced the same shape one level down — the PR
+closing a drift class was itself missing its reporting slot.
+
+**How to apply:** at code review of any `.claude/agents/*.md` change that adds a
+criterion/checklist, diff the criteria list against the Output format block and require
+parity before ship. Same test for the Code review table's `Layer` column — a new finding
+class needs a layer it maps to, and if that layer is non-blocking, say so on purpose.
+Do not silently widen an already-drifted downstream summary; delete the summary and
+point at the agent file instead ([[prune-by-deletion-not-rewording]]).

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -121,9 +121,9 @@ Read the plan. Evaluate against:
 6. **Docs sync** — If the plan adds/changes a strategy, an env-var or
    `configs/council.yaml` key family, or the REST/SSE wire shape, does its
    Files-to-change list include the corresponding docs (see the trigger→target
-   map in the Docs Sync Checklist below)? Absent that, the plan must state
-   `docs: N/A — <reason>`. Exempt: pure internal refactors, test-only changes,
-   dependency PRs.
+   map in the Docs Sync Checklist below)? Absent that, the plan's **Not in
+   Scope** section must state the reason docs sync doesn't apply. Exempt:
+   pure internal refactors, test-only changes, dependency PRs.
 
 **Output format:**
 
@@ -136,6 +136,7 @@ Layer compliance: ✓ / ✗ <details if ✗>
 Interface design: ✓ / ✗ <details if ✗>
 Scope: ✓ / ✗ <details if ✗>
 Debt level: ✓ / ✗ <details if ✗>
+Docs sync: ✓ / ✗ / n-a <details if ✗>
 
 [If APPROVED WITH CHANGES or REJECTED:]
 Required changes before proceeding:
@@ -193,10 +194,9 @@ Verdict: APPROVED / APPROVED WITH CHANGES / REJECTED
 
 ## Docs Sync Checklist (check every review)
 
-Three of the last 8 merged PRs before this rule existed were docs-only drift
-fixes (#327, #304) — a strategy/config/wire-shape change landed without its
-doc updates, caught only by a later dreaming pass. This checklist closes that
-gap at the diff, not just the plan.
+Docs-only drift-repair PRs are a recurring line item (#304, #327) — a
+strategy/config/wire-shape change landed without its doc updates, caught only
+by a later dreaming pass. Full rationale: `.claude/agent-memory/tech-lead/docs-triad-sync-gate.md`.
 
 **Trigger → target map:**
 
@@ -210,6 +210,11 @@ gap at the diff, not just the plan.
       in the same diff
 - [ ] Exempt from this checklist: pure internal refactors, test-only changes,
       dependency-bump PRs
+
+A trigger match with no corresponding doc change and no exemption is a
+blocking finding: minimum verdict APPROVED WITH CHANGES, notwithstanding the
+"Layer 1 findings only block" rule in the Code review output format above —
+this checklist's findings block regardless of pyramid layer.
 
 ---
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -118,6 +118,12 @@ Read the plan. Evaluate against:
 3. **Scope** — Is the plan appropriately scoped to the issue? No scope creep?
 4. **Debt level match** — Do the proposed tests match the declared ⚡/⚖️/🏗️ level?
 5. **Risk** — What could go wrong? Are risks called out in the plan?
+6. **Docs sync** — If the plan adds/changes a strategy, an env-var or
+   `configs/council.yaml` key family, or the REST/SSE wire shape, does its
+   Files-to-change list include the corresponding docs (see the trigger→target
+   map in the Docs Sync Checklist below)? Absent that, the plan must state
+   `docs: N/A — <reason>`. Exempt: pure internal refactors, test-only changes,
+   dependency PRs.
 
 **Output format:**
 
@@ -182,6 +188,28 @@ Verdict: APPROVED / APPROVED WITH CHANGES / REJECTED
 - [ ] `http.MaxBytesReader` not removed or limit not raised without justification
 - [ ] `WriteHeader` called exactly once per handler path (especially in SSE)
 - [ ] Error messages do not expose internal paths or stack traces
+
+---
+
+## Docs Sync Checklist (check every review)
+
+Three of the last 8 merged PRs before this rule existed were docs-only drift
+fixes (#327, #304) — a strategy/config/wire-shape change landed without its
+doc updates, caught only by a later dreaming pass. This checklist closes that
+gap at the diff, not just the plan.
+
+**Trigger → target map:**
+
+| Trigger | Must touch |
+|---|---|
+| new/changed strategy | `docs/strategies.md`, `docs/architecture-v2.md`, `CLAUDE.md` if the strategy list/count is stated |
+| new/changed env var or `configs/council.yaml` key | `docs/architecture-v2.md`, `docs/user-guide.md`, `README.md` if user-facing, `CLAUDE.md` |
+| REST/SSE wire-shape change | `docs/api.md` **and** `docs/openapi.yaml` (paired — narrative + machine contract, updating one alone is itself a drift bug), `docs/architecture-v2.md` |
+
+- [ ] If the diff matches any trigger above, the corresponding docs are touched
+      in the same diff
+- [ ] Exempt from this checklist: pure internal refactors, test-only changes,
+      dependency-bump PRs
 
 ---
 


### PR DESCRIPTION
## Summary
- Docs-only drift-repair PRs (#304, #327) are a recurring pattern — a strategy/config/wire-shape change lands without its doc updates, caught only by a later dreaming pass. Dreaming pass 2026-W32 flagged this as structural.
- Retargeted during Tech Lead's own plan review from the originally proposed `backlog/SKILL.md` to `tech-lead.md` directly — `backlog/SKILL.md`'s own summary of Tech Lead's criteria had already drifted (listed only 4 of 5, having dropped "Risk"), proving that list isn't the real enforcement point.
- Two placements, same trigger→target doc map: Plan review criterion 6 (plan-time) and a new Docs Sync Checklist next to the Security Checklist (diff-time).
- Follow-up commit (Tech Lead post-implementation review, ESCALATE): the PR that closes a docs-drift class had reproduced it one level down — criterion 6 had no slot in the printed Output format block (same fate as criterion 5/"Risk", which `backlog/SKILL.md` had already dropped from its summary), and the checklist never stated its own blocking semantics so a Layer-3 finding couldn't actually gate a ship. Both fixed, plus a false PR-count stat and an undefined escape-hatch key.

`backlog/SKILL.md` is explicitly **not** modified.

**User sign-off:** explicit ("ship all of them") for this issue's approved scope.

Closes #334

## Test plan
- [x] No Go files changed — build/vet/test not applicable
- [x] Confirmed `backlog/SKILL.md` untouched
- [x] Confirmed no conflict with #333 (already merged, touches a different section of the same file)
- [x] Tech Lead post-implementation review: APPROVED WITH CHANGES, all 4 required changes applied and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)